### PR TITLE
Make send() and recv() fail when channel is closed

### DIFF
--- a/paramiko/channel.py
+++ b/paramiko/channel.py
@@ -25,6 +25,7 @@ import sys
 import time
 import threading
 import socket
+import errno
 import os
 
 from paramiko.common import *


### PR DESCRIPTION
`sendall()` was checking if the channel has been closed, and failed accordingly, but `send()` and `recv()` did not. This meant that `chan.send("foo")` when the channel was already closed, just blocked forever.
