### PR TITLE
Typo causes failure if Putty Pageant is running (rebased)

### DIFF
--- a/paramiko/_winapi.py
+++ b/paramiko/_winapi.py
@@ -219,8 +219,8 @@ class SECURITY_ATTRIBUTES(ctypes.Structure):
 
     @descriptor.setter
     def descriptor(self, value):
-        self._descriptor = descriptor
-        self.lpSecurityDescriptor = ctypes.addressof(descriptor)
+        self._descriptor = value
+        self.lpSecurityDescriptor = ctypes.addressof(value)
 
 def GetTokenInformation(token, information_class):
     """

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`461` Correct the obvious typo in SECURITY_ATTRIBUTES descriptor setter.
 * :bug:`22 major` Try harder to connect to multiple network families (e.g. IPv4
   vs IPv6) in case of connection issues; this helps with problems such as hosts
   which resolve both IPv4 and IPv6 addresses but are only listening on IPv4.


### PR DESCRIPTION
This is just #488 rebased on current master (conflict in changelog.rst)

> Pageant connections fail due to a typo in the setter for the security agent descriptor. Fixing the typo takes care of the problem. Note that the Pageant connection is not covered in the test-cases and probably needs to be checked by hand from time-to-time due to being Windows specific.