### PR TITLE
Update agent.py to prevent ResourceWarning

### DIFF
--- a/paramiko/agent.py
+++ b/paramiko/agent.py
@@ -73,7 +73,7 @@ class AgentSSH(object):
         self._keys = tuple(keys)
 
     def _close(self):
-        #self._conn.close()
+        self._conn.close()
         self._conn = None
         self._keys = ()
 


### PR DESCRIPTION
When using Python 3 with warnings "enabled" you get a ResourceWarning each time the '_close'-method of AgentSSH is called.
Closing the socket stored in '_conn' explicitly before setting the attribute to None prevents this error.
