### PR TITLE
Reintroduce __version_info__ variable

### DIFF
--- a/paramiko/__init__.py
+++ b/paramiko/__init__.py
@@ -58,6 +58,7 @@ if sys.version_info < (2, 5):
 
 __author__ = "Jeff Forcier <jeff@bitprophet.org>"
 __version__ = "1.11.0"
+__version_info__ = tuple([ int(d) for d in __version__.split(".") ])
 __license__ = "GNU Lesser General Public License (LGPL)"
 
 


### PR DESCRIPTION
At least one application (mysql-workbench) (used to) use(s) the **version_info**
that got removed by commit 99859b8b021a5d13ca067a3e79560d6121f9c52f.

Breaking existing software with new versions of paramiko should be avoided.
This pull-request reintroduces the **version_info** var, but fills it
from the **version** var. No need to maintain multiple version strings.
