### PR TITLE
BaseSFTP._write_all no longer interprets 0 as error

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -18,6 +18,8 @@ v1.8.1 (DD MM YYYY)
 * #90: Ensure that callbacks handed to `SFTPClient.get()` always fire at least
   once, even for zero-length files downloaded. Thanks to Github user `@enB` for
   the catch.
+* #84: Make `BaseSFTP._write_all()` correctly handle all possible return values
+  from `send()`.  Thanks to Github user `@gmacon` for the patch.
 
 
 v1.8.0 (3rd Oct 2012)

--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,10 @@ Releases
 v1.8.1 (DD MM YYYY)
 -------------------
 
+* #90: Ensure that callbacks handed to `SFTPClient.get()` always fire at least
+  once, even for zero-length files downloaded. Thanks to Github user `@enB` for
+  the catch.
+
 
 v1.8.0 (3rd Oct 2012)
 ---------------------

--- a/paramiko/sftp.py
+++ b/paramiko/sftp.py
@@ -134,7 +134,7 @@ class BaseSFTP (object):
     def _write_all(self, out):
         while len(out) > 0:
             n = self.sock.send(out)
-            if n <= 0:
+            if n < 0:
                 raise EOFError()
             if n == len(out):
                 return

--- a/paramiko/sftp_client.py
+++ b/paramiko/sftp_client.py
@@ -612,12 +612,12 @@ class SFTPClient (BaseSFTP):
                 size = 0
                 while True:
                     data = fr.read(32768)
-                    if len(data) == 0:
-                        break
                     fl.write(data)
                     size += len(data)
                     if callback is not None:
                         callback(size, file_size)
+                    if len(data) == 0:
+                        break
             finally:
                 fl.close()
         finally:


### PR DESCRIPTION
When talking to a high-traffic SFTP server, send() may return 0,
but this is not an error.  This change treats the 0 return the same
way as Packetizer.write_all.