### PR TITLE
Fix Connection to Enterasys B2 Switch

### DIFF
--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -277,7 +277,7 @@ class Transport (threading.Thread, ClosingContextManager):
         self._channels = ChannelMap()
         self.channel_events = {}       # (id -> Event)
         self.channels_seen = {}        # (id -> True)
-        self._channel_counter = 1
+        self._channel_counter = 0
         self.default_max_packet_size = default_max_packet_size
         self.default_window_size = default_window_size
         self._forward_agent_handler = None


### PR DESCRIPTION
Connecting to an Enterasys B2 Switch (using demo_simple.py) for an
interactive shell doesn't work:

```
Connected. Getting Shell...
DEBUG:paramiko.transport:[chan 1] Max packet in: 34816 bytes
DEBUG:paramiko.transport:[chan 1] Max packet out: 16384
bytes
INFO:paramiko.transport:Secsh channel 1 opened.
ERROR:paramiko.transport:Channel request for unknown
channel 0
*** Caught exception: <class 'paramiko.SSHException'>: Channel closed.
```

The channels gets opened with index 1 on client
(paramiko) side and index 0 on server (switch)
side.
Probably the switch doesn't support this and
replies to the pty request with a wrong channel
id. Because of that paramiko closes the
connection.

This can be solved (or worked around) easily by
initialising _channel_counter with 0.
This is what other clients, like openssh do.

I don't see a problem with initialising this
counter with 0.
Would this be acceptable?
