### PR TITLE
Warn on parse failure when reading known_hosts

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,8 @@ Releases
 v1.10.2 (DD MM 2013)
 --------------------
 
+* #153, #67: Warn on parse failure when reading known_hosts
+  file. Thanks to `@glasserc` for patch.
 * #146: Indentation fixes for readability. Thanks to Abhinav Upadhyay for catch
   & patch.
 


### PR DESCRIPTION
This should fix #67 in that it should be much more obvious why a server is unknown: to wit, a key is being ignored.

I wasn't sure how to pass log information from client or transport to hostkeys so I just called out to util.get_logger again. If you have a better way in mind, please let me know and I'll try to implement it.
