### PR TITLE
Silently ignore invalid keys in HostKeys.load()

### DIFF
--- a/paramiko/hostkeys.py
+++ b/paramiko/hostkeys.py
@@ -19,6 +19,7 @@
 
 import binascii
 import os
+import ssh_exception
 
 from hashlib import sha1
 from hmac import HMAC
@@ -96,7 +97,10 @@ class HostKeys (MutableMapping):
                 line = line.strip()
                 if (len(line) == 0) or (line[0] == '#'):
                     continue
-                e = HostKeyEntry.from_line(line, lineno)
+                try:
+                    e = HostKeyEntry.from_line(line, lineno)
+                except ssh_exception.SSHException:
+                    continue
                 if e is not None:
                     _hostnames = e.hostnames
                     for h in _hostnames:

--- a/tests/test_hostkeys.py
+++ b/tests/test_hostkeys.py
@@ -31,6 +31,7 @@ test_hosts_file = """\
 secure.example.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAIEA1PD6U2/TVxET6lkpKhOk5r\
 9q/kAYG6sP9f5zuUYP8i7FOFp/6ncCEbbtg/lB+A3iidyxoSWl+9jtoyyDOOVX4UIDV9G11Ml8om3\
 D+jrpI9cycZHqilK0HmxDeCuxbwyMuaCygU9gS2qoRvNLWZk70OpIKSSpBo0Wl3/XUmz9uhc=
+broken.example.com ssh-rsa AAAA
 happy.example.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAIEA8bP1ZA7DCZDB9J0s50l31M\
 BGQ3GQ/Fc7SX6gkpXkwcZryoi4kNFhHu5LvHcZPdxXV1D+uTMfGS1eyd2Yz/DoNWXNAl8TI0cAsW\
 5ymME3bQ4J/k1IKxCtz/bAlAqFgKoc+EolMziDYqWIATtW0rYTJvzGAzTmMj80/QpsFH+Pc2M=


### PR DESCRIPTION
When broken entries exists in known_hosts, paramiko raises SSHException
with "Invalid key". This patch catches the exception during
HostKeys.load() and continues to next line.

This should fix #490.