### PR TITLE
Use keyword arguments for arguments when creating a Transport.

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -250,7 +250,7 @@ class SSHClient (ClosingContextManager):
                     pass
             retry_on_signal(lambda: sock.connect(addr))
 
-        t = self._transport = Transport(sock, gss_kex, gss_deleg_creds)
+        t = self._transport = Transport(sock, gss_kex=gss_kex, gss_deleg_creds=gss_deleg_creds)
         t.use_compression(compress=compress)
         if gss_kex and gss_host is None:
             t.set_gss_host(hostname)

--- a/tests/test_kex_gss.py
+++ b/tests/test_kex_gss.py
@@ -84,7 +84,7 @@ class GSSKexTest(unittest.TestCase):
 
     def _run(self):
         self.socks, addr = self.sockl.accept()
-        self.ts = paramiko.Transport(self.socks, True)
+        self.ts = paramiko.Transport(self.socks, gss_kex=True)
         host_key = paramiko.RSAKey.from_private_key_file('tests/test_rsa.key')
         self.ts.add_server_key(host_key)
         self.ts.set_gss_host(targ_name)


### PR DESCRIPTION
Fixes #399
## Problem

A Transport was being constructed with positional arguments from variables named gss_kex and gss_deleg_creds, yet they were being passed to the default_window_size and default_max_packet_size arguments in Transport.**init**.
## Solution

This pull request fixes the regression by passing keyword arguments when creating a Transport so that gss_kex and gss_deleg_creds always get passed to the Transport.**init** arguments with the same name.
## To Do

This could really use a regression test for ssh agent forwarding.  However, I currently don't know the code well enough to write one.
