### PR TITLE
Limit memory allocation of get_bytes to 1MB

### DIFF
--- a/paramiko/message.py
+++ b/paramiko/message.py
@@ -110,7 +110,8 @@ class Message (object):
         @rtype: string
         """
         b = self.packet.read(n)
-        if len(b) < n:
+        max_pad_size = 1<<20  # Limit padding to 1 MB
+        if len(b) < n and n < max_pad_size:
             return b + '\x00' * (n - len(b))
         return b
 


### PR DESCRIPTION
If get_bytes() can pad unlimited, a RSA pub key could be crafted
that would allocate GB's of nulls, thereby forming a DoS-vector.

E.g. if the message would be '\x7f\xff\xff\xff...', get_string() could 
throw a memory error or crash a system. 
