### PR TITLE
Fix SFTPAttribute unpacking.

### DIFF
--- a/paramiko/message.py
+++ b/paramiko/message.py
@@ -148,19 +148,6 @@ class Message (object):
         @return: a 32-bit unsigned integer.
         @rtype: int
         """
-        byte = self.get_bytes(1)
-        if byte == max_byte:
-            return util.inflate_long(self.get_binary())
-        byte += self.get_bytes(3)
-        return struct.unpack('>I', byte)[0]
-
-    def get_size(self):
-        """
-        Fetch an int from the stream.
-
-        @return: a 32-bit unsigned integer.
-        @rtype: int
-        """
         return struct.unpack('>I', self.get_bytes(4))[0]
 
     def get_int64(self):

--- a/paramiko/sftp_attr.py
+++ b/paramiko/sftp_attr.py
@@ -96,19 +96,19 @@ class SFTPAttributes (object):
         return attr
 
     def _unpack(self, msg):
-        self._flags = msg.get_int()
+        self._flags = msg.get_size()
         if self._flags & self.FLAG_SIZE:
             self.st_size = msg.get_int64()
         if self._flags & self.FLAG_UIDGID:
-            self.st_uid = msg.get_int()
-            self.st_gid = msg.get_int()
+            self.st_uid = msg.get_size()
+            self.st_gid = msg.get_size()
         if self._flags & self.FLAG_PERMISSIONS:
-            self.st_mode = msg.get_int()
+            self.st_mode = msg.get_size()
         if self._flags & self.FLAG_AMTIME:
-            self.st_atime = msg.get_int()
-            self.st_mtime = msg.get_int()
+            self.st_atime = msg.get_size()
+            self.st_mtime = msg.get_size()
         if self._flags & self.FLAG_EXTENDED:
-            count = msg.get_int()
+            count = msg.get_size()
             for i in range(count):
                 self.attr[msg.get_string()] = msg.get_string()
 


### PR DESCRIPTION
SFTP running on Cygwin may return 0xffffffff for unknown uid and gid which creates a problem when paramiko tries to interpret it as a big_int. The SFTP draft [1] specifies the 'File Attributes' fields to be int32, so the SFTPAttribute unpacking code must use get_size() after the change by scottkmaxwell to support big_int [2].

[1] http://tools.ietf.org/id/draft-ietf-secsh-filexfer-13.txt
[2] https://github.com/paramiko/paramiko/commit/0e4ce3762a5b25c5d3eb89335495d3bb9054e3e7

Sorry for the spam. I had to move the pull request to a topical branch so that I could rebase from your master.