### PR TITLE
updated config class to be compatible with multiple localforward,remoteforward

### DIFF
--- a/paramiko/config.py
+++ b/paramiko/config.py
@@ -126,14 +126,15 @@ class SSHConfig (object):
                 self._config.append(host)
                 value = value.split()
                 host = {key: value, 'config': {}}
-            #identityfile is a special case, since it is allowed to be
+            #identityfile, localforward, remoteforward keys are special cases, since they are allowed to be
             # specified multiple times and they should be tried in order
             # of specification.
-            elif key == 'identityfile':
+            
+            elif key in ['identityfile', 'localforward', 'remoteforward']:
                 if key in host['config']:
-                    host['config']['identityfile'].append(value)
+                    host['config'][key].append(value)
                 else:
-                    host['config']['identityfile'] = [value]
+                    host['config'][key] = [value]
             elif key not in host['config']:
                 host['config'].update({key: value})
         self._config.append(host)


### PR DESCRIPTION
localforward and remoteforward keys can be specified multiple times for one host. with this commit, this keys' values are going into a list like "identityfile" direction.
