### PR TITLE
Add support of RFC 6668

### DIFF
--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -26,7 +26,7 @@ import sys
 import threading
 import time
 import weakref
-from hashlib import md5, sha1
+from hashlib import md5, sha1, sha256, sha512
 
 import paramiko
 from paramiko import util
@@ -96,7 +96,7 @@ class Transport (threading.Thread, ClosingContextManager):
 
     _preferred_ciphers = ('aes128-ctr', 'aes256-ctr', 'aes128-cbc', 'blowfish-cbc',
                           'aes256-cbc', '3des-cbc', 'arcfour128', 'arcfour256')
-    _preferred_macs = ('hmac-sha1', 'hmac-md5', 'hmac-sha1-96', 'hmac-md5-96')
+    _preferred_macs = ('hmac-sha2-256', 'hmac-sha2-512', 'hmac-sha1', 'hmac-md5', 'hmac-sha1-96', 'hmac-md5-96')
     _preferred_keys = ('ssh-rsa', 'ssh-dss', 'ecdsa-sha2-nistp256')
     _preferred_kex =  ( 'diffie-hellman-group14-sha1', 'diffie-hellman-group-exchange-sha1' , 'diffie-hellman-group1-sha1')
     _preferred_compression = ('none',)
@@ -113,6 +113,8 @@ class Transport (threading.Thread, ClosingContextManager):
     }
 
     _mac_info = {
+        'hmac-sha2-256': {'class': sha256, 'size': 32},
+        'hmac-sha2-512': {'class': sha512, 'size': 64},
         'hmac-sha1': {'class': sha1, 'size': 20},
         'hmac-sha1-96': {'class': sha1, 'size': 12},
         'hmac-md5': {'class': md5, 'size': 16},

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -447,9 +447,9 @@ class TransportTest(unittest.TestCase):
         bytes = self.tc.packetizer._Packetizer__sent_bytes
         chan.send('x' * 1024)
         bytes2 = self.tc.packetizer._Packetizer__sent_bytes
-        # tests show this is actually compressed to *52 bytes*!  including packet overhead!  nice!! :)
+        # tests show this is actually compressed to *64 bytes*!  including packet overhead!  nice!! :)
         self.assertTrue(bytes2 - bytes < 1024)
-        self.assertEqual(52, bytes2 - bytes)
+        self.assertEqual(64, bytes2 - bytes)
 
         chan.close()
         schan.close()


### PR DESCRIPTION
Adds hmac-sha2-256 and hmac-sha2-512 as supported and recommended
MACs.

fixes: #580