### PR TITLE
NameError: global name 'descriptor' is not defined

### DIFF
--- a/paramiko/_winapi.py
+++ b/paramiko/_winapi.py
@@ -219,8 +219,8 @@ class SECURITY_ATTRIBUTES(ctypes.Structure):
 
     @descriptor.setter
     def descriptor(self, value):
-        self._descriptor = descriptor
-        self.lpSecurityDescriptor = ctypes.addressof(descriptor)
+        self._descriptor = value
+        self.lpSecurityDescriptor = ctypes.addressof(value)
 
 def GetTokenInformation(token, information_class):
     """


### PR DESCRIPTION
Hi,

Background: PyHoca-GUI is a package within the [X2Go project](http://www.x2go.org). PyHoca-GUI uses the python-x2go library package, which in turn uses paramiko for SSH client functionality. PyHoca-GUI currently supports Linux and Windows. With the PyHoca-GUI Windows builds, we use bbfreeze to bundle python-x2go & paramiko as part of the [build process](http://wiki.x2go.org/doku.php/wiki:development:build-howto-mswin:pyhoca-gui). @sunweaver is the primary developer for PyHoca-GUI and python-x2go.

I just did a build of PyHoca-GUI for Windows. paramiko 1.15.2 was included instead of 1.14.0 (when I last built several months ago.) When attempting to use Pageant (the ssh agent) with 1.15.2, both a user and I got this error:

>
  File "gevent/greenlet.py", line 327, in run
  File "pyhoca/wxgui/frontend.py", line 636, in _do_authenticate
  File "x2go/client.py", line 1367, in connect_session
  File "x2go/session.py", line 1322, in connect
  File "x2go/backends/control/plain.py", line 999, in connect
  File "paramiko\client.py", line 307, in connect
  File "paramiko\client.py", line 456, in _auth
  File "paramiko\agent.py", line 340, in __init__
  File "paramiko\agent.py", line 66, in _connect
  File "paramiko\agent.py", line 83, in _send_message
  File "paramiko\win_pageant.py", line 123, in send
  File "paramiko\win_pageant.py", line 89, in _query_pageant
  File "paramiko\_winapi.py", line 273, in get_security_attributes_for_user
  File "paramiko\_winapi.py", line 222, in descriptor
NameError: global name 'descriptor' is not defined

It looks like c5836ad5524e52df87801ddd4f3a5187afae785f introduced this as a regression.

I am a beginner at Python, but I do know Java fairly well. Here's my fix. I tested it successfully with PyHoca-GUI.