### PR TITLE
SSH config handling can be slow

### DIFF
--- a/paramiko/config.py
+++ b/paramiko/config.py
@@ -156,6 +156,16 @@ class SSHConfig (object):
 
         host = socket.gethostname().split('.')[0]
         fqdn = None
+
+        #
+        # If the SSH config contains AddressFamily, use that when determining
+        # the local host's FQDN. Using socket.getfqdn() from the standard
+        # library is the most general solution, but can result in noticeable
+        # delays on some platforms when IPv6 is misconfigured or not available,
+        # as it calls getaddrinfo with no address family specified, so both
+        # IPv4 and IPv6 are checked.
+        #
+
         address_family = config.get('addressfamily', 'any').lower()
 
         if address_family == 'inet':


### PR DESCRIPTION
The timing of the ProxyCommand support was impeccable, but I noticed that when I started using my SSH config, my Fabric runs were excruciatingly slow. I traced it to the use of socket.getfqdn() in config.SSHConfig._expand_variables. This is an admittedly convoluted fix, but it's much, much faster for me.
