### PR TITLE
Make evaluation of key auth available for two-factor auth analysis.

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -461,7 +461,7 @@ class SSHClient (object):
                     try:
                         key = pkey_class.from_private_key_file(key_filename, password)
                         self._log(DEBUG, 'Trying key %s from %s' % (hexlify(key.get_fingerprint()), key_filename))
-                        self._transport.auth_publickey(username, key)
+                        allowed_types = self._transport.auth_publickey(username, key)
                         two_factor = (allowed_types == ['password'])
                         if not two_factor:
                             return


### PR DESCRIPTION
When authenticating with an explicitly given key_filename, also evaluate
the key based authentication and check if two-factor auth is required.

Without the fix shipped with this pull request, two-factor auth fails
whenever the SSH key is specified via the key_filename parameter in
SSHClient().connect().
