### PR TITLE
Add method for "posix-rename@openssh.com" extension.

### DIFF
--- a/paramiko/sftp_client.py
+++ b/paramiko/sftp_client.py
@@ -285,6 +285,14 @@ class SFTPClient (BaseSFTP):
         self._log(DEBUG, 'rename(%r, %r)' % (oldpath, newpath))
         self._request(CMD_RENAME, oldpath, newpath)
 
+    def posix_rename(self, oldpath, newpath):
+        oldpath = self._adjust_cwd(oldpath)
+        newpath = self._adjust_cwd(newpath)
+        self._log(DEBUG, 'rename(%r, %r)' % (oldpath, newpath))
+        self._request(CMD_EXTENDED, 'posix-rename@openssh.com', oldpath,
+                newpath)
+
+
     def mkdir(self, path, mode=0777):
         """
         Create a folder (directory) named C{path} with numeric mode C{mode}.


### PR DESCRIPTION
I have added this method manually, but what I am doing just feels wrong. I'd rather use the extension advertisement mentioned at section 3.3 of [1] and just make rename use the atomic method if it's available. Do you have any pointers for finding the info?

[1]http://www.openbsd.org/cgi-bin/cvsweb/src/usr.bin/ssh/PROTOCOL?rev=HEAD;content-type=text/plain

Thanks,
wt