### PR TITLE
Issue #327: safe_string TypeError

### DIFF
--- a/paramiko/util.py
+++ b/paramiko/util.py
@@ -117,8 +117,10 @@ def unhexify(s):
 def safe_string(s):
     out = ''
     for c in s:
-        if (byte_ord(c) >= 32) and (byte_ord(c) <= 127):
+        if (type(c) is int):
             out += chr(c)
+        elif (byte_ord(c) >= 32) and (byte_ord(c) <= 127):
+            out += c
         else:
             out += '%%%02X' % byte_ord(c)
     return out

--- a/paramiko/util.py
+++ b/paramiko/util.py
@@ -118,7 +118,7 @@ def safe_string(s):
     out = ''
     for c in s:
         if (byte_ord(c) >= 32) and (byte_ord(c) <= 127):
-            out += c
+            out += chr(c)
         else:
             out += '%%%02X' % byte_ord(c)
     return out


### PR DESCRIPTION
In some cases safe_string gets an array
of integers as argument. safe_string then
tries to concatenate those integers onto a
string, resulting in a TypeError.
