### PR TITLE
Fix lying docstring for putfo()

### DIFF
--- a/paramiko/sftp_client.py
+++ b/paramiko/sftp_client.py
@@ -559,7 +559,7 @@ class SFTPClient (BaseSFTP):
             (since 1.7.4)
         @rtype: SFTPAttributes
 
-        @since: 1.4
+        @since: 1.10
         """
         fr = self.file(remotepath, 'wb')
         fr.set_pipelined(True)


### PR DESCRIPTION
The copy-pasted docstring for putfo() claimed it's available since 1.4 (as put() is), though it was in actuality added in 1.10.
