### PR TITLE
Fixes #275 -- upload wheels as a part of the release process

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -43,7 +43,7 @@ def release(ctx):
     rmtree(target, ignore_errors=True)
     copytree(docs_build, target)
     # Publish
-    publish(ctx)
+    publish(ctx, wheel=True)
 
 
 ns = Collection(test, coverage, release, docs=docs, www=www)


### PR DESCRIPTION
Requires teh latest version of invocations from git
