### PR TITLE
banner functionality

### DIFF
--- a/paramiko/auth_handler.py
+++ b/paramiko/auth_handler.py
@@ -45,6 +45,7 @@ class AuthHandler (object):
         self.authenticated = False
         self.auth_event = None
         self.auth_method = ''
+        self.banner = None
         self.password = None
         self.private_key = None
         self.interactive_handler = None
@@ -61,6 +62,9 @@ class AuthHandler (object):
             return self.auth_username
         else:
             return self.username
+
+    def get_banner(self):
+        return self.banner
 
     def auth_none(self, username, event):
         self.transport.lock.acquire()
@@ -375,6 +379,7 @@ class AuthHandler (object):
 
     def _parse_userauth_banner(self, m):
         banner = m.get_string()
+        self.banner = banner
         lang = m.get_string()
         self.transport._log(INFO, 'Auth banner: ' + banner)
         # who cares.

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -1074,6 +1074,18 @@ class Transport (threading.Thread):
             return None
         return self.auth_handler.get_username()
 
+    def get_banner(self):
+        """
+        Return the banner supplied by the server upon connect. If no banner is supplied,
+        this method returns C{None}.
+
+        @return: server supplied banner, or C{None}.
+        @rtype: string
+        """
+        if not self.active or (self.auth_handler is None):
+            return None
+        return self.auth_handler.get_banner()
+
     def auth_none(self, username):
         """
         Try to authenticate to the server using no authentication at all.


### PR DESCRIPTION
I would like to be able to obtain the banner supplied by a server to which my python script connects using paramiko.
This is to be able to supply reasons for not be able to connect at a certain moment, (can be handy for legal issues as well)
The following changes are in line wich the get_username method.
Tested and works. :-)
I have not updated documentation in the pull request but this line can be added I suppose in the class Transport documentation on http://www.lag.net/paramiko/docs/ :
string get_banner(self)
            Return the banner supplied by the remote server.
