### PR TITLE
Add informative BadHostKeyException

### DIFF
--- a/paramiko/ssh_exception.py
+++ b/paramiko/ssh_exception.py
@@ -105,7 +105,11 @@ class BadHostKeyException (SSHException):
     .. versionadded:: 1.6
     """
     def __init__(self, hostname, got_key, expected_key):
-        SSHException.__init__(self, 'Host key for server %s does not match!' % hostname)
+        SSHException.__init__(self,
+                              'Host key for server %s does not match : got %s expected %s' % (
+                                  hostname,
+                                  got_key.get_base64(),
+                                  expected_key.get_base64()))
         self.hostname = hostname
         self.key = got_key
         self.expected_key = expected_key


### PR DESCRIPTION
Displaying the keys being compared makes it easy to diagnose the
problem. Otherwise there is more guessing involved.

Signed-off-by: Loic Dachary <loic@dachary.org>