### PR TITLE
Use more specific Exceptions

### DIFF
--- a/paramiko/_winapi.py
+++ b/paramiko/_winapi.py
@@ -18,6 +18,11 @@ except AttributeError:
 ######################
 # jaraco.windows.error
 
+if not getattr(__builtins__, "WindowsError", None):
+    class WindowsError(OSError):
+        pass
+
+
 def format_system_message(errno):
 	"""
 	Call FormatMessage with a system error number to retrieve
@@ -123,7 +128,7 @@ class MemoryMap(object):
 			unicode(self.name))
 		handle_nonzero_success(filemap)
 		if filemap == INVALID_HANDLE_VALUE:
-			raise Exception("Failed to create file mapping")
+			raise WindowsError("Failed to create file mapping")
 		self.filemap = filemap
 		self.view = MapViewOfFile(filemap, FILE_MAP_WRITE, 0, 0, 0)
 		return self

--- a/paramiko/config.py
+++ b/paramiko/config.py
@@ -30,6 +30,13 @@ SSH_PORT = 22
 proxy_re = re.compile(r"^(proxycommand)\s*=*\s*(.*)", re.I)
 
 
+class Error(Exception):
+    """
+    Errors raised within the paramiko.config module
+    """
+    pass
+
+
 class LazyFqdn(object):
     """
     Returns the host's fqdn on request as string.
@@ -127,7 +134,7 @@ class SSHConfig (object):
                 while (i < len(line)) and not line[i].isspace():
                     i += 1
                 if i == len(line):
-                    raise Exception('Unparsable line: %r' % line)
+                    raise Error('Unparsable line: %r' % line)
                 key = line[:i].lower()
                 value = line[i:].lstrip()
 

--- a/paramiko/message.py
+++ b/paramiko/message.py
@@ -286,7 +286,7 @@ class Message (object):
         elif type(i) is list:
             return self.add_list(i)
         else:
-            raise Exception('Unknown type')
+            raise ValueError('Unknown type')
 
     def add(self, *seq):
         """

--- a/paramiko/pkey.py
+++ b/paramiko/pkey.py
@@ -236,7 +236,7 @@ class PKey (object):
         @raise IOError: if there was an error writing the file
         @raise SSHException: if the key is invalid
         """
-        raise Exception('Not implemented in PKey')
+        raise NotImplemented('Not implemented in PKey')
 
     def write_private_key(self, file_obj, password=None):
         """
@@ -251,7 +251,7 @@ class PKey (object):
         @raise IOError: if there was an error writing to the file
         @raise SSHException: if the key is invalid
         """
-        raise Exception('Not implemented in PKey')
+        raise NotImplemented('Not implemented in PKey')
 
     def _read_private_key_file(self, tag, filename, password=None):
         """

--- a/paramiko/sftp_client.py
+++ b/paramiko/sftp_client.py
@@ -704,7 +704,7 @@ class SFTPClient (BaseSFTP):
                 elif isinstance(item, SFTPAttributes):
                     item._pack(msg)
                 else:
-                    raise Exception('unknown type for %r type %r' % (item, type(item)))
+                    raise ValueError('unknown type for %r type %r' % (item, type(item)))
             num = self.request_number
             self._expecting[num] = fileobj
             self._send_packet(t, str(msg))

--- a/paramiko/sftp_server.py
+++ b/paramiko/sftp_server.py
@@ -186,7 +186,7 @@ class SFTPServer (BaseSFTP, SubsystemHandler):
             elif type(item) is SFTPAttributes:
                 item._pack(msg)
             else:
-                raise Exception('unknown type for ' + repr(item) + ' type ' + repr(type(item)))
+                raise ValueError('unknown type for ' + repr(item) + ' type ' + repr(type(item)))
         self._send_packet(t, str(msg))
 
     def _send_handle_response(self, request_number, handle, folder=False):


### PR DESCRIPTION
Changed instances of "raise Exception" to use more specific exception types (tests pass).

For example, when we want to parse a config, and handle only errors specific to config:

``` python
from paramiko import config
try:
    cfig = config.SSHConfig
    cfig.parse(open('~/.ssh/config'))
except config.Error:
    print "Error parsing config file"
except OSError:
    print "Error opening file"
```

Added:
- `paramiko._winapi.WindowsError(OSError)`
- `paramiko.config.Error(Exception)`

Used built-in exceptions where it made sense. For example:
- `Exception("not implemented ...")` was replaced by `NotImplemented("not implemented ...")`
- `Exception("Unknown type ...") was replaced by`ValueError("Unknown type...")``. The classes being checked by isinstance() were passed as function parameters, hence ValueError instead of TypeError.
