### PR TITLE
Only one service request per authentication serie

### DIFF
--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -1226,7 +1226,8 @@ class Transport (threading.Thread):
             my_event = threading.Event()
         else:
             my_event = event
-        self.auth_handler = AuthHandler(self)
+        if self.auth_handler is None:
+            self.auth_handler = AuthHandler(self)
         self.auth_handler.auth_publickey(username, key, my_event)
         if event is not None:
             # caller wants to wait for event themselves


### PR DESCRIPTION
This fixes the issue I had with the authentication key not being the first one delivered by ssh-agent. The problem was paramiko sending a service request for each ssh key held by the agent. The server would disconnect on the second service request. With the changes, (1) the authentication is instantiated only once for the full list of keys provided by the agent, (2) the service request is only performed once.

Cheers!