### PR TITLE
Fix 'python setup.py bdist_dumb' on Mac OS X

### DIFF
--- a/setup_helper.py
+++ b/setup_helper.py
@@ -124,7 +124,12 @@ def make_tarball(base_name, base_dir, compress='gzip', verbose=0, dry_run=0,
         tar = tarfile.open(archive_name, mode=mode)
         # This recursively adds everything underneath base_dir
         try:
-            tar.add(base_dir, filter=_set_uid_gid)
+            try:
+                # Support for the `filter' parameter was added in Python 2.7,
+                # earlier versions will raise TypeError.
+                tar.add(base_dir, filter=_set_uid_gid)
+            except TypeError:
+                tar.add(base_dir)
         finally:
             tar.close()
 

--- a/setup_helper.py
+++ b/setup_helper.py
@@ -30,9 +30,42 @@ import distutils.archive_util
 from distutils.dir_util import mkpath
 from distutils.spawn import spawn
 
+try:
+    from pwd import getpwnam
+except ImportError:
+    getpwnam = None
 
-def make_tarball(base_name, base_dir, compress='gzip',
-                 verbose=False, dry_run=False):
+try:
+    from grp import getgrnam
+except ImportError:
+    getgrnam = None
+
+def _get_gid(name):
+    """Returns a gid, given a group name."""
+    if getgrnam is None or name is None:
+        return None
+    try:
+        result = getgrnam(name)
+    except KeyError:
+        result = None
+    if result is not None:
+        return result[2]
+    return None
+
+def _get_uid(name):
+    """Returns an uid, given a user name."""
+    if getpwnam is None or name is None:
+        return None
+    try:
+        result = getpwnam(name)
+    except KeyError:
+        result = None
+    if result is not None:
+        return result[2]
+    return None
+
+def make_tarball(base_name, base_dir, compress='gzip', verbose=0, dry_run=0,
+                 owner=None, group=None):
     """Create a tar file from all the files under 'base_dir'.
     This file may be compressed.
 
@@ -75,11 +108,25 @@ def make_tarball(base_name, base_dir, compress='gzip',
     mkpath(os.path.dirname(archive_name), dry_run=dry_run)
     log.info('Creating tar file %s with mode %s' % (archive_name, mode))
 
+    uid = _get_uid(owner)
+    gid = _get_gid(group)
+
+    def _set_uid_gid(tarinfo):
+        if gid is not None:
+            tarinfo.gid = gid
+            tarinfo.gname = group
+        if uid is not None:
+            tarinfo.uid = uid
+            tarinfo.uname = owner
+        return tarinfo
+
     if not dry_run:
         tar = tarfile.open(archive_name, mode=mode)
         # This recursively adds everything underneath base_dir
-        tar.add(base_dir)
-        tar.close()
+        try:
+            tar.add(base_dir, filter=_set_uid_gid)
+        finally:
+            tar.close()
 
     if compress and compress not in tarfile_compress_flag:
         spawn([compress] + compress_flags[compress] + [archive_name],


### PR DESCRIPTION
Hi Paramiko developers!

In 2013 I published pip-accel and it wasn't long before [the first bug report](https://github.com/paylogic/pip-accel/issues/2) came in that the `python setup.py bdist_dumb` command was broken for the [ssh](https://pypi.python.org/pypi/ssh) package on Mac OS X. After some analysis I realized that the ssh package included a distutils monkey patch (`setup_helper.py`) which had become incompatible with newer versions of distutils. [My advice](https://github.com/paylogic/pip-accel/issues/2#issuecomment-17097541) to the person who reported the bug was to switch to Paramiko because ssh was a fork of Paramiko, ssh seemed abandoned and Paramiko didn't include the distutils monkey patch.

Imagine my surprise when the same bug report was reopened in 2015 because the distutils hack had found its way from ssh to Paramiko :-). Multiple users have now complained about it. I can't reasonably fix this from the side of pip-accel because the distutils monkey patch is simply broken against new versions of distutils on Mac OS X. The only other option was a pull request against the Paramiko project to get the real bug fixed, so here I am :-).

----

Here's what happens when `python setup.py bdist_dumb` is run in a checkout of the Paramiko master branch on Mac OS X (tested on Yosemite (10.10.5)):

```
running install_scripts
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/var/folders/63/_tgckwx14vb40h5f_9gq4cjw0000gp/T/pip-Kh_t56-build/setup.py", line 91, in <module>
    **kw
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/core.py", line 151, in setup
    dist.run_commands()
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/dist.py", line 953, in run_commands
    self.run_command(cmd)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/command/bdist.py", line 146, in run
    self.run_command(cmd_name)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/cmd.py", line 326, in run_command
    self.distribution.run_command(command)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/command/bdist_dumb.py", line 124, in run
    owner=self.owner, group=self.group)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/cmd.py", line 392, in make_archive
    owner=owner, group=group)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/archive_util.py", line 237, in make_archive
    filename = func(base_name, base_dir, **kwargs)
TypeError: make_tarball() got an unexpected keyword argument 'owner'
```

With the minor changes to `setup_helper.py` in my feature branch the `python setup.py bdist_dumb` completes successfully and pip-accel can successfully install Paramiko. I tested this as follows:

**This shows the issue:**

```sh
VENV=/tmp/paramiko-master-broken
virtualenv $VENV \
 && (source $VENV/bin/activate \
      && pip install pip-accel \
      && pip-accel install https://github.com/paramiko/paramiko/archive/master.zip \
      && python -c 'import paramiko') \
 && echo "Successfully installed Paramiko on Mac OS X :-)" \
 || echo "Failed to install Paramiko on Mac OS X :-("
```

On my test system the above shell snippet outputs a "Failed to install Paramiko" message.

**This shows that the issue is resolved in my feature branch:**

```sh
VENV=/tmp/paramiko-pull-request-works
virtualenv $VENV \
 && (source $VENV/bin/activate \
      && pip install pip-accel \
      && pip-accel install https://github.com/xolox/paramiko/archive/fix-bdist-dumb-mac-os-x.zip \
      && python -c 'import paramiko') \
 && echo "Successfully installed Paramiko on Mac OS X :-)" \
 || echo "Failed to install Paramiko on Mac OS X :-("
```

On my test system the above shell snippet outputs a "Successfully installed Paramiko" message.

----

I hope I've clearly explained why I think my pull request would be an improvement. If you have any questions I would be happy to answer them.

*Disclaimer:* I don't know why `setup_helper.py` was originally added and I couldn't determine this based on a `git blame` of the file and looking up the old revisions; I couldn't find a public issue or discussion arguing about why the monkey patch is necessary in the first place. My pull request assumes the monkey patch is there for a good reason and just makes it work again. To the best of my knowledge my changes should be backwards compatible with both older and newer versions of distutils.

Thanks for your time!