### PR TITLE
Allow blank (empty) password login

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -513,6 +513,14 @@ class SSHClient (ClosingContextManager):
                 saved_exception = e
         elif two_factor:
             raise SSHException('Two-factor authentication requires a password')
+        else:
+            # if the user has blank password we use auth_none
+            # tested on busybox with dropbear using -B flag (Allow blank password logins)
+            try:
+                self._transport.auth_none(username)
+                return
+            except SSHException as e:
+                saved_exception = e
 
         # if we got an auth-failed exception earlier, re-raise it
         if saved_exception is not None:


### PR DESCRIPTION
If the user has an empty password we have to call **auth_none** instead of **auth_password**.
I tested the correct behavior with a ssh server (dropbear) running on an embedded system with busybox and a root user with no password. Dropbear runs with -B flag (*Allow blank password logins*).

With this change the connection happens correctly:

```
Python 3.4.2 (default, Oct 31 2014, 17:35:22) 
[GCC 4.8.2] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import paramiko
>>> ssh = paramiko.SSHClient()
>>> ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
>>> ssh.connect('192.168.68.202', username='root')
>>> quit()
```