### PR TITLE
Get WarningPolicy working in this example

### DIFF
--- a/demos/demo_simple.py
+++ b/demos/demo_simple.py
@@ -63,7 +63,7 @@ password = getpass.getpass('Password for %s@%s: ' % (username, hostname))
 try:
     client = paramiko.SSHClient()
     client.load_system_host_keys()
-    client.set_missing_host_key_policy(paramiko.WarningPolicy)
+    client.set_missing_host_key_policy(paramiko.WarningPolicy())
     print '*** Connecting...'
     client.connect(hostname, port, username, password)
     chan = client.invoke_shell()


### PR DESCRIPTION
Using this as an example, I was getting the following error:

  File "cs4224_connector.py", line 31, in **init**
    self.m_ssh.connect(g_host, g_port, username=g_user, password=g_password)
  File "C:\Python27\lib\site-packages\paramiko\client.py", line 321, in connect
    self._policy.missing_host_key(self, server_hostkey_name, server_key)
TypeError: unbound method missing_host_key() must be called with WarningPolicy instance as first argument (got SSHClient
 instance instead)

This commit should fix it.
