### PR TITLE
Refactor key loading logic into its own method for clarity and better er...

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -429,6 +429,14 @@ class SSHClient (object):
         """
         return self._transport
 
+    def _key_from_filename_and_password(self, key_filename, password):
+        for pkey_class in (RSAKey, DSSKey):
+            try:
+                return pkey_class.from_private_key_file(key_filename, password=password)
+            except:
+                pass
+        raise SSHException("Not a valid RSA or DSA private key file, or wrong password.")
+
     def _auth(self, username, password, pkey, key_filenames, allow_agent, look_for_keys):
         """
         Try, in order:
@@ -457,9 +465,8 @@ class SSHClient (object):
 
         if not two_factor:
             for key_filename in key_filenames:
-                for pkey_class in (RSAKey, DSSKey):
                     try:
-                        key = pkey_class.from_private_key_file(key_filename, password)
+                        key = self._key_from_filename_and_password(key_filename, password)
                         self._log(DEBUG, 'Trying key %s from %s' % (hexlify(key.get_fingerprint()), key_filename))
                         self._transport.auth_publickey(username, key)
                         two_factor = (allowed_types == ['password'])


### PR DESCRIPTION
Many a time, when trying to login to a server using multiple RSA keys through the key_filename parameter, I got an error like "Not a valid DSA key file". This was puzzling because all keys were in fact RSA, and perfecly valid, and I was able to log in other servers.

In fact the issue was different: the problem lied in the fact that the public key matching the private RSA key was not in the target authorized_keys file, but the connection logic "masked" the true error with the last "saved exception", and since it tried to load DSA keys after RSA keys, the error was always "not a valid DSA key file".

This proposal splits the key loading part into its own method, with its own exception; in this situation, the correct "authentication failed" exception will be propagated. Of course, if an invalid RSA/DSA key file is found after an authentication failure, it's still the latter error that will be propagated, yet I think it's an improvement over the original behaviour.
