### PR TITLE
client support for RSA ssh certificates

### DIFF
--- a/paramiko/__init__.py
+++ b/paramiko/__init__.py
@@ -43,6 +43,7 @@ from paramiko.ssh_exception import (
 )
 from paramiko.server import ServerInterface, SubsystemHandler, InteractiveQuery
 from paramiko.rsakey import RSAKey
+from paramiko.rsacert import RSACert
 from paramiko.dsskey import DSSKey
 from paramiko.ecdsakey import ECDSAKey
 from paramiko.ed25519key import Ed25519Key

--- a/paramiko/rsacert.py
+++ b/paramiko/rsacert.py
@@ -1,0 +1,166 @@
+import base64
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from paramiko import util
+from paramiko.message import Message
+from paramiko.rsakey import RSAKey
+from paramiko.ssh_exception import SSHException
+
+
+class RSACert(RSAKey):
+    """
+    Certificate equivalent of RSAKey
+    See the `official SSH certificate format specification
+    <http://cvsweb.openbsd.org/cgi-bin/cvsweb/src/usr.bin/ssh/PROTOCOL.certkeys?rev=1.9&content-type=text/x-cvsweb-markup>`_
+
+    OpenSSH versions newer than 5.4 support certificate-based authentication,
+    which can simplify authentication without relying upon heavy-weight
+    services such as LDAP. A good introductory guide to SSH certificates can
+    be found here:
+
+    https://www.digitalocean.com/community/tutorials/how-to-create-an-ssh-ca-to-validate-hosts-and-clients-with-ubuntu
+    """
+
+    def __init__(self, msg=None, data=None, privkey_filename=None,
+                 cert_filename=None, password=None, privkey_file_obj=None,
+                 cert_file_obj=None):
+        self.nonce = None
+        self.key = None
+        self.serial = None
+        self.type = None
+        self.key_id = None
+        self.valid_principals = None
+        self.valid_after = None
+        self.valid_before = None
+        self.critical_options = None
+        self.extensions = None
+        self.reserved = None
+        self.signature_key = None
+        self.signature = None
+        self.d = None
+        self.p = None
+        self.q = None
+
+        if cert_filename is not None:
+            msg = self._load_cert_from_file(cert_filename)
+        elif cert_file_obj is not None:
+            msg = self._load_cert(cert_file_obj)
+        elif cert_filename is None and cert_file_obj is None and data is None:
+            raise SSHException(
+                'Either a data object or a certificate file must be given')
+
+        if privkey_file_obj is not None:
+            self._from_private_key(privkey_file_obj, password)
+        elif privkey_filename is not None:
+            self._from_private_key_file(privkey_filename, password)
+
+        if (msg is None) and (data is not None):
+            msg = Message(data)
+
+        if msg is None:
+            raise SSHException('Key object may not be empty')
+        if msg.get_text() != 'ssh-rsa-cert-v01@openssh.com':
+            raise SSHException('Invalid key')
+
+        self.nonce = msg.get_string()
+
+        e = msg.get_mpint()
+        n = msg.get_mpint()
+        # Key might've been set by a private key file. If not, set it from the
+        # cert
+        if self.key is None:
+            self.key = rsa.RSAPublicNumbers(e=e, n=n).public_key(
+                default_backend())
+
+        self.serial = msg.get_int64()
+        self.type = msg.get_int()
+        self.key_id = msg.get_string()
+        self.valid_principals = msg.get_string()
+        self.valid_after = msg.get_int64()
+        self.valid_before = msg.get_int64()
+        self.critical_options = msg.get_string()
+        self.extensions = msg.get_string()
+        self.reserved = msg.get_string()
+        self.signature_key = msg.get_string()
+        self.signature = msg.get_string()
+
+    @property
+    def size(self):
+        return util.bit_length(self.public_numbers.n)
+
+    def get_name(self):
+        return 'ssh-rsa-cert-v01@openssh.com'
+
+    def get_public_key(self):
+        return RSAKey(key=self.key)
+
+    def _message_without_signature(self):
+        m = Message()
+        m.add_string('ssh-rsa-cert-v01@openssh.com')
+        m.add_string(self.nonce)
+        m.add_mpint(self.public_numbers.e)
+        m.add_mpint(self.public_numbers.n)
+        m.add_int64(self.serial)
+        m.add_int(self.type)
+        m.add_string(self.key_id)
+        m.add_string(self.valid_principals)
+        m.add_int64(self.valid_after)
+        m.add_int64(self.valid_before)
+        m.add_string(self.critical_options)
+        m.add_string(self.extensions)
+        m.add_string(self.reserved)
+        m.add_string(self.signature_key)
+        return m
+
+    def _message_with_signature(self):
+        m = self._message_without_signature()
+        m.add_string(self.signature)
+        return m
+
+    def asbytes(self):
+        return self._message_with_signature().asbytes()
+
+    def verify_certificate_signature(self):
+        return RSAKey(data=self.signature_key).verify_ssh_sig(
+            self._message_without_signature().asbytes(),
+            Message(self.signature))
+
+    def _load_cert_from_file(self, cert_file):
+        with open(cert_file, 'r') as f:
+            data = self._load_cert(f)
+        return data
+
+    def _load_cert(self, cert_file_obj):
+        data = cert_file_obj.read().replace('\n', '')
+        data = data.split()
+        if len(data) > 1:
+            data = data[1]
+        else:
+            data = data[0]
+        return Message(base64.b64decode(data.encode('ascii')))
+
+    @staticmethod
+    def generate(bits, progress_func=None):
+        """
+        Not implemented in RSACert because a certificate must be signed by a CA
+        and therefore loaded from some pre-existing data
+        """
+        raise Exception('Not implemented in RSACert')
+
+    @classmethod
+    def from_private_key_file(cls, filename, password=None):
+        """
+        Not implemented in RSACert because certificates cannot be generated
+        from private key files
+        """
+        raise Exception('Not implemented in RSACert')
+
+    @classmethod
+    def from_private_key(cls, file_obj, password=None):
+        """
+        Not implemented in RSACert because certificates cannot be generated
+        from private key files
+        """
+        raise Exception('Not implemented in RSACert')

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -64,6 +64,7 @@ from paramiko.message import Message
 from paramiko.packet import Packetizer, NeedRekeyException
 from paramiko.primes import ModulusPack
 from paramiko.py3compat import string_types, long, byte_ord, b, input, PY2
+from paramiko.rsacert import RSACert
 from paramiko.rsakey import RSAKey
 from paramiko.ecdsakey import ECDSAKey
 from paramiko.server import ServerInterface
@@ -203,6 +204,7 @@ class Transport(threading.Thread, ClosingContextManager):
     }
 
     _key_info = {
+        'ssh-rsa-cert-v01@openssh.com': RSACert,
         'ssh-rsa': RSAKey,
         'ssh-dss': DSSKey,
         'ecdsa-sha2-nistp256': ECDSAKey,

--- a/sites/docs/api/keys.rst
+++ b/sites/docs/api/keys.rst
@@ -17,6 +17,11 @@ RSA
 
 .. automodule:: paramiko.rsakey
 
+RSA Certificate
+===============
+
+.. automodule:: paramiko.rsacert
+
 ECDSA
 =====
 

--- a/tests/test_pkey.py
+++ b/tests/test_pkey.py
@@ -27,13 +27,14 @@ from binascii import hexlify
 from hashlib import md5
 import base64
 
-from paramiko import RSAKey, DSSKey, ECDSAKey, Ed25519Key, Message, util
+from paramiko import RSAKey, RSACert, DSSKey, ECDSAKey, Ed25519Key, Message, util
 from paramiko.py3compat import StringIO, byte_chr, b, bytes, PY2
 
 from tests.util import test_path
 
 # from openssh's ssh-keygen
 PUB_RSA = 'ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAIEA049W6geFpmsljTwfvI1UmKWWJPNFI74+vNKTk4dmzkQY2yAMs6FhlvhlI8ysU4oj71ZsRYMecHbBbxdN79+JRFVYTKaLqjwGENeTd+yv4q+V2PvZv3fLnzApI3l7EJCqhWwJUHJ1jAkZzqDx0tyOL4uoZpww3nmE0kb3y21tH4c='
+PUB_RSA_CERT = 'ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgSMQNY/NloAtYIUsc0Hn+iESDMQSes4l6bLaQfZh5NxwAAAABIwAAAIEA049W6geFpmsljTwfvI1UmKWWJPNFI74+vNKTk4dmzkQY2yAMs6FhlvhlI8ysU4oj71ZsRYMecHbBbxdN79+JRFVYTKaLqjwGENeTd+yv4q+V2PvZv3fLnzApI3l7EJCqhWwJUHJ1jAkZzqDx0tyOL4uoZpww3nmE0kb3y21tH4cAAAAAAAAAAAAAAAEAAAANdXNlcl91c2VybmFtZQAAAAwAAAAIdXNlcm5hbWUAAAAAVWQGuAAAAABXQ+kGAAAAAAAAAIIAAAAVcGVybWl0LVgxMS1mb3J3YXJkaW5nAAAAAAAAABdwZXJtaXQtYWdlbnQtZm9yd2FyZGluZwAAAAAAAAAWcGVybWl0LXBvcnQtZm9yd2FyZGluZwAAAAAAAAAKcGVybWl0LXB0eQAAAAAAAAAOcGVybWl0LXVzZXItcmMAAAAAAAAAAAAAARcAAAAHc3NoLXJzYQAAAAMBAAEAAAEBAMpIMaZW0F/Fie0PcfMTQBZ902htZbGoszPpbGagDUUn7EcBXzbbwyTuSGHwbSsDvJW5JTNCpfJSsrcBDNY0XV5qpsLGE6DMLMAwWztwwrV/bbd2cjcVZJDAcH2S9YmGoscbjYD/FljjA5VYyI5VjYpMgRL1p+AqXOpl/PtQn09ZCrZ8dbPHhGBswFQww1GkOPUMP/iaoG+lwu7VmjhLi2Mf7TX1ce9B8T2VhTdQLtuR7S0jKaS7RgR7wdabAk6XzKJWhMyzXU7qsp9EdIr3axk27+lbj8nS2ya4wrwRMRacZRcvgWVFhh+EROp1DDWJcjVYJFMaeIu5MuUKrKtbVZ0AAAEPAAAAB3NzaC1yc2EAAAEAihMznF3UeBbQDWfh/yGHAk5QbK8cO1OVdenUgtxPpiYlqtc9jiqgSCDbBfZecAbNgpGACO1GamR8E2d3ZsEH+BRV6CWlL1/XMfatKREiseTh7BCyJetDTANbV9uuCqDrbt7r/V4uko61lJY+AaequSNNVVq5+7qhdpFH44TqXa0Yd7TMGU0Ss/Wsr+Mdpu1Bs5wDXWTrOsdDz5Ss66pd7eA14OZ/ihbJhMP7wPibqFi0B+wy2FlhZOShMmrDokjmRQkUzf3I0wir13hbF55AsofP+cEF4MZU/HE5yVbbTXdEXL5ry4B921QGvmLvCsL1ee2wTRWtbb4JRNNaIDg5HQ=='
 PUB_DSS = 'ssh-dss AAAAB3NzaC1kc3MAAACBAOeBpgNnfRzr/twmAQRu2XwWAp3CFtrVnug6s6fgwj/oLjYbVtjAy6pl/h0EKCWx2rf1IetyNsTxWrniA9I6HeDj65X1FyDkg6g8tvCnaNB8Xp/UUhuzHuGsMIipRxBxw9LF608EqZcj1E3ytktoW5B5OcjrkEoz3xG7C+rpIjYvAAAAFQDwz4UnmsGiSNu5iqjn3uTzwUpshwAAAIEAkxfFeY8P2wZpDjX0MimZl5wkoFQDL25cPzGBuB4OnB8NoUk/yjAHIIpEShw8V+LzouMK5CTJQo5+Ngw3qIch/WgRmMHy4kBq1SsXMjQCte1So6HBMvBPIW5SiMTmjCfZZiw4AYHK+B/JaOwaG9yRg2Ejg4Ok10+XFDxlqZo8Y+wAAACARmR7CCPjodxASvRbIyzaVpZoJ/Z6x7dAumV+ysrV1BVYd0lYukmnjO1kKBWApqpH1ve9XDQYN8zgxM4b16L21kpoWQnZtXrY3GZ4/it9kUgyB7+NwacIBlXa8cMDL7Q/69o0d54U0X/NeX5QxuYR6OMJlrkQB7oiW/P/1mwjQgE='
 PUB_ECDSA_256 = 'ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJSPZm3ZWkvk/Zx8WP+fZRZ5/NBBHnGQwR6uIC6XHGPDIHuWUzIjAwA0bzqkOUffEsbLe+uQgKl5kbc/L8KA/eo='
 PUB_ECDSA_384 = 'ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBBbGibQLW9AAZiGN2hEQxWYYoFaWKwN3PKSaDJSMqmIn1Z9sgRUuw8Y/w502OGvXL/wFk0i2z50l3pWZjD7gfMH7gX5TUiCzwrQkS+Hn1U2S9aF5WJp0NcIzYxXw2r4M2A=='
@@ -232,6 +233,49 @@ class KeyTest(unittest.TestCase):
         msg.rewind()
         pub = DSSKey(data=key.asbytes())
         self.assertTrue(pub.verify_ssh_sig(b'ice weasels', msg))
+
+    def test_10_load_rsa_cert(self):
+        cert = RSACert(privkey_filename=test_path('test_rsa.key'),
+                       cert_file_obj=StringIO(PUB_RSA_CERT))
+        self.assertEqual('ssh-rsa-cert-v01@openssh.com', cert.get_name())
+        self.assertEqual(PUB_RSA.split()[1],
+                         cert.get_public_key().get_base64())
+        self.assertTrue(cert.verify_certificate_signature())
+
+    def test_11_load_rsa_cert_password(self):
+        cert = RSACert(privkey_filename=test_path('test_rsa_password.key'),
+                       cert_file_obj=StringIO(PUB_RSA_CERT),
+                       password='television')
+        self.assertEqual('ssh-rsa-cert-v01@openssh.com', cert.get_name())
+        self.assertEqual(PUB_RSA.split()[1],
+                         cert.get_public_key().get_base64())
+        self.assertTrue(cert.verify_certificate_signature())
+
+    def test_12_sign_rsa_cert(self):
+        cert = RSACert(privkey_filename=test_path('test_rsa.key'),
+                       cert_file_obj=StringIO(PUB_RSA_CERT))
+        msg = cert.sign_ssh_data(b'ice weasels')
+        self.assertTrue(type(msg) is Message)
+        msg.rewind()
+        self.assertEqual('ssh-rsa', msg.get_text())
+        sig = bytes().join(
+            [byte_chr(int(x, 16)) for x in SIGNED_RSA.split(':')])
+        self.assertEqual(sig, msg.get_binary())
+        msg.rewind()
+        pub = cert.get_public_key()
+        self.assertTrue(pub.verify_ssh_sig(b'ice weasels', msg))
+
+    def test_13_compare_rsa_cert(self):
+        cert_with_private_key = RSACert(
+            privkey_filename=test_path('test_rsa.key'),
+            cert_file_obj=StringIO(PUB_RSA_CERT))
+        cert_without_private_key = RSACert(
+            cert_file_obj=StringIO(PUB_RSA_CERT))
+
+        self.assertTrue(cert_with_private_key.can_sign())
+        self.assertFalse(cert_without_private_key.can_sign())
+        self.assertEqual(cert_with_private_key.get_public_key(),
+                         cert_without_private_key.get_public_key())
 
     def test_A_generate_rsa(self):
         key = RSAKey.generate(1024)


### PR DESCRIPTION
I have extended the RSAKey class to support the ssh-rsa-cert-v01@openssh.com type of certificate authentication in a new RSACert class. A test case was added to test_pkey.py to test loading an RSA certificate (a signed public key that's the same one given in the tests already).
I think this class should be a reasonable example from which DSS and ECDSA certificate classes can also be created.

Let me know what you think!

Jason
