### PR TITLE
Fix issue 34 (SFTPFile prefetch assumes response order matches requests)

### DIFF
--- a/paramiko/sftp_client.py
+++ b/paramiko/sftp_client.py
@@ -682,7 +682,7 @@ class SFTPClient (BaseSFTP):
                     self._convert_status(msg)
                 return t, msg
             if fileobj is not type(None):
-                fileobj._async_response(t, msg)
+                fileobj._async_response(t, msg, num)
             if waitfor is None:
                 # just doing a single check
                 break


### PR DESCRIPTION
`SFTPFile._async_response` gets a new 'num' parameter giving the request
number.  This can be matched up with the return value of
`SFTPClient._async_request` to retrieve data specific to that request.

The prefetch queue `SFTPFile._prefetch_reads` is replaced with the dict
`_prefetch_extents`, which maps request numbers to `(offset, length)`
tuples.

A lock is used to exclude the case where a response arrives in
`_async_response` before `_prefetch_thread` has updated it.

[Maintainer note: See #34 for initial bug report.]
