### PR TITLE
Fix get_int()

### DIFF
--- a/paramiko/message.py
+++ b/paramiko/message.py
@@ -135,24 +135,7 @@ class Message (object):
 
         :return: a 32-bit unsigned `int`.
         """
-        byte = self.get_bytes(1)
-        if byte == max_byte:
-            return util.inflate_long(self.get_binary())
-        byte += self.get_bytes(3)
-        return struct.unpack('>I', byte)[0]
-
-    def get_size(self):
-        """
-        Fetch an int from the stream.
-
-        @return: a 32-bit unsigned integer.
-        @rtype: int
-        """
-        byte = self.get_bytes(1)
-        if byte == max_byte:
-            return util.inflate_long(self.get_binary())
-        byte += self.get_bytes(3)
-        return struct.unpack('>I', byte)[0]
+        return struct.unpack('>I', self.get_bytes(4))[0]
 
     def get_size(self):
         """


### PR DESCRIPTION
Fix get_int (make it decode a 4-byte unsigned 32-bit integer) and remove extra copy of get_size.

I came to the conclusion the existing implementation for get_int() was incorrect while investigating this issue : https://github.com/paramiko/paramiko/issues/353 but it is likely also causing other problems as well (e.g. hung sftp sessions) due to the server's channel window size being incorrectly decoded by the client.

This change reverts get_int() to the version prior to this commit: https://github.com/paramiko/paramiko/commit/0e4ce3762a5b25c5d3eb89335495d3bb9054e3e7

Also remove a second redundant (and wrong) copy of the function get_size() that came from the same commit but was subsequently eclipsed by a good version in this merge (the good version is defined second in the file): https://github.com/paramiko/paramiko/commit/e7f41de2f2dac5d03404f35edc5514f12e42c49f
