### PR TITLE
Fixed a typo in method name

### DIFF
--- a/paramiko/util.py
+++ b/paramiko/util.py
@@ -126,7 +126,7 @@ def safe_string(s):
 
 def bit_length(n):
     try:
-        return n.bitlength()
+        return n.bit_length()
     except AttributeError:
         norm = deflate_long(n, False)
         hbyte = byte_ord(norm[0])


### PR DESCRIPTION
The method on Python3 is `bit_length`, not `bitlength`.