### PR TITLE
Correct undefined name error in LazyFqdn.__str__

### DIFF
--- a/paramiko/config.py
+++ b/paramiko/config.py
@@ -56,7 +56,7 @@ class LazyFqdn(object):
             if address_family != 'any':
                 family = socket.AF_INET if address_family == 'inet' \
                     else socket.AF_INET6
-                results = socket.getaddrinfo(host,
+                results = socket.getaddrinfo(socket.gethostname(),
                                              None,
                                              family,
                                              socket.SOCK_DGRAM,


### PR DESCRIPTION
If AddressFamily is set to anything but "any" in your ssh config, this (presumably little-used; it's a fluke of history that we have that enabled in our environment) code path runs, and the undefined "host" variable gets referenced. I'm guessing, at some point in the past, host used to be set to socket.gethostname(); here's a quick patch. :)
