### PR TITLE
Fixes to work on Google App Engine

### DIFF
--- a/paramiko/proxy.py
+++ b/paramiko/proxy.py
@@ -21,7 +21,11 @@ from datetime import datetime
 import os
 from shlex import split as shlsplit
 import signal
-from subprocess import Popen, PIPE
+try:
+    from subprocess import Popen, PIPE
+except ImportError:
+    # Subprocess module doesn't work on Google App Engine.
+    Popen = PIPE = None
 from select import select
 import socket
 

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -134,6 +134,7 @@ class Transport (threading.Thread):
     }
 
     _modulus_pack = None
+    _active_check_timeout = 0.1
 
     def __init__(self, sock):
         """
@@ -198,7 +199,7 @@ class Transport (threading.Thread):
             # we set the timeout so we can check self.active periodically to
             # see if we should bail.  socket.timeout exception is never
             # propagated.
-            self.sock.settimeout(0.1)
+            self.sock.settimeout(self._active_check_timeout)
         except AttributeError:
             pass
 


### PR DESCRIPTION
This PR resolves some problems when using GoogleAppEngine Sockets API.

1: Subprocess module doesn't work on Google App Engine.

```
Traceback (most recent call last):
  File "/home/tokibito/src/google_appengine/google/appengine/runtime/wsgi.py", line 239, in Handle
    handler = _config_handle.add_wsgi_middleware(self._LoadHandler())
  File "/home/tokibito/src/google_appengine/google/appengine/runtime/wsgi.py", line 298, in _LoadHandler
    handler, path, err = LoadObject(self._handler)
  File "/home/tokibito/src/google_appengine/google/appengine/runtime/wsgi.py", line 84, in LoadObject
    obj = __import__(path[0])
  File "/home/tokibito/sandbox/gae-paramiko/main.py", line 2, in <module>
    import paramiko
  File "/home/tokibito/sandbox/gae-paramiko/lib/paramiko/__init__.py", line 56, in <module>
    from paramiko.proxy import ProxyCommand
  File "/home/tokibito/sandbox/gae-paramiko/lib/paramiko/proxy.py", line 24, in <module>
    from subprocess import Popen, PIPE
```

2: It is raises the socket error if  the active check timeout is too short.

```
Traceback (most recent call last):
  File "/base/data/home/runtimes/python27/python27_lib/versions/1/google/appengine/runtime/wsgi.py", line 266, in Handle
    result = handler(dict(self._environ), self._StartResponse)
  File "/base/data/home/apps/s~nullpobug-sandbox-hrd/ssh.376051288567321218/main.py", line 9, in app
    client.connect('test.nullpobug.com', username='spam', key_filename=os.path.join(base_dir, 'secret.key'))
  File "/base/data/home/apps/s~nullpobug-sandbox-hrd/ssh.376051288567321218/lib/paramiko/client.py", line 242, in connect
    t.start_client()
  File "/base/data/home/apps/s~nullpobug-sandbox-hrd/ssh.376051288567321218/lib/paramiko/transport.py", line 346, in start_client
    raise e
SSHException: Error reading SSH protocol banner[Errno 11] Resource temporarily unavailable
```

Such code works on Google App Engine with this patch.

```
import os
import paramiko
import paramiko.transport

def app(environ, start_response):
    base_dir = os.path.dirname(os.path.abspath(__file__))
    paramiko.transport.Transport._active_check_timeout = 5
    client = paramiko.SSHClient()
    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
    client.connect('test.nullpobug.com', username='spam', key_filename=os.path.join(base_dir, 'secret.key'))
    stdin, stdout, stderr = client.exec_command('uname -a')

    start_response('200 OK', [('Content-type', 'text/plain')])
    return stdout.read()
```
