### PR TITLE
Add a setup.cfg identifying this package as universal

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[wheel]
+universal = 1


### PR DESCRIPTION
Meaning that it's build is not system dependent. Which it's not, because it's pure python. Refs #275
