### PR TITLE
README: clarify that API docs must be generated

### DIFF
--- a/README
+++ b/README
@@ -123,12 +123,12 @@ Use
 ---
 
 the demo scripts are probably the best example of how to use this package.
-there is also a lot of documentation, generated with epydoc, in the doc/
-folder.  point your browser there.  seriously, do it.  mad props to
-epydoc, which actually motivated me to write more documentation than i
-ever would have before.
+also, run `make docs`. this will produce detailed API-level developer
+documentation in the docs/ folder.  point your browser there.  seriously,
+do it.  mad props to epydoc, which actually motivated me to write more
+documentation than i ever would have before.
 
-there are also unit tests here::
+there are also unit tests here:
 
     $ python ./test.py
 


### PR DESCRIPTION
Also, remove an extra colon.