### PR TITLE
Allow the user to set the client id in the SSH version exchange

### DIFF
--- a/demos/demo.py
+++ b/demos/demo.py
@@ -38,12 +38,12 @@ def agent_auth(transport, username):
     Attempt to authenticate to the given transport using any of the private
     keys available from an SSH agent.
     """
-    
+
     agent = paramiko.Agent()
     agent_keys = agent.get_keys()
     if len(agent_keys) == 0:
         return
-        
+
     for key in agent_keys:
         print 'Trying ssh-agent key %s' % hexlify(key.get_fingerprint()),
         try:
@@ -116,6 +116,7 @@ except Exception, e:
 
 try:
     t = paramiko.Transport(sock)
+    t.set_client_id('demo.py ' + paramiko.__version__)
     try:
         t.start_client()
     except paramiko.SSHException:

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -532,6 +532,18 @@ class Transport (threading.Thread):
             if event.isSet():
                 break
 
+    def set_client_id(self, client_id):
+        """
+        Change the software identification in the client side SSH version.
+        The default banner, currently, is 'SSH 2.0 paramiko-1.13' and
+        this function allows the caller to alter the banner to be like
+        so: 'SSH 2.0 <client_id>'
+
+        @param client_id: The string to display in the client SSH banner
+        @type client_id: str
+        """
+        self.local_version = 'SSH-' + self._PROTO_ID + '-' + client_id
+
     def add_server_key(self, key):
         """
         Add a host key to the list of keys used for server mode.  When behaving


### PR DESCRIPTION
There are various situations in which a developer may want to display a different version string in the protocol version exchange. This patch adds a function in Transport to allow this. The patch also alters demo.py to show usage.

Below are Wireshark screenshots showing the version string before and after this patch.
![before_patch](https://f.cloud.github.com/assets/787916/2249083/f882fe14-9d80-11e3-97cb-8bf95d7e5f45.png)
![after_patch](https://f.cloud.github.com/assets/787916/2249088/fd74a1f2-9d80-11e3-912d-3ad5a5474bc1.png)
