### PR TITLE
Use correct variable name

### DIFF
--- a/paramiko/_winapi.py
+++ b/paramiko/_winapi.py
@@ -219,8 +219,8 @@ class SECURITY_ATTRIBUTES(ctypes.Structure):
 
     @descriptor.setter
     def descriptor(self, value):
-        self._descriptor = descriptor
-        self.lpSecurityDescriptor = ctypes.addressof(descriptor)
+        self._descriptor = value
+        self.lpSecurityDescriptor = ctypes.addressof(value)
 
 def GetTokenInformation(token, information_class):
     """


### PR DESCRIPTION
Attempting to access a global variable named descriptor. Issue causes fatal error on Windows.