### PR TITLE
Handle Windows CRLF correctly in config files; fixes fabric/fabric#1023

### DIFF
--- a/paramiko/config.py
+++ b/paramiko/config.py
@@ -110,7 +110,7 @@ class SSHConfig (object):
         """
         host = {"host": ['*'], "config": {}}
         for line in file_obj:
-            line = line.rstrip('\n').lstrip()
+            line = line.rstrip('\r\n').lstrip()
             if (line == '') or (line[0] == '#'):
                 continue
             if '=' in line:

--- a/test.py
+++ b/test.py
@@ -45,6 +45,7 @@ from test_transport import TransportTest
 from test_sftp import SFTPTest
 from test_sftp_big import BigSFTPTest
 from test_client import SSHClientTest
+from test_config import ConfigTest
 
 default_host = 'localhost'
 default_user = os.environ.get('USER', 'nobody')
@@ -130,6 +131,7 @@ def main():
         suite.addTest(unittest.makeSuite(AuthTest))
         suite.addTest(unittest.makeSuite(TransportTest))
     suite.addTest(unittest.makeSuite(SSHClientTest))
+    suite.addTest(unittest.makeSuite(ConfigTest))
     if options.use_sftp:
         suite.addTest(unittest.makeSuite(SFTPTest))
     if options.use_big_file:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,33 @@
+# Copyright (C) 2013 Christopher Swenson <chris@caswenson.com>
+#
+# This file is part of paramiko.
+#
+# Paramiko is free software; you can redistribute it and/or modify it under the
+# terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# Paramiko is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Paramiko; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+
+"""
+Some unit tests for the config file parser.
+"""
+
+import paramiko
+import unittest
+from StringIO import StringIO
+
+
+class ConfigTest (unittest.TestCase):
+		def test_parse_dos_crlf_succeeds(self):
+				config_file = StringIO("host abcqwerty\r\nHostName 127.0.0.1\r\n")
+				config = paramiko.SSHConfig()
+				config.parse(config_file)
+				self.assertEqual(config.lookup("abcqwerty")["hostname"], "127.0.0.1")


### PR DESCRIPTION
The standard SSH clients correctly ignore CRLFs in SSH config files, but we do not trim them out.

This patches the config file parser to trim those out of the lines we read from the config file (and adds a test).

This fixes https://github.com/fabric/fabric/issues/1023
