### PR TITLE
add sha256,sha512 HMAC algorithm

### DIFF
--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -26,7 +26,7 @@ import sys
 import threading
 import time
 import weakref
-from hashlib import md5, sha1
+from hashlib import md5, sha1, sha256, sha512
 
 import paramiko
 from paramiko import util
@@ -96,7 +96,7 @@ class Transport (threading.Thread, ClosingContextManager):
 
     _preferred_ciphers = ('aes128-ctr', 'aes256-ctr', 'aes128-cbc', 'blowfish-cbc',
                           'aes256-cbc', '3des-cbc', 'arcfour128', 'arcfour256')
-    _preferred_macs = ('hmac-sha1', 'hmac-md5', 'hmac-sha1-96', 'hmac-md5-96')
+    _preferred_macs = ('hmac-sha1', 'hmac-md5', 'hmac-sha1-96', 'hmac-md5-96', 'hmac-sha2-256', 'hmac-sha2-512')
     _preferred_keys = ('ssh-rsa', 'ssh-dss', 'ecdsa-sha2-nistp256')
     _preferred_kex =  ( 'diffie-hellman-group14-sha1', 'diffie-hellman-group-exchange-sha1' , 'diffie-hellman-group1-sha1')
     _preferred_compression = ('none',)
@@ -117,6 +117,8 @@ class Transport (threading.Thread, ClosingContextManager):
         'hmac-sha1-96': {'class': sha1, 'size': 12},
         'hmac-md5': {'class': md5, 'size': 16},
         'hmac-md5-96': {'class': md5, 'size': 12},
+        'hmac-sha2-256': {'class': sha256, 'size': 32},
+        'hmac-sha2-512': {'class': sha512, 'size': 64},
     }
 
     _key_info = {


### PR DESCRIPTION
if the host only supported sha256/sha512,  the paramiko will report no supported HMAC.