### PR TITLE
Take known_hosts into account when sending the preferrerd key order.

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -252,6 +252,26 @@ class SSHClient (ClosingContextManager):
 
         t = self._transport = Transport(sock, gss_kex=gss_kex, gss_deleg_creds=gss_deleg_creds)
         t.use_compression(compress=compress)
+
+        if port == SSH_PORT:
+            server_hostkey_name = hostname
+        else:
+            server_hostkey_name = "[%s]:%d" % (hostname, port)
+
+        # if we already have a host key stored, change our key preference
+        known_host_keys = self._system_host_keys.get(server_hostkey_name,
+                                                     {})
+        if not known_host_keys:
+            self._host_keys.get(server_hostkey_name, {})
+        if known_host_keys:
+            # order the keys as follows: known keys in preferred-keys order,
+            # then unknown keys in preferred-keys order
+            valid_known_keys = [k for k in known_host_keys
+                                if k in t._preferred_keys]
+            t._preferred_keys = (valid_known_keys
+                                 + [k for k in t._preferred_keys
+                                    if k not in valid_known_keys])
+
         if gss_kex and gss_host is None:
             t.set_gss_host(hostname)
         elif gss_kex and gss_host is not None:
@@ -267,11 +287,6 @@ class SSHClient (ClosingContextManager):
 
         server_key = t.get_remote_server_key()
         keytype = server_key.get_name()
-
-        if port == SSH_PORT:
-            server_hostkey_name = hostname
-        else:
-            server_hostkey_name = "[%s]:%d" % (hostname, port)
 
         # If GSS-API Key Exchange is performed we are not required to check the
         # host key, because the host is authenticated via GSS-API / SSPI as


### PR DESCRIPTION
A common problem when using parameter on systems like Ubuntu or Debian
is that the default host key request by the regular SSH client is
ecdsa-sha2-nistp256, while Paramiko will ask for ssh-rsa first. This will
cause a miss upon the first key lookup and will trigger a "host is not
in known_hosts" warning, even though it's present.

This patch will check if the host is known first and alter the list of
preferred host key types based upon that information before connecting.

I'm not 100% sure everything is in the right place, since I spent most of my time actually tracking down thte issue. However I believe that the current state is a catatrophe! While in theory this should cause affected people to cautiously file bug reports, this is what reality looks like: https://stackoverflow.com/questions/10670217/paramiko-unknown-server - cannot get it working? oh well, better disable host key checking (which is conveniently named "auto add" instead).