### PR TITLE
Typo causes failure if Putty Pageant is running.

### DIFF
--- a/paramiko/_winapi.py
+++ b/paramiko/_winapi.py
@@ -219,8 +219,8 @@ class SECURITY_ATTRIBUTES(ctypes.Structure):
 
     @descriptor.setter
     def descriptor(self, value):
-        self._descriptor = descriptor
-        self.lpSecurityDescriptor = ctypes.addressof(descriptor)
+        self._descriptor = value
+        self.lpSecurityDescriptor = ctypes.addressof(value)
 
 def GetTokenInformation(token, information_class):
     """

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`461` Correct the obvious typo in SECURITY_ATTRIBUTES descriptor setter.
 * :bug:`402` Check to see if an SSH agent is actually present before trying to
   forward it to the remote end. This replaces what was usually a useless
   ``TypeError`` with a human-readable ``AuthenticationError``. Credit to Ken


### PR DESCRIPTION
Pageant connections fail due to a typo in the setter for the security agent descriptor.  Fixing the typo takes care of the problem.  Note that the Pageant connection is not covered in the test-cases and probably needs to be checked by hand from time-to-time due to being Windows specific.