### PR TITLE
Detect valid SSH private keys that may require unlocking/decrypting correctly

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -33,7 +33,7 @@ from paramiko.dsskey import DSSKey
 from paramiko.hostkeys import HostKeys
 from paramiko.resource import ResourceManager
 from paramiko.rsakey import RSAKey
-from paramiko.ssh_exception import SSHException, BadHostKeyException
+from paramiko.ssh_exception import PasswordRequiredException, SSHException, BadHostKeyException
 from paramiko.transport import Transport
 from paramiko.util import retry_on_signal
 
@@ -465,6 +465,9 @@ class SSHClient (object):
                         two_factor = (allowed_types == ['password'])
                         if not two_factor:
                             return
+                        break
+                    except PasswordRequiredException, e:
+                        saved_exception = e
                         break
                     except SSHException, e:
                         saved_exception = e


### PR DESCRIPTION
Currently locked/encrypted SSH private keys are considered as invalid during `client.SSHClient._auth()`. An encrypted RSA key that I want to use during authentication (passed in as `key_filename=/home/<user>/.ssh/id_rsa`) is considered to be an invalid DSA(!) private key file.

The patch of this pull request fixes that.

Greets,
Mike
