### PR TITLE
Remove duplicate code.

### DIFF
--- a/paramiko/sftp_client.py
+++ b/paramiko/sftp_client.py
@@ -612,7 +612,7 @@ class SFTPClient (BaseSFTP):
         file_size = os.stat(localpath).st_size
         fl = file(localpath, 'rb')
         try:
-            return self.putfo(fl, remotepath, os.stat(localpath).st_size, callback, confirm)
+            return self.putfo(fl, remotepath, file_size, callback, confirm)
         finally:
             fl.close()
 


### PR DESCRIPTION
Use the previously unused variable (file_size) and avoid calling os.stat twice.
