### PR TITLE
Swapping two lines in sftp_client makes server happy

### DIFF
--- a/paramiko/sftp_client.py
+++ b/paramiko/sftp_client.py
@@ -603,8 +603,8 @@ class SFTPClient (BaseSFTP):
 
         @since: 1.4
         """
-        fr = self.file(remotepath, 'rb')
         file_size = self.stat(remotepath).st_size
+        fr = self.file(remotepath, 'rb')
         fr.prefetch()
         try:
             fl = file(localpath, 'wb')


### PR DESCRIPTION
By doing the self.stat(remotepath).st_size before the self.file(remotepath, 'rb'), the connection started working.

Not in this patch; I also made another change suggested by others, where size is passed to prefetch, so that stat is not called again in that prefetch routine. Without that additional change, a stat will be called on the open file inside prefetch, and so probably trigger the problem again. I did not test this. Do you want me to send another patch with that change too?