### PR TITLE
Encode Unicode strings as UTF-8 during SFTP processing

### DIFF
--- a/paramiko/sftp_server.py
+++ b/paramiko/sftp_server.py
@@ -181,6 +181,8 @@ class SFTPServer (BaseSFTP, SubsystemHandler):
                 msg.add_int(item)
             elif type(item) is long:
                 msg.add_int64(item)
+            elif type(item) is unicode:
+                msg.add_string(item.encode('utf-8'))
             elif type(item) is str:
                 msg.add_string(item)
             elif type(item) is SFTPAttributes:


### PR DESCRIPTION
Avoids throwing an exception when filenames in responses are unicode strings.
