### PR TITLE
Add a closed property to BufferedFile

### DIFF
--- a/paramiko/file.py
+++ b/paramiko/file.py
@@ -354,6 +354,10 @@ class BufferedFile (object):
         """
         return self
 
+    @property
+    def closed(self):
+        return self._closed
+
 
     ###  overrides...
 


### PR DESCRIPTION
Added a closed property as an alternative accessor to BufferedFile's _closed property.
