### PR TITLE
SSHClient: Allow to use ECDSA private keys.

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -490,17 +490,23 @@ class SSHClient (object):
             keyfiles = []
             rsa_key = os.path.expanduser('~/.ssh/id_rsa')
             dsa_key = os.path.expanduser('~/.ssh/id_dsa')
+            ecdsa_key = os.path.expanduser('~/.ssh/id_ecdsa')
             if os.path.isfile(rsa_key):
                 keyfiles.append((RSAKey, rsa_key))
             if os.path.isfile(dsa_key):
                 keyfiles.append((DSSKey, dsa_key))
+            if os.path.isfile(ecdsa_key):
+                keyfiles.append((ECDSAKey, ecdsa_key))
             # look in ~/ssh/ for windows users:
             rsa_key = os.path.expanduser('~/ssh/id_rsa')
             dsa_key = os.path.expanduser('~/ssh/id_dsa')
+            ecdsa_key = os.path.expanduser('~/ssh/id_ecdsa')
             if os.path.isfile(rsa_key):
                 keyfiles.append((RSAKey, rsa_key))
             if os.path.isfile(dsa_key):
                 keyfiles.append((DSSKey, dsa_key))
+            if os.path.isfile(ecdsa_key):
+                keyfiles.append((ECDSAKey, ecdsa_key))
 
             if not look_for_keys:
                 keyfiles = []


### PR DESCRIPTION
Nowadays, ECDSA keys became more widespread, so it might be a good idea to support those private keys as well, especially because the change to Paramiko shouldn't be too dramatic.
