### PR TITLE
Allow two-factor auth _and_ unlocking of SSH keys at the same time

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -446,7 +446,7 @@ class SSHClient (object):
         two-factor authentication [for which it is required].
 
         If the SSH key needs unlocking via passphrase and two-factor
-        auth requires a password, the passphrase is unused for unlocking
+        auth requires a password, the passphrase is used for unlocking
         the key whereas the password is used for server authentication.
         """
         saved_exception = None


### PR DESCRIPTION
As of Paramiko 1.11.0 the user can either authenticate against a server with
two-factor auth _or_ unlock an encrypted key with a provided password. Also,
the user can unlock a private SSH key and perform two-factor auth if the
passphrase of the key and the server logon password are identical.

A more generic approach is supporting a passphrase=... and a password=...
parameter in paramiko.client.SSHClient().connect(). The passphrase (if
given) is used for unlocking a key, the password is used for everything
else (i.e. also for unlocking the key in case passphrase is omitted).

If no passphrase is given, the password is used for unlocking the private
key (to sustain the behvaiour of earlier paramiko versions).
