### PR TITLE
fix hang if using proxycommand

### DIFF
--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -615,10 +615,10 @@ class Transport (threading.Thread):
         """
         if not self.active:
             return
+        self.sock.close()
         self.stop_thread()
         for chan in self._channels.values():
             chan._unlink()
-        self.sock.close()
 
     def get_remote_server_key(self):
         """


### PR DESCRIPTION
[Maintainer note: this patch can't be used as-is but see comments for eventual diagnosis & fixes.]

problem was introduced by commit 068bf63cf03d689187bede5c11b6c38ec2b2a8e1
when using a proxycommand, self.is_alive() loop in stop_thread never
ends

Don't know if it is the right way to do it, but, works for me
