### PR TITLE
Initialize self.known_hosts as None to avoid uncaught AttributeError

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -124,6 +124,7 @@ class SSHClient (object):
         self._policy = RejectPolicy()
         self._transport = None
         self._agent = None
+        self.known_hosts = None
 
     def load_system_host_keys(self, filename=None):
         """


### PR DESCRIPTION
There's an integration with Boto that relies on the ability to use the AutoAddPolicy feature for handling EC2 instances you may not already have a host key for. This integration seems to be broken in that a check occurs for the known_hosts value of the SSHClient class, which has never been initialized. This initializes it to None, which at least for this case solves that problem.

If this isn't an acceptable change to make, it would be great to know what changes would need to be made to [Boto's integration](https://github.com/boto/boto/blob/develop/boto/manage/cmdshell.py) in order to get these two working well together again.

Thanks :)
