### PR TITLE
Fix line number for known_hosts error messages.

### DIFF
--- a/paramiko/hostkeys.py
+++ b/paramiko/hostkeys.py
@@ -92,7 +92,7 @@ class HostKeys (MutableMapping):
         :raises IOError: if there was an error reading the file
         """
         with open(filename, 'r') as f:
-            for lineno, line in enumerate(f):
+            for lineno, line in enumerate(f, 1):
                 line = line.strip()
                 if (len(line) == 0) or (line[0] == '#'):
                     continue


### PR DESCRIPTION
Line number for files conventionally start with 1, but using `for lineno, line in enumerate(f):` would consider the first line to be line 0.

Passing an initial value of 1 to `enumerate` will fix this line number.