### PR TITLE
Fix bug that leaves fds in select after EOF received

### DIFF
--- a/paramiko/agent.py
+++ b/paramiko/agent.py
@@ -130,14 +130,21 @@ class AgentProxyThread(threading.Thread):
                     if len(data) != 0:
                         self.__inr.send(data)
                     else:
+                        self._close()
                         break
                 elif self.__inr == fd:
                     data = self.__inr.recv(512)
                     if len(data) != 0:
                         self._agent._conn.send(data)
                     else:
+                        self._close()
                         break
             time.sleep(io_sleep)
+
+    def _close(self):
+        self._exit = True
+        self.__inr.close()
+        self._agent._conn.close()
 
 class AgentLocalProxy(AgentProxyThread):
     """


### PR DESCRIPTION
This fixes an issue I ran into where ssh-agent pipes were left open after we received EOF.  I reported it as a fabric issue here:

https://github.com/fabric/fabric/issues/876

This breaks out of the select loop and closes pipes when select returns an fd that is ready with 0 read (EOF).
