### PR TITLE
Fix hang when sending packets on closed connection

### DIFF
--- a/paramiko/packet.py
+++ b/paramiko/packet.py
@@ -265,7 +265,7 @@ class Packetizer (object):
                 n = 0
                 if self.__closed:
                     n = -1
-            if n < 0:
+            if n <= 0:
                 raise EOFError()
             if n == len(out):
                 break


### PR DESCRIPTION
This fixes an issue where paramiko hangs, as shown in trace below.
Basically `channel._wait_for_send_window` returns zero if `self.closed` or `self.eof_sent`, but `packet.write_all` only recognizes return values < 0 as eof.

```
packet.py(238):         while len(out) > 0:
packet.py(239):             got_timeout = False
packet.py(240):             try:
packet.py(241):                 n = self.__socket.send(out)
 --- modulename: channel, funcname: send
channel.py(686):         size = len(s)
channel.py(687):         self.lock.acquire()
channel.py(688):         try:
channel.py(689):             size = self._wait_for_send_window(size)
 --- modulename: channel, funcname: _wait_for_send_window
channel.py(1160):         if self.closed or self.eof_sent:
channel.py(1161):             return 0
channel.py(690):             if size == 0:
channel.py(692):                 return 0
channel.py(698):             self.lock.release()
packet.py(255):             if got_timeout:
packet.py(259):             if n < 0:
packet.py(261):             if n == len(out):
packet.py(263):             out = out[n:]
packet.py(238):         while len(out) > 0:
```
