### PR TITLE
Allow auth retries when client presents a bad key

### DIFF
--- a/paramiko/auth_handler.py
+++ b/paramiko/auth_handler.py
@@ -420,7 +420,7 @@ class AuthHandler (object):
                 self.transport._log(INFO, 'Auth rejected: unsupported or mangled public key')
                 key = None
             if key is None:
-                self._disconnect_no_more_auth()
+                self._send_auth_result(username, method, AUTH_FAILED)
                 return
             # first check if this key is okay... if not, we can skip the verify
             result = self.transport.server_object.check_auth_publickey(username, key)


### PR DESCRIPTION
Without this, a user has to go out of their way to prevent their SSH
client from sending the server that key, even if it's just a valid key
that paramiko doesn't support yet.