### PR TITLE
fix userauth procedure

### DIFF
--- a/paramiko/auth_handler.py
+++ b/paramiko/auth_handler.py
@@ -118,10 +118,19 @@ class AuthHandler (object):
 
 
     def _request_auth(self):
+        #if MSG_SERVICE_REQUEST already sent, do not send again
+        if hasattr(self.transport, '_SERVICE_REQUEST_SENT'):
+            #triger userauth manually
+            m = Message()
+            m.add_string('ssh-userauth')
+            m.rewind()
+            self._parse_service_accept(m)
+            return
         m = Message()
         m.add_byte(chr(MSG_SERVICE_REQUEST))
         m.add_string('ssh-userauth')
         self.transport._send_message(m)
+        self.transport._SERVICE_REQUEST_SENT = True
 
     def _disconnect_service_not_available(self):
         m = Message()


### PR DESCRIPTION
For compatibility, there should be only one 'ssh-userauth' Service Request,
followed by one/many Authentication Requests, instead of sending many
Service Requests. see [RFC 4251](http://tools.ietf.org/html/rfc4251#page-3).

I encounter the problem on an old commercial Secure Shell Daemon with keyboard-interactive authentication.  Transport.auth_password() by default use Transport.auth_interative as a fallback by sending another ssh-userauth service request. However, the server may regard it as an error and disconnect the client with the following message:

```
May  3 20:14:25 localhost sshd[21673]: WARNING: sshd-auth: The client requested authentication method `password', that is not allowed for user `root'.
May  3 20:14:25 localhost sshd[21673]: Local disconnected: Protocol error: packet 5 in interactive
```

The commit solved the compatibility problem for me, may it help others.
