### PR TITLE
Handle special keys

### DIFF
--- a/demos/interactive.py
+++ b/demos/interactive.py
@@ -16,7 +16,6 @@
 # along with Paramiko; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
 
-
 import socket
 import sys
 from paramiko.py3compat import u
@@ -25,6 +24,8 @@ from paramiko.py3compat import u
 try:
     import termios
     import tty
+    import fcntl
+    import os
     has_termios = True
 except ImportError:
     has_termios = False
@@ -39,8 +40,10 @@ def interactive_shell(chan):
 
 def posix_shell(chan):
     import select
-    
+
     oldtty = termios.tcgetattr(sys.stdin)
+    fl = fcntl.fcntl(sys.stdin.fileno(), fcntl.F_GETFL)
+    fcntl.fcntl(sys.stdin.fileno(), fcntl.F_SETFL, fl | os.O_NONBLOCK)
     try:
         tty.setraw(sys.stdin.fileno())
         tty.setcbreak(sys.stdin.fileno())
@@ -48,32 +51,35 @@ def posix_shell(chan):
 
         while True:
             r, w, e = select.select([chan, sys.stdin], [], [])
+
             if chan in r:
                 try:
                     x = u(chan.recv(1024))
                     if len(x) == 0:
                         sys.stdout.write('\r\n*** EOF\r\n')
+                        chan.close()
                         break
                     sys.stdout.write(x)
                     sys.stdout.flush()
                 except socket.timeout:
                     pass
             if sys.stdin in r:
-                x = sys.stdin.read(1)
+                x = sys.stdin.read(4)
                 if len(x) == 0:
                     break
                 chan.send(x)
 
     finally:
         termios.tcsetattr(sys.stdin, termios.TCSADRAIN, oldtty)
+        fcntl.fcntl(sys.stdin.fileno(), fcntl.F_SETFL, fl)
 
-    
+
 # thanks to Mike Looijmans for this code
 def windows_shell(chan):
     import threading
 
     sys.stdout.write("Line-buffered terminal emulation. Press F6 or ^Z to send EOF.\r\n\r\n")
-        
+
     def writeall(sock):
         while True:
             data = sock.recv(256)
@@ -83,10 +89,10 @@ def windows_shell(chan):
                 break
             sys.stdout.write(data)
             sys.stdout.flush()
-        
+
     writer = threading.Thread(target=writeall, args=(chan,))
     writer.start()
-        
+
     try:
         while True:
             d = sys.stdin.read(1)


### PR DESCRIPTION
Correctly send special keys (*arrow keys, insert, delete, end, home, page up, page down, etc*), which send an escape sequence and a keycode from a single key press (e.g. *up-arrow* sends `^[[A`). This fixes *vim* running in an interactive terminal session, but requires to put `sys.stdin` in non-blocking mode so that regular keys are sent without filling a buffer.