### PR TITLE
Add timeout for handshake completion.

### DIFF
--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -1563,6 +1563,9 @@ class Transport (threading.Thread):
                     msg.add_byte(chr(MSG_UNIMPLEMENTED))
                     msg.add_int(m.seqno)
                     self._send_message(msg)
+                # Let our packetizer know the handshake is complete
+                self.packetizer.set_handshake_complete()
+
         except SSHException, e:
             self._log(ERROR, 'Exception: ' + str(e))
             self._log(ERROR, util.tb_strings())


### PR DESCRIPTION
This adds a mechanism for timing out a connection if the ssh handshake never completes.

When managing large fleets, we not-infrequently encounter cases where a host is alive enough to accept an SSH connection but not enough to accept commands.  (I've seen this with failing disks, for example -- my hypothesis is enough of the ssh daemon is cached in memory, but the shell or other libraries can't be read.)

(Internal p4 CLN 5034409; patch approved for release via TT/0013249552)
author: pala@amazon.com