### PR TITLE
SFTP: Add support for "posix-rename@openssh.com" extension for SFTP client.

### DIFF
--- a/paramiko/sftp_client.py
+++ b/paramiko/sftp_client.py
@@ -33,7 +33,7 @@ from paramiko.sftp import BaseSFTP, CMD_OPENDIR, CMD_HANDLE, SFTPError, CMD_READ
     CMD_NAME, CMD_CLOSE, SFTP_FLAG_READ, SFTP_FLAG_WRITE, SFTP_FLAG_CREATE, \
     SFTP_FLAG_TRUNC, SFTP_FLAG_APPEND, SFTP_FLAG_EXCL, CMD_OPEN, CMD_REMOVE, \
     CMD_RENAME, CMD_MKDIR, CMD_RMDIR, CMD_STAT, CMD_ATTRS, CMD_LSTAT, \
-    CMD_SYMLINK, CMD_SETSTAT, CMD_READLINK, CMD_REALPATH, CMD_STATUS, SFTP_OK, \
+    CMD_SYMLINK, CMD_SETSTAT, CMD_READLINK, CMD_REALPATH, CMD_STATUS, CMD_EXTENDED, SFTP_OK, \
     SFTP_EOF, SFTP_NO_SUCH_FILE, SFTP_PERMISSION_DENIED
 
 from paramiko.sftp_attr import SFTPAttributes
@@ -354,7 +354,7 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
         Rename a file or folder from ``oldpath`` to ``newpath``.
 
         :param str oldpath: existing name of the file or folder
-        :param str newpath: new name for the file or folder
+        :param str newpath: new name for the file or folder, must not exist already
 
         :raises IOError: if ``newpath`` is a folder, or something else goes
             wrong
@@ -363,6 +363,23 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
         newpath = self._adjust_cwd(newpath)
         self._log(DEBUG, 'rename(%r, %r)' % (oldpath, newpath))
         self._request(CMD_RENAME, oldpath, newpath)
+
+    def posix_rename(self, oldpath, newpath):
+        """
+        Rename a file or folder from ``oldpath`` to ``newpath``, following
+        posix conventions.
+
+        :param str oldpath: existing name of the file or folder
+        :param str newpath: new name for the file or folder, will be
+            overwritten if it already exists
+
+        :raises IOError: if ``newpath`` is a folder, posix-rename is not
+            supported by the server or something else goes wrong
+        """
+        oldpath = self._adjust_cwd(oldpath)
+        newpath = self._adjust_cwd(newpath)
+        self._log(DEBUG, 'posix_rename(%r, %r)' % (oldpath, newpath))
+        self._request(CMD_EXTENDED, "posix-rename@openssh.com", oldpath, newpath)
 
     def mkdir(self, path, mode=o777):
         """

--- a/paramiko/sftp_server.py
+++ b/paramiko/sftp_server.py
@@ -439,6 +439,10 @@ class SFTPServer (BaseSFTP, SubsystemHandler):
             tag = msg.get_text()
             if tag == 'check-file':
                 self._check_file(request_number, msg)
+            elif tag == 'posix-rename@openssh.com':
+                oldpath = msg.get_text()
+                newpath = msg.get_text()
+                self._send_status(request_number, self.server.posix_rename(oldpath, newpath))
             else:
                 self._send_status(request_number, SFTP_OP_UNSUPPORTED)
         else:

--- a/paramiko/sftp_si.py
+++ b/paramiko/sftp_si.py
@@ -201,6 +201,18 @@ class SFTPServerInterface (object):
         """
         return SFTP_OP_UNSUPPORTED
 
+    def posix_rename(self, oldpath, newpath):
+        """
+        Rename (or move) a file, following posix conventions. If newpath
+        already exists, it will be overwritten.
+
+        :param str oldpath:
+            the requested path (relative or absolute) of the existing file.
+        :param str newpath: the requested new path of the file.
+        :return: an SFTP error code `int` like `.SFTP_OK`.
+        """
+        return SFTP_OP_UNSUPPORTED
+
     def mkdir(self, path, attr):
         """
         Create a new directory with the given attributes.  The ``attr``

--- a/tests/stub_sftp.py
+++ b/tests/stub_sftp.py
@@ -23,7 +23,7 @@ A stub SFTP server for loopback SFTP testing.
 import os
 import sys
 from paramiko import ServerInterface, SFTPServerInterface, SFTPServer, SFTPAttributes, \
-    SFTPHandle, SFTP_OK, AUTH_SUCCESSFUL, OPEN_SUCCEEDED
+    SFTPHandle, SFTP_OK, SFTP_FAILURE, AUTH_SUCCESSFUL, OPEN_SUCCEEDED
 from paramiko.common import o666
 
 
@@ -139,11 +139,23 @@ class StubSFTPServer (SFTPServerInterface):
     def rename(self, oldpath, newpath):
         oldpath = self._realpath(oldpath)
         newpath = self._realpath(newpath)
+        if os.path.exists(newpath):
+            return SFTP_FAILURE
         try:
             os.rename(oldpath, newpath)
         except OSError as e:
             return SFTPServer.convert_errno(e.errno)
         return SFTP_OK
+
+    def posix_rename(self, oldpath, newpath):
+        oldpath = self._realpath(oldpath)
+        newpath = self._realpath(newpath)
+        try:
+            os.rename(oldpath, newpath)
+        except OSError as e:
+            return SFTPServer.convert_errno(e.errno)
+        return SFTP_OK
+
 
     def mkdir(self, path, attr):
         path = self._realpath(path)

--- a/tests/test_sftp.py
+++ b/tests/test_sftp.py
@@ -276,6 +276,39 @@ class SFTPTest (unittest.TestCase):
             except:
                 pass
 
+
+    def test_5a_posix_rename(self):
+        """Test posix-rename@openssh.com protocol extension."""
+        try:
+            # first check that the normal rename works as specified
+            with sftp.open(FOLDER + '/a', 'w') as f:
+                f.write('one')
+            sftp.rename(FOLDER + '/a', FOLDER + '/b')
+            with sftp.open(FOLDER + '/a', 'w') as f:
+                f.write('two')
+            try:
+                sftp.rename(FOLDER + '/a', FOLDER + '/b')
+                self.assertTrue(False, 'no exception when rename-ing onto existing file')
+            except OSError:
+                pass
+
+            # now check with the posix_rename
+            sftp.posix_rename(FOLDER + '/a', FOLDER + '/b')
+            with sftp.open(FOLDER + '/b', 'r') as f:
+                data = u(f.read())
+            self.assertEqual('two', data, "Contents of renamed file not the same as original file")
+
+        finally:
+            try:
+                sftp.remove(FOLDER + '/a')
+            except:
+                pass
+            try:
+                sftp.remove(FOLDER + '/b')
+            except:
+                pass
+
+
     def test_6_folder(self):
         """
         create a temporary folder, verify that we can create a file in it, then

--- a/tests/test_sftp.py
+++ b/tests/test_sftp.py
@@ -289,7 +289,7 @@ class SFTPTest (unittest.TestCase):
             try:
                 sftp.rename(FOLDER + '/a', FOLDER + '/b')
                 self.assertTrue(False, 'no exception when rename-ing onto existing file')
-            except OSError:
+            except (OSError, IOError):
                 pass
 
             # now check with the posix_rename


### PR DESCRIPTION
Hi,

this is the same feature as https://github.com/paramiko/paramiko/pull/65, but with docstrings and a test.

Note that at the moment, the test fails early if run against the sftp stub server, as the stub server actually uses os.rename() to implement the sftp rename, which is wrong as per the sftp spec. However, the test works if run against openssh.

Cheers,

Mika
