### PR TITLE
Adds check for ProxyCommand None with test for issue #415

### DIFF
--- a/paramiko/config.py
+++ b/paramiko/config.py
@@ -73,6 +73,9 @@ class SSHConfig (object):
                     'host': self._get_hosts(value),
                     'config': {}
                 }
+            elif key == 'proxycommand' and value.lower() == 'none':
+                # Proxycommands of none should not be added as an actual value. (Issue #415)
+                continue
             else:
                 if value.startswith('"') and value.endswith('"'):
                     value = value[1:-1]

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -453,3 +453,23 @@ Host param3 parara
             )
         for host in incorrect_data:
             self.assertRaises(Exception, conf._get_hosts, host)
+
+    def test_proxycommand_none_issue_418(self):
+        test_config_file = """
+Host proxycommand-standard-none
+    ProxyCommand None
+
+Host proxycommand-with-equals-none
+    ProxyCommand=None
+    """
+        for host, values in {
+            'proxycommand-standard-none':    {'hostname': 'proxycommand-standard-none'},
+            'proxycommand-with-equals-none': {'hostname': 'proxycommand-with-equals-none'}
+        }.items():
+
+            f = StringIO(test_config_file)
+            config = paramiko.util.parse_ssh_config(f)
+            self.assertEqual(
+                paramiko.util.lookup_ssh_host_config(host, config),
+                values
+            )


### PR DESCRIPTION
This fixes the issue reported in #415 where the configuration "ProxyCommand none" is interpreted as an actual command. The proposed solution for this is to treat ProxyCommand None as a configuration value we skip so that downstream dependancies such as Fabric don't have to deal with the specifics. An associated test has been included in test_utils.py.
