### PR TITLE
forward.py demo uses request after it is closed

### DIFF
--- a/demos/forward.py
+++ b/demos/forward.py
@@ -79,8 +79,8 @@ class Handler (SocketServer.BaseRequestHandler):
                     break
                 self.request.send(data)
         chan.close()
-        self.request.close()
         verbose('Tunnel closed from %r' % (self.request.getpeername(),))
+        self.request.close()
 
 
 def forward_tunnel(local_port, remote_host, remote_port, transport):


### PR DESCRIPTION
A small change to reverse the order of two lines in the forward.py demo. In the existing code, the request was being used in a log message after the request was already closed. This was causing the following exception:

```
Exception happened during processing of request from ('127.0.0.1', 57216)
Traceback (most recent call last):
  File "/usr/lib/python2.7/SocketServer.py", line 593, in process_request_thread
    self.finish_request(request, client_address)
  File "/usr/lib/python2.7/SocketServer.py", line 334, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/lib/python2.7/SocketServer.py", line 649, in __init__
    self.handle()
  File "/home/milad/pmiko/paramiko_forward.py", line 83, in handle
    verbose('Tunnel closed from %r' % (self.request.getpeername(),))
  File "/usr/lib/python2.7/socket.py", line 224, in meth
    return getattr(self._sock,name)(*args)
  File "/usr/lib/python2.7/socket.py", line 170, in _dummy
    raise error(EBADF, 'Bad file descriptor')
error: [Errno 9] Bad file descriptor
```
