### PR TITLE
fix close socket issue for files larger than 100Mb with CrushFTP server

### DIFF
--- a/paramiko/file.py
+++ b/paramiko/file.py
@@ -119,7 +119,7 @@ class BufferedFile (ClosingContextManager):
                 raise StopIteration
             return line
 
-    def read(self, size=None):
+    def read(self, size=None, file_size=0):
         """
         Read at most ``size`` bytes from the file (less if we hit the end of the
         file first).  If the ``size`` argument is negative or omitted, read all
@@ -173,6 +173,8 @@ class BufferedFile (ClosingContextManager):
                 break
             self._rbuffer += new_data
             self._realpos += len(new_data)
+            if self._realpos >= file_size:
+                break
         result = self._rbuffer[:size]
         self._rbuffer = self._rbuffer[size:]
         self._pos += len(result)

--- a/paramiko/sftp_client.py
+++ b/paramiko/sftp_client.py
@@ -690,11 +690,13 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
             fr.prefetch()
             size = 0
             while True:
-                data = fr.read(32768)
+                data = fr.read(32768, file_size)
                 fl.write(data)
                 size += len(data)
                 if callback is not None:
                     callback(size, file_size)
+                if size >= file_size:
+                    break
                 if len(data) == 0:
                     break
         return size


### PR DESCRIPTION
A socket closed is received when downloading files larger than 100Mb from an CrushFTP sFTP server. However, Paramiko expects an EOF. 
Comparing the downloaded buffer size with the total (expected) file size allows to fix this behavior.
