### PR TITLE
Undefined name 'BadProxyCommand'

### DIFF
--- a/paramiko/proxy.py
+++ b/paramiko/proxy.py
@@ -64,7 +64,7 @@ class ProxyCommand(object):
             # died and we can't proceed. The best option here is to
             # raise an exception informing the user that the informed
             # ProxyCommand is not working.
-            raise BadProxyCommand(' '.join(self.cmd), e.strerror)
+            raise ProxyCommandFailure(' '.join(self.cmd), e.strerror)
         return len(content)
 
     def recv(self, size):
@@ -80,7 +80,7 @@ class ProxyCommand(object):
         try:
             return os.read(self.process.stdout.fileno(), size)
         except IOError, e:
-            raise BadProxyCommand(' '.join(self.cmd), e.strerror)
+            raise ProxyCommandFailure(' '.join(self.cmd), e.strerror)
 
     def close(self):
         os.kill(self.process.pid, signal.SIGTERM)


### PR DESCRIPTION
paramiko/proxy.py refers to an undefined exception name `BadProxyCommand` twice.

I checked with pyflakes to see if there might be any other similar problems, and found none:

```
mg@platonas: ~/src/paramiko [git:master=] $ pyflakes paramiko|grep -v 'imported but unused'|grep -v 'never used'|grep -v 'unable to detect'
paramiko/proxy.py:67: undefined name 'BadProxyCommand'
paramiko/proxy.py:83: undefined name 'BadProxyCommand'
```
