### PR TITLE
Workaround for slow sftp put/get on Windows.

### DIFF
--- a/paramiko/packet.py
+++ b/paramiko/packet.py
@@ -87,6 +87,7 @@ class Packetizer (object):
         self.__mac_size_in = 0
         self.__block_engine_out = None
         self.__block_engine_in = None
+        self.__sdctr_out = False
         self.__mac_engine_out = None
         self.__mac_engine_in = None
         self.__mac_key_out = ''
@@ -110,11 +111,12 @@ class Packetizer (object):
         """
         self.__logger = log
 
-    def set_outbound_cipher(self, block_engine, block_size, mac_engine, mac_size, mac_key):
+    def set_outbound_cipher(self, block_engine, block_size, mac_engine, mac_size, mac_key, sdctr):
         """
         Switch outbound data cipher.
         """
         self.__block_engine_out = block_engine
+        self.__sdctr_out = sdctr
         self.__block_size_out = block_size
         self.__mac_engine_out = mac_engine
         self.__mac_size_out = mac_size
@@ -488,12 +490,12 @@ class Packetizer (object):
         padding = 3 + bsize - ((len(payload) + 8) % bsize)
         packet = struct.pack('>IB', len(payload) + padding + 1, padding)
         packet += payload
-        if self.__block_engine_out is not None:
-            packet += rng.read(padding)
-        else:
-            # cute trick i caught openssh doing: if we're not encrypting,
+        if self.__sdctr_out or self.__block_engine_out is None:
+            # cute trick i caught openssh doing: if we're not encrypting or SDCTR mode (RFC4344),
             # don't waste random bytes for the padding
             packet += (chr(0) * padding)
+        else:
+            packet += rng.read(padding)
         return packet
 
     def _trigger_rekey(self):

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -1882,7 +1882,8 @@ class Transport (threading.Thread):
             mac_key = self._compute_key('F', mac_engine.digest_size)
         else:
             mac_key = self._compute_key('E', mac_engine.digest_size)
-        self.packetizer.set_outbound_cipher(engine, block_size, mac_engine, mac_size, mac_key)
+        sdctr = self.local_cipher.endswith('-ctr')
+        self.packetizer.set_outbound_cipher(engine, block_size, mac_engine, mac_size, mac_key, sdctr)
         compress_out = self._compression_info[self.local_compression][0]
         if (compress_out is not None) and ((self.local_compression != 'zlib@openssh.com') or self.authenticated):
             self._log(DEBUG, 'Switching on outbound compression ...')


### PR DESCRIPTION
This patch improves performance of sftp put/gets for Windows clients using ***-ctr** ciphers.

Both the approach and the code need a review before being merged.
