### PR TITLE
Updating doco for sftp_client.put()

### DIFF
--- a/paramiko/sftp_client.py
+++ b/paramiko/sftp_client.py
@@ -566,7 +566,9 @@ class SFTPClient(BaseSFTP):
         The SFTP operations use pipelining for speed.
 
         :param str localpath: the local file to copy
-        :param str remotepath: the destination path on the SFTP server
+        :param str remotepath: the destination path on the SFTP server. Note
+            that the filename should be included. Only specifying a directory
+            may result in an error.
         :param callable callback:
             optional callback function (form: ``func(int, int)``) that accepts
             the bytes transferred so far and the total bytes to be transferred


### PR DESCRIPTION
Adding a note to indicate that the remotepath should include a filename.
