### PR TITLE
Don't validate points in known_hosts ECDSA keys

### DIFF
--- a/paramiko/ecdsakey.py
+++ b/paramiko/ecdsakey.py
@@ -38,7 +38,8 @@ class ECDSAKey (PKey):
     data.
     """
 
-    def __init__(self, msg=None, data=None, filename=None, password=None, vals=None, file_obj=None):
+    def __init__(self, msg=None, data=None, filename=None, password=None,
+                 vals=None, file_obj=None, validate_point=True):
         self.verifying_key = None
         self.signing_key = None
         if file_obj is not None:
@@ -65,7 +66,8 @@ class ECDSAKey (PKey):
                 raise SSHException('Point compression is being used: %s' %
                                    binascii.hexlify(pointinfo))
             self.verifying_key = VerifyingKey.from_string(pointinfo[1:],
-                                                          curve=curves.NIST256p)
+                                                          curve=curves.NIST256p,
+                                                          validate_point=validate_point)
         self.size = 256
 
     def asbytes(self):

--- a/paramiko/hostkeys.py
+++ b/paramiko/hostkeys.py
@@ -324,7 +324,7 @@ class HostKeyEntry:
             elif keytype == 'ssh-dss':
                 key = DSSKey(data=decodebytes(key))
             elif keytype == 'ecdsa-sha2-nistp256':
-                key = ECDSAKey(data=decodebytes(key))
+                key = ECDSAKey(data=decodebytes(key), validate_point=False)
             else:
                 log.info("Unable to handle key of type %s" % (keytype,))
                 return None

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ try:
     from setuptools import setup
     kw = {
         'install_requires': ['pycrypto >= 2.1, != 2.4',
-                             'ecdsa',
+                             'ecdsa >= 0.11',
                              ],
     }
 except ImportError:


### PR DESCRIPTION
Point validation is really expensive and apparently unnecessary when
we already trust the keys in our known_hosts file.

With my current known_hosts file of 657 keys, this reduces the time
taken to complete a remote task in fabric from 24 seconds to 7 seconds.

This requires python-ecdsa >= 0.11.

Closes #270.
