### PR TITLE
Update sftp_client.py and sftp_file.py so that STAT on a file is only…

### DIFF
--- a/paramiko/sftp_file.py
+++ b/paramiko/sftp_file.py
@@ -379,7 +379,7 @@ class SFTPFile (BufferedFile):
         """
         self.pipelined = pipelined
     
-    def prefetch(self):
+    def prefetch(self, size):
         """
         Pre-fetch the remaining contents of this file in anticipation of future
         `.read` calls.  If reading the entire file, pre-fetching can
@@ -393,7 +393,6 @@ class SFTPFile (BufferedFile):
 
         .. versionadded:: 1.5.1
         """
-        size = self.stat().st_size
         # queue up async reads for the rest of the file
         chunks = []
         n = self._realpos


### PR DESCRIPTION
… called once and the value passed to any required subroutines.

This is to allow support for the IBM Sterling Integrator SFTP Server when files are defined with an extractability count of 1.

Files with an extractability count of 1 will become unavailable once the GET request has started and any subsequent STAT commands to obtain the file size will fail with a file not found error.