### PR TITLE
Add pkey.KeyFormatException and make PKey and subclasses raise it on invalid key data

### DIFF
--- a/paramiko/__init__.py
+++ b/paramiko/__init__.py
@@ -50,7 +50,7 @@ from paramiko.message import Message
 from paramiko.packet import Packetizer
 from paramiko.file import BufferedFile
 from paramiko.agent import Agent, AgentKey
-from paramiko.pkey import PKey
+from paramiko.pkey import PKey, KeyFormatException
 from paramiko.hostkeys import HostKeys
 from paramiko.config import SSHConfig
 from paramiko.proxy import ProxyCommand

--- a/paramiko/dsskey.py
+++ b/paramiko/dsskey.py
@@ -29,7 +29,7 @@ from paramiko.py3compat import long
 from paramiko.ssh_exception import SSHException
 from paramiko.message import Message
 from paramiko.ber import BER, BERException
-from paramiko.pkey import PKey
+from paramiko.pkey import PKey, KeyFormatException
 
 
 class DSSKey (PKey):
@@ -58,7 +58,7 @@ class DSSKey (PKey):
             if msg is None:
                 raise SSHException('Key object may not be empty')
             if msg.get_text() != 'ssh-dss':
-                raise SSHException('Invalid key')
+                raise KeyFormatException('Invalid key')
             self.p = msg.get_mpint()
             self.q = msg.get_mpint()
             self.g = msg.get_mpint()
@@ -185,9 +185,9 @@ class DSSKey (PKey):
         try:
             keylist = BER(data).decode()
         except BERException as e:
-            raise SSHException('Unable to parse key file: ' + str(e))
+            raise KeyFormatException('Unable to parse key file: ' + str(e))
         if (type(keylist) is not list) or (len(keylist) < 6) or (keylist[0] != 0):
-            raise SSHException('not a valid DSA private key file (bad ber encoding)')
+            raise KeyFormatException('not a valid DSA private key file (bad ber encoding)')
         self.p = keylist[1]
         self.q = keylist[2]
         self.g = keylist[3]

--- a/paramiko/ecdsakey.py
+++ b/paramiko/ecdsakey.py
@@ -27,7 +27,7 @@ from ecdsa.test_pyecdsa import ECDSA
 from paramiko.common import four_byte, one_byte
 
 from paramiko.message import Message
-from paramiko.pkey import PKey
+from paramiko.pkey import PKey, KeyFormatException
 from paramiko.py3compat import byte_chr, u
 from paramiko.ssh_exception import SSHException
 
@@ -55,14 +55,14 @@ class ECDSAKey (PKey):
             if msg is None:
                 raise SSHException('Key object may not be empty')
             if msg.get_text() != 'ecdsa-sha2-nistp256':
-                raise SSHException('Invalid key')
+                raise KeyFormatException('Invalid key')
             curvename = msg.get_text()
             if curvename != 'nistp256':
-                raise SSHException("Can't handle curve of type %s" % curvename)
+                raise KeyFormatException("Can't handle curve of type %s" % curvename)
 
             pointinfo = msg.get_binary()
             if pointinfo[0:1] != four_byte:
-                raise SSHException('Point compression is being used: %s' %
+                raise KeyFormatException('Point compression is being used: %s' %
                                    binascii.hexlify(pointinfo))
             self.verifying_key = VerifyingKey.from_string(pointinfo[1:],
                                                           curve=curves.NIST256p)

--- a/paramiko/pkey.py
+++ b/paramiko/pkey.py
@@ -54,10 +54,11 @@ class PKey (object):
         :param .Message msg:
             an optional SSH `.Message` containing a public key of this type.
         :param str data: an optional string containing a public key of this type
-
+        
+        :raises KeyFormatException:
+            if a key cannot be created from the ``data`` or ``msg`` given.
         :raises SSHException:
-            if a key cannot be created from the ``data`` or ``msg`` given, or
-            no key was passed in.
+            if no key was passed in.
         """
         pass
 
@@ -178,7 +179,7 @@ class PKey (object):
         :raises IOError: if there was an error reading the file
         :raises PasswordRequiredException: if the private key file is
             encrypted, and ``password`` is ``None``
-        :raises SSHException: if the key file is invalid
+        :raises KeyFormatException: if the key file is invalid
         """
         key = cls(filename=filename, password=password)
         return key
@@ -199,7 +200,7 @@ class PKey (object):
         :raises IOError: if there was an error reading the key
         :raises PasswordRequiredException: if the private key file is encrypted,
             and ``password`` is ``None``
-        :raises SSHException: if the key file is invalid
+        :raises KeyFormatException: if the key file is invalid
         """
         key = cls(file_obj=file_obj, password=password)
         return key
@@ -250,7 +251,7 @@ class PKey (object):
         :raises IOError: if there was an error reading the file.
         :raises PasswordRequiredException: if the private key file is
             encrypted, and ``password`` is ``None``.
-        :raises SSHException: if the key file is invalid.
+        :raises KeyFormatException: if the key file is invalid.
         """
         with open(filename, 'r') as f:
             data = self._read_private_key(tag, f, password)
@@ -262,7 +263,7 @@ class PKey (object):
         while (start < len(lines)) and (lines[start].strip() != '-----BEGIN ' + tag + ' PRIVATE KEY-----'):
             start += 1
         if start >= len(lines):
-            raise SSHException('not a valid ' + tag + ' private key file')
+            raise KeyFormatException('not a valid ' + tag + ' private key file')
         # parse any headers first
         headers = {}
         start += 1
@@ -280,19 +281,19 @@ class PKey (object):
         try:
             data = decodebytes(b(''.join(lines[start:end])))
         except base64.binascii.Error as e:
-            raise SSHException('base64 decoding error: ' + str(e))
+            raise KeyFormatException('base64 decoding error: ' + str(e))
         if 'proc-type' not in headers:
             # unencryped: done
             return data
         # encrypted keyfile: will need a password
         if headers['proc-type'] != '4,ENCRYPTED':
-            raise SSHException('Unknown private key structure "%s"' % headers['proc-type'])
+            raise KeyFormatException('Unknown private key structure "%s"' % headers['proc-type'])
         try:
             encryption_type, saltstr = headers['dek-info'].split(',')
         except:
-            raise SSHException("Can't parse DEK-info in private key file")
+            raise KeyFormatException("Can't parse DEK-info in private key file")
         if encryption_type not in self._CIPHER_TABLE:
-            raise SSHException('Unknown private key cipher "%s"' % encryption_type)
+            raise KeyFormatException('Unknown private key cipher "%s"' % encryption_type)
         # if no password was passed in, raise an exception pointing out that we need one
         if password is None:
             raise PasswordRequiredException('Private key file is encrypted')
@@ -349,3 +350,11 @@ class PKey (object):
         f.write(s)
         f.write('\n')
         f.write('-----END %s PRIVATE KEY-----\n' % tag)
+
+
+class KeyFormatException(SSHException):
+    """
+    Exception raised when an attempt to read a key fails because the key is
+    malformed.
+    """
+    pass

--- a/paramiko/rsakey.py
+++ b/paramiko/rsakey.py
@@ -27,7 +27,7 @@ from paramiko import util
 from paramiko.common import rng, max_byte, zero_byte, one_byte
 from paramiko.message import Message
 from paramiko.ber import BER, BERException
-from paramiko.pkey import PKey
+from paramiko.pkey import PKey, KeyFormatException
 from paramiko.py3compat import long
 from paramiko.ssh_exception import SSHException
 
@@ -60,7 +60,7 @@ class RSAKey (PKey):
             if msg is None:
                 raise SSHException('Key object may not be empty')
             if msg.get_text() != 'ssh-rsa':
-                raise SSHException('Invalid key')
+                raise KeyFormatException('Invalid key')
             self.e = msg.get_mpint()
             self.n = msg.get_mpint()
         self.size = util.bit_length(self.n)
@@ -173,9 +173,9 @@ class RSAKey (PKey):
         try:
             keylist = BER(data).decode()
         except BERException:
-            raise SSHException('Unable to parse key file')
+            raise KeyFormatException('Unable to parse key file')
         if (type(keylist) is not list) or (len(keylist) < 4) or (keylist[0] != 0):
-            raise SSHException('Not a valid RSA private key file (bad ber encoding)')
+            raise KeyFormatException('Not a valid RSA private key file (bad ber encoding)')
         self.n = keylist[1]
         self.e = keylist[2]
         self.d = keylist[3]


### PR DESCRIPTION
Raise a more specific subclass of SSHException, KeyFormatException, when attempting to parse invalid key data.
