### PR TITLE
Add SSHConfig method returning hostnames defined in SSH config

### DIFF
--- a/paramiko/config.py
+++ b/paramiko/config.py
@@ -126,6 +126,16 @@ class SSHConfig (object):
         ret = self._expand_variables(ret, hostname)
         return ret
 
+    def get_hostnames(self):
+        """
+        Return the set of literal hostnames defined in the SSH config (both
+        explicit hostnames and wildcard entries).
+        """
+        hosts = set()
+        for entry in self._config:
+            hosts.update(entry['host'])
+        return hosts
+
     def _allowed(self, hosts, hostname):
         match = False
         for host in hosts:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -349,6 +349,11 @@ IdentityFile something_%l_using_fqdn
         config.parse(config_file)
         self.assertEqual(config.lookup("abcqwerty")["hostname"], "127.0.0.1")
 
+    def test_14_get_hostnames(self):
+        f = StringIO(test_config_file)
+        config = paramiko.util.parse_ssh_config(f)
+        self.assertEqual(config.get_hostnames(), set(['*', '*.example.com', 'spoo.example.com']))
+
     def test_quoted_host_names(self):
         test_config_file = """\
 Host "param pam" param "pam"


### PR DESCRIPTION
For my application, I need to distinguish between explicit host configuration entries and configuration entries synthesized from wildcard entries (e.g. '*'), something which is not possibly using SSHConfig.lookup().

I figure I might not be the only one, hence the pull request. Unit test is included.

Best regards,
Søren Løvborg
