### PR TITLE
Add `shutdown` methods for `ChannelFile`

### DIFF
--- a/paramiko/_winapi.py
+++ b/paramiko/_winapi.py
@@ -219,8 +219,8 @@ class SECURITY_ATTRIBUTES(ctypes.Structure):
 
     @descriptor.setter
     def descriptor(self, value):
-        self._descriptor = descriptor
-        self.lpSecurityDescriptor = ctypes.addressof(descriptor)
+        self._descriptor = value
+        self.lpSecurityDescriptor = ctypes.addressof(value)
 
 def GetTokenInformation(token, information_class):
     """

--- a/paramiko/channel.py
+++ b/paramiko/channel.py
@@ -1220,6 +1220,18 @@ class ChannelFile (BufferedFile):
         self.channel.sendall(data)
         return len(data)
 
+    def getChannel(self):
+        return self.channel
+
+    def shutdown(self, how):
+        self.channel.shutdown(how)
+
+    def shutdown_read(self):
+        self.channel.shutdown_read()
+
+    def shutdown_write(self):
+        self.channel.shutdown_write()
+
 
 class ChannelStderrFile (ChannelFile):
     def __init__(self, channel, mode='r', bufsize=-1):


### PR DESCRIPTION
This patch makes this code work:
```py
def test(hostname, login, password):
    client = paramiko.SSHClient()
    client.connect(hostname=hostname, username=login, password=password)
    stdin, stdout, stderr = client.exec_command('cat', timeout=5)
    stdin.write('foo')
    stdin.shutdown_write()
    client.close()
```
