### PR TITLE
pass exc_info along when logging exs, dont split and log tb separately

### DIFF
--- a/paramiko/server.py
+++ b/paramiko/server.py
@@ -69,7 +69,7 @@ class ServerInterface (object):
             - ``OPEN_FAILED_CONNECT_FAILED``
             - ``OPEN_FAILED_UNKNOWN_CHANNEL_TYPE``
             - ``OPEN_FAILED_RESOURCE_SHORTAGE``
-        
+
         The default implementation always returns
         ``OPEN_FAILED_ADMINISTRATIVELY_PROHIBITED``.
 
@@ -160,7 +160,7 @@ class ServerInterface (object):
         Note that you don't have to actually verify any key signtature here.
         If you're willing to accept the key, Paramiko will do the work of
         verifying the client's signature.
-        
+
         The default implementation always returns `.AUTH_FAILED`.
 
         :param str username: the username of the authenticating client
@@ -173,21 +173,21 @@ class ServerInterface (object):
         :rtype: int
         """
         return AUTH_FAILED
-    
+
     def check_auth_interactive(self, username, submethods):
         """
         Begin an interactive authentication challenge, if supported.  You
         should override this method in server mode if you want to support the
         ``"keyboard-interactive"`` auth type, which requires you to send a
         series of questions for the client to answer.
-        
+
         Return `.AUTH_FAILED` if this auth method isn't supported.  Otherwise,
         you should return an `.InteractiveQuery` object containing the prompts
         and instructions for the user.  The response will be sent via a call
         to `check_auth_interactive_response`.
-        
+
         The default implementation always returns `.AUTH_FAILED`.
-        
+
         :param str username: the username of the authenticating client
         :param str submethods:
             a comma-separated list of methods preferred by the client (usually
@@ -198,13 +198,13 @@ class ServerInterface (object):
         :rtype: int or `.InteractiveQuery`
         """
         return AUTH_FAILED
-    
+
     def check_auth_interactive_response(self, responses):
         """
         Continue or finish an interactive authentication challenge, if
         supported.  You should override this method in server mode if you want
         to support the ``"keyboard-interactive"`` auth type.
-        
+
         Return `.AUTH_FAILED` if the responses are not accepted,
         `.AUTH_SUCCESSFUL` if the responses are accepted and complete
         the authentication, or `.AUTH_PARTIALLY_SUCCESSFUL` if your
@@ -275,7 +275,7 @@ class ServerInterface (object):
                  `.AUTH_SUCCESSFUL`
         :rtype: int
         :note: Kerberos credential delegation is not supported.
-        :see: `.ssh_gss` `.kex_gss` 
+        :see: `.ssh_gss` `.kex_gss`
         :note: : We are just checking in L{AuthHandler} that the given user is
                  a valid krb5 principal!
                  We don't check if the krb5 principal is allowed to log in on
@@ -303,7 +303,7 @@ class ServerInterface (object):
         UseGSSAPI = False
         GSSAPICleanupCredentials = False
         return UseGSSAPI
-        
+
     def check_port_forward_request(self, address, port):
         """
         Handle a request for port forwarding.  The client is asking that
@@ -312,11 +312,11 @@ class ServerInterface (object):
         address (any address associated with this server) and a port of ``0``
         indicates that no specific port is requested (usually the OS will pick
         a port).
-        
+
         The default implementation always returns ``False``, rejecting the
         port forwarding request.  If the request is accepted, you should return
         the port opened for listening.
-        
+
         :param str address: the requested address
         :param int port: the requested port
         :return:
@@ -324,18 +324,18 @@ class ServerInterface (object):
             to reject
         """
         return False
-    
+
     def cancel_port_forward_request(self, address, port):
         """
         The client would like to cancel a previous port-forwarding request.
         If the given address and port is being forwarded across this ssh
         connection, the port should be closed.
-        
+
         :param str address: the forwarded address
         :param int port: the forwarded port
         """
         pass
-        
+
     def check_global_request(self, kind, msg):
         """
         Handle a global request of the given ``kind``.  This method is called
@@ -354,7 +354,7 @@ class ServerInterface (object):
 
         The default implementation always returns ``False``, indicating that it
         does not support any global requests.
-        
+
         .. note:: Port forwarding requests are handled separately, in
             `check_port_forward_request`.
 
@@ -411,20 +411,20 @@ class ServerInterface (object):
         Determine if a shell command will be executed for the client.  If this
         method returns ``True``, the channel should be connected to the stdin,
         stdout, and stderr of the shell command.
-        
+
         The default implementation always returns ``False``.
-        
+
         :param .Channel channel: the `.Channel` the request arrived on.
         :param str command: the command to execute.
         :return:
             ``True`` if this channel is now hooked up to the stdin, stdout, and
             stderr of the executing command; ``False`` if the command will not
             be executed.
-        
+
         .. versionadded:: 1.1
         """
         return False
-        
+
     def check_channel_subsystem_request(self, channel, name):
         """
         Determine if a requested subsystem will be provided to the client on
@@ -471,15 +471,15 @@ class ServerInterface (object):
         :return: ``True`` if the terminal was resized; ``False`` if not.
         """
         return False
-    
+
     def check_channel_x11_request(self, channel, single_connection, auth_protocol, auth_cookie, screen_number):
         """
         Determine if the client will be provided with an X11 session.  If this
         method returns ``True``, X11 applications should be routed through new
         SSH channels, using `.Transport.open_x11_channel`.
-        
+
         The default implementation always returns ``False``.
-        
+
         :param .Channel channel: the `.Channel` the X11 request arrived on
         :param bool single_connection:
             ``True`` if only a single X11 channel should be opened, else
@@ -529,7 +529,7 @@ class ServerInterface (object):
             - ``OPEN_FAILED_CONNECT_FAILED``
             - ``OPEN_FAILED_UNKNOWN_CHANNEL_TYPE``
             - ``OPEN_FAILED_RESOURCE_SHORTAGE``
-        
+
         The default implementation always returns
         ``OPEN_FAILED_ADMINISTRATIVELY_PROHIBITED``.
 
@@ -567,14 +567,14 @@ class InteractiveQuery (object):
     """
     A query (set of prompts) for a user during interactive authentication.
     """
-    
+
     def __init__(self, name='', instructions='', *prompts):
         """
         Create a new interactive query to send to the client.  The name and
         instructions are optional, but are generally displayed to the end
         user.  A list of prompts may be included, or they may be added via
         the `add_prompt` method.
-        
+
         :param str name: name of this query
         :param str instructions:
             user instructions (usually short) about this query
@@ -588,12 +588,12 @@ class InteractiveQuery (object):
                 self.add_prompt(x)
             else:
                 self.add_prompt(x[0], x[1])
-    
+
     def add_prompt(self, prompt, echo=True):
         """
         Add a prompt to this query.  The prompt should be a (reasonably short)
         string.  Multiple prompts can be added to the same query.
-        
+
         :param str prompt: the user prompt
         :param bool echo:
             ``True`` (default) if the user's response should be echoed;
@@ -634,7 +634,7 @@ class SubsystemHandler (threading.Thread):
         self.__transport = channel.get_transport()
         self.__name = name
         self.__server = server
-        
+
     def get_server(self):
         """
         Return the `.ServerInterface` object associated with this channel and
@@ -648,8 +648,7 @@ class SubsystemHandler (threading.Thread):
             self.start_subsystem(self.__name, self.__transport, self.__channel)
         except Exception as e:
             self.__transport._log(ERROR, 'Exception in subsystem handler for "%s": %s' %
-                                  (self.__name, str(e)))
-            self.__transport._log(ERROR, util.tb_strings())
+                                  (self.__name, str(e)), exc_info=sys.exc_info())
         try:
             self.finish_subsystem()
         except:

--- a/paramiko/sftp_server.py
+++ b/paramiko/sftp_server.py
@@ -102,16 +102,14 @@ class SFTPServer (BaseSFTP, SubsystemHandler):
                 self._log(DEBUG, 'EOF -- end of session')
                 return
             except Exception as e:
-                self._log(DEBUG, 'Exception on channel: ' + str(e))
-                self._log(DEBUG, util.tb_strings())
+                self._log(DEBUG, 'Exception on channel: ' + str(e), exc_info=sys.exc_info())
                 return
             msg = Message(data)
             request_number = msg.get_int()
             try:
                 self._process(t, request_number, msg)
             except Exception as e:
-                self._log(DEBUG, 'Exception in server processing: ' + str(e))
-                self._log(DEBUG, util.tb_strings())
+                self._log(DEBUG, 'Exception in server processing: ' + str(e), exc_info=sys.exc_info())
                 # send some kind of failure message, at least
                 try:
                     self._send_status(request_number, SFTP_FAILURE)

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -88,7 +88,7 @@ class Transport (threading.Thread, ClosingContextManager):
     `channels <.Channel>`, across the session.  Multiple channels can be
     multiplexed across a single session (and often are, in the case of port
     forwardings).
-    
+
     Instances of this class may be used as context managers.
     """
     _PROTO_ID = '2.0'
@@ -98,7 +98,7 @@ class Transport (threading.Thread, ClosingContextManager):
                           'aes256-cbc', '3des-cbc', 'arcfour128', 'arcfour256')
     _preferred_macs = ('hmac-sha1', 'hmac-md5', 'hmac-sha1-96', 'hmac-md5-96')
     _preferred_keys = ('ssh-rsa', 'ssh-dss', 'ecdsa-sha2-nistp256')
-    _preferred_kex =  ( 'diffie-hellman-group14-sha1', 'diffie-hellman-group-exchange-sha1' , 'diffie-hellman-group1-sha1')
+    _preferred_kex = ('diffie-hellman-group14-sha1', 'diffie-hellman-group-exchange-sha1' , 'diffie-hellman-group1-sha1')
     _preferred_compression = ('none',)
 
     _cipher_info = {
@@ -1634,7 +1634,6 @@ class Transport (threading.Thread, ClosingContextManager):
                 self.saved_exception = e
             except EOFError as e:
                 self._log(DEBUG, 'EOF in transport thread')
-                #self._log(DEBUG, util.tb_strings())
                 self.saved_exception = e
             except socket.error as e:
                 if type(e.args) is tuple:
@@ -1716,7 +1715,7 @@ class Transport (threading.Thread, ClosingContextManager):
         comment = ''
         i = buf.find(' ')
         if i >= 0:
-            comment = buf[i+1:]
+            comment = buf[i + 1:]
             buf = buf[:i]
         # parse out version string and make sure it matches
         segs = buf.split('-', 2)

--- a/paramiko/util.py
+++ b/paramiko/util.py
@@ -50,7 +50,7 @@ def inflate_long(s, always_positive=False):
         # noinspection PyAugmentAssignment
         s = filler * (4 - len(s) % 4) + s
     for i in range(0, len(s), 4):
-        out = (out << 32) + struct.unpack('>I', s[i:i+4])[0]
+        out = (out << 32) + struct.unpack('>I', s[i:i + 4])[0]
     if negative:
         out -= (long(1) << (8 * len(s)))
     return out
@@ -93,7 +93,7 @@ def format_binary(data, prefix=''):
     x = 0
     out = []
     while len(data) > x + 16:
-        out.append(format_binary_line(data[x:x+16]))
+        out.append(format_binary_line(data[x:x + 16]))
         x += 16
     if x < len(data):
         out.append(format_binary_line(data[x:]))
@@ -102,7 +102,7 @@ def format_binary(data, prefix=''):
 
 def format_binary_line(data):
     left = ' '.join(['%02X' % byte_ord(c) for c in data])
-    right = ''.join([('.%c..' % c)[(byte_ord(c)+63)//95] for c in data])
+    right = ''.join([('.%c..' % c)[(byte_ord(c) + 63) // 95] for c in data])
     return '%-50s %s' % (left, right)
 
 
@@ -137,10 +137,6 @@ def bit_length(n):
             hbyte <<= 1
             bitlen -= 1
         return bitlen
-
-
-def tb_strings():
-    return ''.join(traceback.format_exception(*sys.exc_info())).split('\n')
 
 
 def generate_key_bytes(hash_alg, salt, key, nbytes):


### PR DESCRIPTION
ends up looking like this now as single log msg:

```
2014-09-30 07:03:06,891 : ERROR : paramiko.transport : 16813 : Thread-2 : Exception: Error reading SSH protocol banner
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/paramiko/transport.py", line 1582, in run
    self._check_banner()
  File "/usr/local/lib/python2.7/dist-packages/paramiko/transport.py", line 1707, in _check_banner
    raise SSHException('Error reading SSH protocol banner' + str(e))
SSHException: Error reading SSH protocol banner
```

closes #405
