### PR TITLE
Corrected the length of the salt for private key encryption

### DIFF
--- a/paramiko/pkey.py
+++ b/paramiko/pkey.py
@@ -324,13 +324,12 @@ class PKey (object):
     def _write_private_key(self, tag, f, data, password=None):
         f.write('-----BEGIN %s PRIVATE KEY-----\n' % tag)
         if password is not None:
-            # since we only support one cipher here, use it
             cipher_name = list(self._CIPHER_TABLE.keys())[0]
             cipher = self._CIPHER_TABLE[cipher_name]['cipher']
             keysize = self._CIPHER_TABLE[cipher_name]['keysize']
             blocksize = self._CIPHER_TABLE[cipher_name]['blocksize']
             mode = self._CIPHER_TABLE[cipher_name]['mode']
-            salt = os.urandom(16)
+            salt = os.urandom(blocksize)
             key = util.generate_key_bytes(md5, salt, password, keysize)
             if len(data) % blocksize != 0:
                 n = blocksize - len(data) % blocksize


### PR DESCRIPTION
This would corrupt the private key file whenever the DES cipher would get selected.
Apparently, the list is not ordered in the same way on every system. It could also be a good idea to buffer the changes and write them all at once after to avoid corrupting the file whenever there is a bug.
