### PR TITLE
Support passing in "buffer" objects again where bytestrings are expected.

### DIFF
--- a/paramiko/py3compat.py
+++ b/paramiko/py3compat.py
@@ -39,6 +39,8 @@ if PY2:
             return s
         elif isinstance(s, unicode):
             return s.encode(encoding)
+        elif isinstance(s, buffer):
+            return s
         else:
             raise TypeError("Expected unicode or bytes, got %r" % s)
 
@@ -49,6 +51,8 @@ if PY2:
             return s.decode(encoding)
         elif isinstance(s, unicode):
             return s
+        elif isinstance(s, buffer):
+            return s.decode(encoding)
         else:
             raise TypeError("Expected unicode or bytes, got %r" % s)
 

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -23,6 +23,7 @@ Some unit tests for the BufferedFile abstraction.
 import unittest
 from paramiko.file import BufferedFile
 from paramiko.common import linefeed_byte, crlf, cr_byte
+import sys
 
 
 class LoopbackFile (BufferedFile):
@@ -150,6 +151,15 @@ class BufferedFileTest (unittest.TestCase):
         self.assertEqual(s, b'The first thing you need to do is open your eyes. Then, you ' +
                             b'need to close them again.\n')
         f.close()
+
+    def test_8_buffering(self):
+        """
+        verify that buffered objects can be written
+        """
+        if sys.version_info[0] == 2:
+            f = LoopbackFile('r+', 16)
+            f.write(buffer(b'Too small.'))
+            f.close()
 
 if __name__ == '__main__':
     from unittest import main


### PR DESCRIPTION
This fixes bzr's use of paramiko.

Fixes issue #343/#285.
