### PR TITLE
SFTP: Add support for "hardlink@openssh.com" extension for SFTP client.

### DIFF
--- a/paramiko/sftp_client.py
+++ b/paramiko/sftp_client.py
@@ -33,7 +33,7 @@ from paramiko.sftp import BaseSFTP, CMD_OPENDIR, CMD_HANDLE, SFTPError, CMD_READ
     CMD_NAME, CMD_CLOSE, SFTP_FLAG_READ, SFTP_FLAG_WRITE, SFTP_FLAG_CREATE, \
     SFTP_FLAG_TRUNC, SFTP_FLAG_APPEND, SFTP_FLAG_EXCL, CMD_OPEN, CMD_REMOVE, \
     CMD_RENAME, CMD_MKDIR, CMD_RMDIR, CMD_STAT, CMD_ATTRS, CMD_LSTAT, \
-    CMD_SYMLINK, CMD_SETSTAT, CMD_READLINK, CMD_REALPATH, CMD_STATUS, SFTP_OK, \
+    CMD_SYMLINK, CMD_SETSTAT, CMD_READLINK, CMD_REALPATH, CMD_STATUS, CMD_EXTENDED, SFTP_OK, \
     SFTP_EOF, SFTP_NO_SUCH_FILE, SFTP_PERMISSION_DENIED
 
 from paramiko.sftp_attr import SFTPAttributes
@@ -445,6 +445,20 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
         self._log(DEBUG, 'symlink(%r, %r)' % (source, dest))
         source = bytestring(source)
         self._request(CMD_SYMLINK, source, dest)
+
+    def hardlink(self, source, dest):
+        """
+        Create a hardlink of the ``source`` path at ``destination``.
+
+        :param str source: path of the original file
+        :param str dest: path of the newly created symlink
+
+        :raises OSError: if the server does not support hardlinking
+        """
+        dest = self._adjust_cwd(dest)
+        self._log(DEBUG, 'hardlink(%r, %r)' % (source, dest))
+        source = bytestring(source)
+        self._request(CMD_EXTENDED, "hardlink@openssh.com", source, dest)
 
     def chmod(self, path, mode):
         """

--- a/paramiko/sftp_server.py
+++ b/paramiko/sftp_server.py
@@ -439,6 +439,10 @@ class SFTPServer (BaseSFTP, SubsystemHandler):
             tag = msg.get_text()
             if tag == 'check-file':
                 self._check_file(request_number, msg)
+            elif tag == 'hardlink@openssh.com':
+                oldpath = msg.get_text()
+                newpath = msg.get_text()
+                self._send_status(request_number, self.server.hardlink(oldpath, newpath))
             else:
                 self._send_status(request_number, SFTP_OP_UNSUPPORTED)
         else:

--- a/paramiko/sftp_si.py
+++ b/paramiko/sftp_si.py
@@ -294,3 +294,16 @@ class SFTPServerInterface (object):
         :return: an error code `int` like ``SFTP_OK``.
         """
         return SFTP_OP_UNSUPPORTED
+
+    def hardlink(self, oldpath, newpath):
+        """
+        Create a hard link on the server, as new pathname ``newpath``,
+        with ``oldpath`` as the target of the link.
+
+        :param str oldpath:
+            path of the original file.
+        :param str newpath:
+            path of the new hard link to create.
+        :return: an error code `int` like ``SFTP_OK``.
+        """
+        return SFTP_OP_UNSUPPORTED

--- a/tests/stub_sftp.py
+++ b/tests/stub_sftp.py
@@ -191,6 +191,15 @@ class StubSFTPServer (SFTPServerInterface):
             return SFTPServer.convert_errno(e.errno)
         return SFTP_OK
 
+    def hardlink(self, oldpath, newpath):
+        newpath = self._realpath(newpath)
+        oldpath = self._realpath(oldpath)
+        try:
+            os.link(oldpath, newpath)
+        except OSError as e:
+            return SFTPServer.convert_errno(e.errno)
+        return SFTP_OK
+
     def readlink(self, path):
         path = self._realpath(path)
         try:

--- a/tests/test_sftp.py
+++ b/tests/test_sftp.py
@@ -501,6 +501,34 @@ class SFTPTest (unittest.TestCase):
             except:
                 pass
 
+    def test_Ca_hardlink(self):
+        """
+        create a hardlink and check that original and link have synchronized contents.
+        """
+        try:
+            with sftp.open(FOLDER + '/original.txt', 'w') as f:
+                f.write('org\n')
+            sftp.hardlink(FOLDER + '/original.txt', FOLDER + '/hardlink.txt')
+            def assert_equal_contents():
+                with sftp.open(FOLDER + '/original.txt') as f:
+                    orig = f.read()
+                with sftp.open(FOLDER + '/hardlink.txt') as f:
+                    link = f.read()
+                self.assertEqual(orig, link, "Hardlinked files have different content")
+            assert_equal_contents()
+            with sftp.open(FOLDER + '/hardlink.txt', 'w') as f:
+                f.write('other\n')
+            assert_equal_contents()
+        finally:
+            try:
+                sftp.remove(FOLDER + '/original.txt')
+            except:
+                pass
+            try:
+                sftp.remove(FOLDER + '/hardlink.txt')
+            except:
+                pass
+
     def test_D_flush_seek(self):
         """
         verify that buffered writes are automatically flushed on seek.


### PR DESCRIPTION
Hi,

the "hardlink@openssh.com" extension can be pretty useful if you have large data sets. Over here the tests pass for openssh and paramiko SFTP server.

Cheers,

Mika