### PR TITLE
Make sure the callback function is called only once

### DIFF
--- a/paramiko/sftp_client.py
+++ b/paramiko/sftp_client.py
@@ -695,10 +695,10 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
                 data = fr.read(32768)
                 fl.write(data)
                 size += len(data)
-                if callback is not None:
-                    callback(size, file_size)
                 if len(data) == 0:
                     break
+                if callback is not None:
+                    callback(size, file_size)
         return size
 
     def get(self, remotepath, localpath, callback=None):


### PR DESCRIPTION
Since the callback is called before checking the size of data chunk, the callback function is called twice.