### PR TITLE
Don't hash the input hostname when checking a host key if the input host...

### DIFF
--- a/paramiko/hostkeys.py
+++ b/paramiko/hostkeys.py
@@ -247,7 +247,7 @@ class HostKeys (UserDict.DictMixin):
         entries = []
         for e in self._entries:
             for h in e.hostnames:
-                if h.startswith('|1|') and constant_time_bytes_eq(self.hash_host(hostname, h), h) or h == hostname:
+                if h.startswith('|1|') and not hostname.startswith('|1|') and constant_time_bytes_eq(self.hash_host(hostname, h), h) or h == hostname:
                     entries.append(e)
         if len(entries) == 0:
             return None


### PR DESCRIPTION
...name is already hashed

This happens in the loop checking if a hostkey is already loaded when
loading host key files. This reduces time to load host keys file with
about two seconds for me
