### PR TITLE
Add recv_into and recvfrom_into to channel

### DIFF
--- a/paramiko/channel.py
+++ b/paramiko/channel.py
@@ -608,6 +608,44 @@ class Channel (ClosingContextManager):
 
         return out
 
+    def recv_into(self, buff, nbytes=0):
+        """
+        Receive data from the channel.  The return value is a tuple of
+        (nbytes, address) representing the number bytes returned.
+        The maximum amount of data to be received at once is specified by
+        ``nbytes`` which if 0, defaults to the number of bytes available in
+        the buffer.
+
+        :param str buff: a buffer for the received bytes
+        :param int nbytes: maximum number of bytes to read.
+        :return: int number of bytes added
+
+        :raises socket.timeout:
+            if no data is ready before the timeout set by `settimeout`.
+        """
+        o = self.recv(nbytes if nbytes else len(buff))
+        n = len(o)
+        buff[:n] = o
+        return n
+
+    def recvfrom_into(self, buff, nbytes=0):
+        """
+        Receive data from the channel.  The return value is a tuple of
+        (nbytes, address) representing the number bytes returned.
+        The maximum amount of data to be received at once is specified by
+        ``nbytes`` which if 0, defaults to the number of bytes available in
+        the buffer.
+
+        :param str buff: a buffer for the received bytes
+        :param int nbytes: maximum number of bytes to read.
+        :return: number of bytes and address as a `tuple`
+
+        :raises socket.timeout:
+            if no data is ready before the timeout set by `settimeout`.
+        """
+        n = self.recv_into(buff, nbytes)
+        return (n, self.getpeername())
+
     def recv_stderr_ready(self):
         """
         Returns true if data is buffered and ready to be read from this

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -548,11 +548,24 @@ class TransportTest(unittest.TestCase):
 
         ss, _ = greeting_server.accept()
         ss.send(b'Hello!\n')
+        sch.send(cch.recv(8192))
+
+        self.assertEqual(b'Hello!\n', cs.recv(7))
+
+        ss.send(b'Bye!\nCome Again later.')
         ss.close()
+
         sch.send(cch.recv(8192))
         sch.close()
 
-        self.assertEqual(b'Hello!\n', cs.recv(7))
+        recv_buff=bytearray(b'XXXXabcdef')
+        self.assertEqual(4, cs.recv_into(recv_buff,4))
+
+        self.assertEqual(b'Bye!abcdef', recv_buff)
+
+        recv_buff=bytearray(b'ZXXXX_abcde_fghij_ZZ')
+        self.assertEqual((18, ('unknown', 0)), cs.recvfrom_into(recv_buff))
+        self.assertEqual(b'\nCome Again later.ZZ', recv_buff)
         cs.close()
 
     def test_G_stderr_select(self):


### PR DESCRIPTION
Added recv_into and recvfrom_into the Channel class to get a step closer to the standard libary socket interface https://docs.python.org/2/library/socket.html

includes testcases