### PR TITLE
make recv_exit_status respect timeout value

### DIFF
--- a/paramiko/channel.py
+++ b/paramiko/channel.py
@@ -289,7 +289,9 @@ class Channel (object):
         
         .. versionadded:: 1.2
         """
-        self.status_event.wait()
+        is_ready = self.status_event.wait(self.timeout)
+	if not is_ready:
+	    socket.timeout()
         assert self.status_event.isSet()
         return self.exit_status
 

--- a/paramiko/channel.py
+++ b/paramiko/channel.py
@@ -289,10 +289,9 @@ class Channel (object):
         
         .. versionadded:: 1.2
         """
-        is_ready = self.status_event.wait(self.timeout)
-	if not is_ready:
-	    socket.timeout()
-        assert self.status_event.isSet()
+        self.status_event.wait(self.timeout)
+        if not self.status_event.isSet():
+            raise socket.timeout()
         return self.exit_status
 
     def send_exit_status(self, status):


### PR DESCRIPTION
in current code when executing chan.recv_exit_status() it will block until exit status available & timeout will not be checked even if it was set
