### PR TITLE
Added key exchange method "diffie-hellman-group14-sha1".

### DIFF
--- a/paramiko/kex_group1.py
+++ b/paramiko/kex_group1.py
@@ -31,12 +31,13 @@ from paramiko.ssh_exception import SSHException
 
 _MSG_KEXDH_INIT, _MSG_KEXDH_REPLY = range(30, 32)
 
-# draft-ietf-secsh-transport-09.txt, page 17
-P = 0xFFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD129024E088A67CC74020BBEA63B139B22514A08798E3404DDEF9519B3CD3A431B302B0A6DF25F14374FE1356D6D51C245E485B576625E7EC6F44C42E9A637ED6B0BFF5CB6F406B7EDEE386BFB5A899FA5AE9F24117C4B1FE649286651ECE65381FFFFFFFFFFFFFFFFL
-G = 2
-
 
 class KexGroup1(object):
+
+    # draft-ietf-secsh-transport-09.txt, page 17
+    P = 0xFFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD129024E088A67CC74020BBEA63B139B22514A08798E3404DDEF9519B3CD3A431B302B0A6DF25F14374FE1356D6D51C245E485B576625E7EC6F44C42E9A637ED6B0BFF5CB6F406B7EDEE386BFB5A899FA5AE9F24117C4B1FE649286651ECE65381FFFFFFFFFFFFFFFFL
+    G = 2
+
 
     name = 'diffie-hellman-group1-sha1'
 
@@ -50,11 +51,11 @@ class KexGroup1(object):
         self._generate_x()
         if self.transport.server_mode:
             # compute f = g^x mod p, but don't send it yet
-            self.f = pow(G, self.x, P)
+            self.f = pow(self.G, self.x, self.P)
             self.transport._expect_packet(_MSG_KEXDH_INIT)
             return
         # compute e = g^x mod p (where g=2), and send it
-        self.e = pow(G, self.x, P)
+        self.e = pow(self.G, self.x, self.P)
         m = Message()
         m.add_byte(chr(_MSG_KEXDH_INIT))
         m.add_mpint(self.e)
@@ -90,10 +91,10 @@ class KexGroup1(object):
         # client mode
         host_key = m.get_string()
         self.f = m.get_mpint()
-        if (self.f < 1) or (self.f > P - 1):
+        if (self.f < 1) or (self.f > self.P - 1):
             raise SSHException('Server kex "f" is out of range')
         sig = m.get_string()
-        K = pow(self.f, self.x, P)
+        K = pow(self.f, self.x, self.P)
         # okay, build up the hash H of (V_C || V_S || I_C || I_S || K_S || e || f || K)
         hm = Message()
         hm.add(self.transport.local_version, self.transport.remote_version,
@@ -109,9 +110,9 @@ class KexGroup1(object):
     def _parse_kexdh_init(self, m):
         # server mode
         self.e = m.get_mpint()
-        if (self.e < 1) or (self.e > P - 1):
+        if (self.e < 1) or (self.e > self.P - 1):
             raise SSHException('Client kex "e" is out of range')
-        K = pow(self.e, self.x, P)
+        K = pow(self.e, self.x, self.P)
         key = str(self.transport.get_server_key())
         # okay, build up the hash H of (V_C || V_S || I_C || I_S || K_S || e || f || K)
         hm = Message()

--- a/paramiko/kex_group14.py
+++ b/paramiko/kex_group14.py
@@ -1,0 +1,33 @@
+# Copyright (C) 2013  Torsten Landschoff <torsten@debian.org>
+#
+# This file is part of paramiko.
+#
+# Paramiko is free software; you can redistribute it and/or modify it under the
+# terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# Paramiko is distrubuted in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Paramiko; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+
+"""
+Standard SSH key exchange ("kex" if you wanna sound cool).  Diffie-Hellman of
+2048 bit key halves, using a known "p" prime and "g" generator.
+"""
+
+from paramiko.kex_group1 import KexGroup1
+
+
+class KexGroup14(KexGroup1):
+
+    # http://tools.ietf.org/html/rfc3526#section-3
+    P = 0xFFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD129024E088A67CC74020BBEA63B139B22514A08798E3404DDEF9519B3CD3A431B302B0A6DF25F14374FE1356D6D51C245E485B576625E7EC6F44C42E9A637ED6B0BFF5CB6F406B7EDEE386BFB5A899FA5AE9F24117C4B1FE649286651ECE45B3DC2007CB8A163BF0598DA48361C55D39A69163FA8FD24CF5F83655D23DCA3AD961C62F356208552BB9ED529077096966D670C354E4ABC9804F1746C08CA18217C32905E462E36CE3BE39E772C180E86039B2783A2EC07A28FB5C55DF06F4C52C9DE2BCBF6955817183995497CEA956AE515D2261898FA051015728E5A8AACAA68FFFFFFFFFFFFFFFFL
+    G = 2
+
+    name = 'diffie-hellman-group14-sha1'

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -38,6 +38,7 @@ from paramiko.compress import ZlibCompressor, ZlibDecompressor
 from paramiko.dsskey import DSSKey
 from paramiko.kex_gex import KexGex
 from paramiko.kex_group1 import KexGroup1
+from paramiko.kex_group14 import KexGroup14
 from paramiko.message import Message
 from paramiko.packet import Packetizer, NeedRekeyException
 from paramiko.primes import ModulusPack
@@ -205,6 +206,7 @@ class Transport (threading.Thread):
     _preferred_macs = ( 'hmac-sha1', 'hmac-md5', 'hmac-sha1-96', 'hmac-md5-96' )
     _preferred_keys = ( 'ssh-rsa', 'ssh-dss', 'ecdsa-sha2-nistp256' )
     _preferred_kex = ( 'diffie-hellman-group1-sha1', 'diffie-hellman-group-exchange-sha1' )
+    _preferred_kex = ( 'diffie-hellman-group1-sha1', 'diffie-hellman-group14-sha1', 'diffie-hellman-group-exchange-sha1' )
     _preferred_compression = ( 'none', )
 
     _cipher_info = {
@@ -233,6 +235,7 @@ class Transport (threading.Thread):
 
     _kex_info = {
         'diffie-hellman-group1-sha1': KexGroup1,
+        'diffie-hellman-group14-sha1': KexGroup14,
         'diffie-hellman-group-exchange-sha1': KexGex,
         }
 


### PR DESCRIPTION
I lately failed to use paramiko to connect to an SSH server which does not implement [diffie-hellman-group1-sha1](http://tools.ietf.org/html/rfc4253#section-8.1) which actually violates the RFC 4253.

OTOH paramiko violates the same RFC in that it does not support [diffie-hellman-group14-sha1](http://tools.ietf.org/html/rfc4253#section-8.2), which must be implemented all the same.

Please pull this branch to add support for this kex protocol to paramiko.
