### PR TITLE
Fail more gracefully when encountering a missing mtime.

### DIFF
--- a/paramiko/sftp_attr.py
+++ b/paramiko/sftp_attr.py
@@ -201,8 +201,9 @@ class SFTPAttributes (object):
             ks = '?---------'
         # compute display date
         if (self.st_mtime is None) or (self.st_mtime == 0xffffffffL):
-            # shouldn't really happen
-            datestr = '(unknown date)'
+            # shouldn't really happen, but if it does, just use an empty space.
+            # otherwise any value placed here is prepended to the file name.
+            datestr = ' '
         else:
             if abs(time.time() - self.st_mtime) > 15552000:
                 # (15552000 = 6 months)


### PR DESCRIPTION
I actually have a file system that does this, and the current code results in
prepending (unknown date) to the file name in the SFTP client. This
prevents changing into the directory or downloading files, as the
client sends the name including the (unknown date) to the server.
By using a space, this case is handled properly (missing date, file
name unaffected).
