### PR TITLE
Add run method to client

### DIFF
--- a/demos/demo_run.py
+++ b/demos/demo_run.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+
+# Copyright (C) 2013  Sergey Skripnick <sskripnick@mirantis.com>
+#
+# This file is part of paramiko.
+#
+# Paramiko is free software; you can redistribute it and/or modify it under the
+# terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# Paramiko is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Paramiko; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+
+"""
+Sample script showing how to use client.run method.
+"""
+
+from cStringIO import StringIO
+
+import paramiko
+
+client = paramiko.SSHClient()
+client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+client.connect('example.com', username='user')
+
+stdout = StringIO()
+stdin = open(__file__, 'r')
+
+exit_status = client.run('cat', stdin=stdin, stdout=stdout)
+
+stdout.seek(0) # don't forget to rewind pseudo file
+print 'Stdout size:', len(stdout.read()) # size of this file
+print 'Exit status:', exit_status
+
+# As stdout/stderr may any object with write method:
+
+
+class PseudoFileOut(object):
+    def write(self, data):
+        print 'stdout chunk:', data
+
+
+class PseudoFileErr(object):
+    def write(self, data):
+        print 'stderr chunk:', data
+
+
+client.run('echo "Hi there!" && echo "Hi stderr too!" >&2', stdout=PseudoFileOut(), stderr=PseudoFileErr())
+# this will print following:
+#stdout chunk: Hi there!
+#stderr chunk: Hi stderr too!
+


### PR DESCRIPTION
Try to run with paramiko script like this:

```bash
while true
do
echo "some stdout"
echo "some stderr" >&2
done
```

Example from README will not work.

For running commands with big amount of mixed stdout/stderr data, lots of code needed.

This method make such things more simple.

Sample usage:
```python
client = paramiko.SSHClient()
client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
client.connect('example.com', username='user')

exit_status = client.run('script.sh', stdout=open('/tmp/temp_stdout', 'w'))
```

Also pseudo files can be passed:
```python

class PseudoFile(object):
    def write(self, data):
        print 'chunk received:', data

exit_status = client.run('script.sh', stderr=PseudoFile())
````

Also StringIO objects works well.

More examples:

Run local script on remote side:
```python
client.run('sh -s', stdin=open('/tmp/local_script.sh', 'rb'))
```

Remote grep:
```python
client.run('grep sample',
           stdin=open('/tmp/local_data', 'rb'),
           stdout=open('/tmp/grepped_data', 'w'))
```
