### PR TITLE
Don't tell pip to use mirrors anymore

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,5 +2,5 @@
 envlist = py26,py27,py32,py33,py34
 
 [testenv]
-commands = pip install --use-mirrors -q -r tox-requirements.txt
+commands = pip install -q -r tox-requirements.txt
            python test.py


### PR DESCRIPTION
The mirrors don't add any value now that pypi has a really good CDN
