### PR TITLE
transport: notify accept condition on clean disconnect

### DIFF
--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -1594,8 +1594,6 @@ class Transport (threading.Thread, ClosingContextManager):
                         continue
                     elif ptype == MSG_DISCONNECT:
                         self._parse_disconnect(m)
-                        self.active = False
-                        self.packetizer.close()
                         break
                     elif ptype == MSG_DEBUG:
                         self._parse_debug(m)


### PR DESCRIPTION
When a clean disconnect happens, setting the transport to be inactive
immediately means that it skips the cleanup at the bottom of the run()
method and avoids waking up anyone waiting on the accept() method.

Remove the cleanup in the disconnect message handler and instead allow
the normal cleanup code to do this as well as notify any waiting threads
that something has happened.
