### PR TITLE
Revert a regression in DSS key generation

### DIFF
--- a/paramiko/dsskey.py
+++ b/paramiko/dsskey.py
@@ -111,9 +111,9 @@ class DSSKey (PKey):
         rstr = util.deflate_long(r, 0)
         sstr = util.deflate_long(s, 0)
         if len(rstr) < 20:
-            rstr += zero_byte * (20 - len(rstr))
+            rstr = zero_byte * (20 - len(rstr)) + rstr
         if len(sstr) < 20:
-            sstr += zero_byte * (20 - len(sstr))
+            sstr = zero_byte * (20 - len(sstr)) + sstr
         m.add_string(rstr + sstr)
         return m
 

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`308` Fix regression in dsskey.py that caused sporadic signature 
+  verification failures. Thanks to Chris Rose.
 * :support:`290` (also :issue:`292`) Add support for building universal
   (Python 2+3 compatible) wheel files during the release process. Courtesy of
   Alex Gaynor.


### PR DESCRIPTION
A change in f0017b833098 caused a random regression in DSS key signing
due to moving the padding on the integers generated by DSA from the left
to the right.

So, for example, if signing the test case string "jerri blank", the
random number might be generated as:

k=703745698612177278239572677252380378525350342103

If so, the signature parts will be:
r=184615963997659989901526712385095827509599268253
s=2682547683721156713440053885014828604195555319

Note the s being shorter.

Prior to f0017b833098, s would be right-padded with zeros:
s=268254768372115671344005388501482860419555531900

After, it would be left-padded:
s=002682547683721156713440053885014828604195555319

When converting back to a long, that loses the padding. This change
restores the behaviour.

Fixes #308
