### PR TITLE
sftp putfo(): don't close destination file pointer until we have stat'd ...

### DIFF
--- a/paramiko/sftp_client.py
+++ b/paramiko/sftp_client.py
@@ -549,6 +549,7 @@ class SFTPClient(BaseSFTP):
                     callback(size, file_size)
                 if len(data) == 0:
                     break
+            fr.flush()
             if confirm:
                 s = self.stat(remotepath)
                 if s.st_size != size:


### PR DESCRIPTION
...it - avoids situation where something on the remote end (e.g. inotify) removes files immediately after they're written

I was delivering media to a remote service which must have had inotify watching for the empty file to signify 'transfer complete' (e.g. inotify close_write).
The listener would immediately remove the file, and start ingesting the media - causing paramiko to not be able to stat() the file.
This change just means we don't close() the remote file until we've stat'd it first, thus avoiding this problem.
