### PR TITLE
Fix connection error-handling code on Python 3

### DIFF
--- a/paramiko/ssh_exception.py
+++ b/paramiko/ssh_exception.py
@@ -162,7 +162,7 @@ class NoValidConnectionsError(socket.error):
         :param dict errors:
             The errors dict to store, as described by class docstring.
         """
-        addrs = errors.keys()
+        addrs = list(errors.keys())
         body = ', '.join([x[0] for x in addrs[:-1]])
         tail = addrs[-1][0]
         msg = "Unable to connect to port {0} on {1} or {2}"


### PR DESCRIPTION
Convert the dictionary view returned by `errors.keys()` to a list. Thanks to @edk0 for pointing this out.

Fixes #615.