### PR TITLE
TypeError: 'dict_keys' object is not subscriptable

### DIFF
--- a/paramiko/ssh_exception.py
+++ b/paramiko/ssh_exception.py
@@ -162,7 +162,7 @@ class NoValidConnectionsError(socket.error):
         :param dict errors:
             The errors dict to store, as described by class docstring.
         """
-        addrs = errors.keys()
+        addrs = list(errors.keys())
         body = ', '.join([x[0] for x in addrs[:-1]])
         tail = addrs[-1][0]
         msg = "Unable to connect to port {0} on {1} or {2}"


### PR DESCRIPTION
    File: paramiko/ssh_exception.py
    Class: NoValidConnectionsError
    Line: 166

My errors object contains the following before the TypeError is raised:

    {('10.0.2.2', 2222): ConnectionRefusedError(111, 'Connection refused')}

In Python 3 dict.keys() returns an iteratable but not indexable object.

Ref: http://stackoverflow.com/questions/26394748/nltk-python-error-typeerror-dict-keys-object-is-not-subscriptable
