### PR TITLE
Fix data types in some docstrings

### DIFF
--- a/paramiko/buffered_pipe.py
+++ b/paramiko/buffered_pipe.py
@@ -81,7 +81,7 @@ class BufferedPipe (object):
         Feed new data into this pipe.  This method is assumed to be called
         from a separate thread, so synchronization is done.
         
-        :param data: the data to add, as a `str`
+        :param data: the data to add, as a `str` or `bytes`
         """
         self._lock.acquire()
         try:
@@ -125,7 +125,7 @@ class BufferedPipe (object):
         :param int nbytes: maximum number of bytes to read
         :param float timeout:
             maximum seconds to wait (or ``None``, the default, to wait forever)
-        :return: the read data, as a `str`
+        :return: the read data, as a `bytes`
         
         :raises PipeTimeout:
             if a timeout was specified and no data was ready before that

--- a/paramiko/channel.py
+++ b/paramiko/channel.py
@@ -587,7 +587,7 @@ class Channel (ClosingContextManager):
         is returned, the channel stream has closed.
 
         :param int nbytes: maximum number of bytes to read.
-        :return: received data, as a `str`
+        :return: received data, as a `bytes`
 
         :raises socket.timeout:
             if no data is ready before the timeout set by `settimeout`.


### PR DESCRIPTION
Some methods return `bytes` type, but documentation said `str`.
Also method BufferedPipe.feed accept both types.

It is okay for python2 users, but having problems with pyton3.