### PR TITLE
Bugfix: an exec request with a non UTF-8 command fails with an UnicodeDecodeError

### DIFF
--- a/paramiko/channel.py
+++ b/paramiko/channel.py
@@ -989,7 +989,7 @@ class Channel (object):
             else:
                 ok = server.check_channel_env_request(self, name, value)
         elif key == 'exec':
-            cmd = m.get_text()
+            cmd = m.get_string()
             if server is None:
                 ok = False
             else:

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`502` Fix an issue in server mode, when processing an exec request.
+  A command that is not a valid UTF-8 string, caused an UnicodeDecodeError.
 * :release:`1.13.3 <2014-12-19>`
 * :bug:`413` (also :issue:`414`, :issue:`420`, :issue:`454`) Be significantly
   smarter about polling & timing behavior when running proxy commands, to avoid

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -53,7 +53,7 @@ class NullServer (paramiko.ServerInterface):
         return paramiko.OPEN_SUCCEEDED
 
     def check_channel_exec_request(self, channel, command):
-        if command != 'yes':
+        if command != b'yes':
             return False
         return True
 

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -72,7 +72,7 @@ class NullServer (ServerInterface):
         return OPEN_SUCCEEDED
 
     def check_channel_exec_request(self, channel, command):
-        if command != 'yes':
+        if command != b'yes':
             return False
         return True
 

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -246,7 +246,7 @@ class TransportTest(ParamikoTest):
         chan = self.tc.open_session()
         schan = self.ts.accept(1.0)
         try:
-            chan.exec_command('no')
+            chan.exec_command(b'command contains \xfc and is not a valid UTF-8 string')
             self.assertTrue(False)
         except SSHException:
             pass


### PR DESCRIPTION
Affected paramiko versions: all.

This pull request fixes a minor bug in the processing of the channel request "exec" on the
server side of a ssh session. 

# Problem
If the client sends a command sting, that is not a valid UTF-8 byte sequence, paramiko raises an UnicodeDecodeError.

Here is an example:
> paramiko.transport - ERROR - Unknown exception: 'utf8' codec can't decode byte 0xe4 in position 889: invalid continuation byte
> paramiko.transport - ERROR - Traceback (most recent call last):
> paramiko.transport - ERROR -   File "F:\fg2\eclipsews\fg2py\src3rdParty\paramiko\transport.py", line 1619, in run
> paramiko.transport - ERROR -     self._channel_handler_table[ptype](chan, m)
> paramiko.transport - ERROR -   File "F:\fg2\eclipsews\fg2py\src3rdParty\paramiko\channel.py", line 978, in _handle_request
> paramiko.transport - ERROR -     cmd = m.get_text()
> paramiko.transport - ERROR -   File "F:\fg2\eclipsews\fg2py\src3rdParty\paramiko\message.py", line 199, in get_text
> paramiko.transport - ERROR -     return u(self.get_bytes(self.get_size()))
> paramiko.transport - ERROR -   File "F:\fg2\eclipsews\fg2py\src3rdParty\paramiko\py3compat.py", line 51, in u
> paramiko.transport - ERROR -     return s.decode(encoding)
> paramiko.transport - ERROR -   File "F:\fg2\eclipsews\fg2py\arch\win32\libexec\lib\encodings\utf_8.py", line 16, in decode
> paramiko.transport - ERROR -     return codecs.utf_8_decode(input, errors, True)
> paramiko.transport - ERROR - UnicodeDecodeError: 'utf8' codec can't decode byte 0xe4 in position 889: invalid continuation byte

According to RFC 4254 sec 6.5 the "command" string of an "exec" channel
request is a byte-string, but paramiko uses the Message.get_text() method to read the command string. get_text() requires an UTF-8 encoded byte string.

# Fix

The pull request changes the request handling code to read a byte string instead of a unicode string and changes one test case to use a non UTF-8 byte string.
