### PR TITLE
AttributeError when loading known_hosts (was: known_hosts storage bug)

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -190,7 +190,7 @@ class SSHClient (object):
         # update local host keys from file (in case other SSH clients
         # have written to the known_hosts file meanwhile.
         if self._host_keys_filename is not None:
-            self.load_host_keys(self._known_keys_filename)
+            self.load_host_keys(self._host_keys_filename)
 
         f = open(filename, 'w')
         for hostname, keys in self._host_keys.iteritems():


### PR DESCRIPTION
The SSHClient.known_hosts attribute exists only in this location and an exception is raised when trying to store host keys. It looks like it's trying to read the `_host_keys_filename` attribute instead.
