### PR TITLE
Hang on large initial window size

### DIFF
--- a/paramiko/message.py
+++ b/paramiko/message.py
@@ -148,19 +148,6 @@ class Message (object):
         @return: a 32-bit unsigned integer.
         @rtype: int
         """
-        byte = self.get_bytes(1)
-        if byte == max_byte:
-            return util.inflate_long(self.get_binary())
-        byte += self.get_bytes(3)
-        return struct.unpack('>I', byte)[0]
-
-    def get_size(self):
-        """
-        Fetch an int from the stream.
-
-        @return: a 32-bit unsigned integer.
-        @rtype: int
-        """
         return struct.unpack('>I', self.get_bytes(4))[0]
 
     def get_int64(self):
@@ -257,19 +244,6 @@ class Message (object):
         self.packet.write(struct.pack('>I', n))
         return self
             
-    def add_int(self, n):
-        """
-        Add an integer to the stream.
-        
-        :param int n: integer to add
-        """
-        if n >= Message.big_int:
-            self.packet.write(max_byte)
-            self.add_string(util.deflate_long(n))
-        else:
-            self.packet.write(struct.pack('>I', n))
-        return self
-
     def add_int(self, n):
         """
         Add an integer to the stream.

--- a/paramiko/message.py
+++ b/paramiko/message.py
@@ -38,8 +38,6 @@ class Message (object):
     paramiko doesn't support yet.
     """
 
-    big_int = long(0xff000000)
-
     def __init__(self, content=None):
         """
         Create a new SSH2 message.
@@ -135,11 +133,7 @@ class Message (object):
 
         :return: a 32-bit unsigned `int`.
         """
-        byte = self.get_bytes(1)
-        if byte == max_byte:
-            return util.inflate_long(self.get_binary())
-        byte += self.get_bytes(3)
-        return struct.unpack('>I', byte)[0]
+        return struct.unpack('>I', self.get_bytes(4))[0]
 
     def get_size(self):
         """
@@ -251,11 +245,7 @@ class Message (object):
         @param n: integer to add
         @type n: int
         """
-        if n >= Message.big_int:
-            self.packet.write(max_byte)
-            self.add_string(util.deflate_long(n))
-        else:
-            self.packet.write(struct.pack('>I', n))
+        self.packet.write(struct.pack('>I', n))
         return self
 
     def add_int64(self, n):

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -30,7 +30,7 @@ class MessageTest (unittest.TestCase):
     __a = b'\x00\x00\x00\x17\x07\x60\xe0\x90\x00\x00\x00\x01\x71\x00\x00\x00\x05\x68\x65\x6c\x6c\x6f\x00\x00\x03\xe8' + b'x' * 1000
     __b = b'\x01\x00\xf3\x00\x3f\x00\x00\x00\x10\x68\x75\x65\x79\x2c\x64\x65\x77\x65\x79\x2c\x6c\x6f\x75\x69\x65'
     __c = b'\x00\x00\x00\x00\x00\x00\x00\x05\x00\x00\xf5\xe4\xd3\xc2\xb1\x09\x00\x00\x00\x01\x11\x00\x00\x00\x07\x00\xf5\xe4\xd3\xc2\xb1\x09\x00\x00\x00\x06\x9a\x1b\x2c\x3d\x4e\xf7'
-    __d = b'\x00\x00\x00\x05\xff\x00\x00\x00\x05\x11\x22\x33\x44\x55\xff\x00\x00\x00\x0a\x00\xf0\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x03\x63\x61\x74\x00\x00\x00\x03\x61\x2c\x62'
+    __d = b'\x00\x00\x00\x05\x00\x00\x00\x00\x11"3D\x00\x00\x00\n\x00\xf0\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x03cat\x00\x00\x00\x03a,b'
 
     def test_1_encode(self):
         msg = Message()
@@ -83,8 +83,13 @@ class MessageTest (unittest.TestCase):
     def test_3_add(self):
         msg = Message()
         msg.add(5)
-        msg.add(0x1122334455)
-        msg.add(0xf00000000000000000)
+
+        import struct
+        self.assertRaises(struct.error, msg.add, 0x1122334455)
+        self.assertRaises(struct.error, msg.add, 0xf00000000000000000)
+        msg.add_int64(0x11223344)
+        self.assertRaises(struct.error, msg.add_int64, 0xf00000000000000000)
+        msg.add_mpint(0xf00000000000000000)
         msg.add(True)
         msg.add('cat')
         msg.add(['a', 'b'])
@@ -93,10 +98,10 @@ class MessageTest (unittest.TestCase):
     def test_4_misc(self):
         msg = Message(self.__d)
         self.assertEqual(msg.get_int(), 5)
-        self.assertEqual(msg.get_int(), 0x1122334455)
-        self.assertEqual(msg.get_int(), 0xf00000000000000000)
-        self.assertEqual(msg.get_so_far(), self.__d[:29])
-        self.assertEqual(msg.get_remainder(), self.__d[29:])
+        self.assertEqual(msg.get_int64(), 0x11223344)
+        self.assertEqual(msg.get_mpint(), 0xf00000000000000000)
+        self.assertEqual(msg.get_so_far(), self.__d[:26])
+        self.assertEqual(msg.get_remainder(), self.__d[26:])
         msg.rewind()
         self.assertEqual(msg.get_int(), 5)
         self.assertEqual(msg.get_so_far(), self.__d[:4])


### PR DESCRIPTION
Hi,

I'm using _paramiko_ for file upload to SFTP server, but I faced problem that with some SFTP 
servers it just hangs in _putfo_. Nevertheless _openssh_'s _sftp_ uploads file without any probles.
After hours of debuging of _paramiko_ and _openssh_ I found out that it happens when servers 
returns _MAX_UINT_ in _intial window size_ (which complies SSHv2 standard).  Because of strage 
packing/unpacking logic _paramiko_ gets wrong _window size_ and hangs in a while.

I studied specifications (https://wiki.filezilla-project.org/SFTP_specifications) to find explanation of this
logic, but didn't find any. 

Anyway my change fixes my problem, but I have strong feeling that this _int_ packing/unpacking logic was implemented on purpose. Could you advice what the purpose of it is?

best regards
Oleksiy
