### PR TITLE
Add support for PyCryptodome (and PyPy)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "pypy"
 install:
   # Self-install for setup.py-driven deps
   - pip install -e .

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Requirements
 
 - `Python <http://www.python.org/>`_ 2.6, 2.7, or 3.3+ (3.2 should also work,
   but it is not recommended)
-- `pycrypto <https://www.dlitz.net/software/pycrypto/>`_ 2.1+
+- `pycrypto <https://www.dlitz.net/software/pycrypto/>`_ 2.5+ or `pycryptodome <http://www.pycryptodome.org/>`_
 - `ecdsa <https://pypi.python.org/pypi/ecdsa>`_ 0.11+
 
 

--- a/paramiko/dsskey.py
+++ b/paramiko/dsskey.py
@@ -21,9 +21,14 @@ DSS keys.
 """
 
 import os
-from hashlib import sha1
 
 from Crypto.PublicKey import DSA
+from Crypto.Hash import SHA as SHA1
+try:
+    # Only in Pycryptodome
+    from Crypto.Signature import DSS
+except ImportError:
+    pass
 
 from paramiko import util
 from paramiko.common import zero_byte
@@ -98,25 +103,33 @@ class DSSKey (PKey):
         return self.x is not None
 
     def sign_ssh_data(self, data):
-        digest = sha1(data).digest()
-        dss = DSA.construct((long(self.y), long(self.g), long(self.p), long(self.q), long(self.x)))
-        # generate a suitable k
-        qsize = len(util.deflate_long(self.q, 0))
-        while True:
-            k = util.inflate_long(os.urandom(qsize), 1)
-            if (k > 2) and (k < self.q):
-                break
-        r, s = dss.sign(util.inflate_long(digest, 1), k)
         m = Message()
         m.add_string('ssh-dss')
-        # apparently, in rare cases, r or s may be shorter than 20 bytes!
-        rstr = util.deflate_long(r, 0)
-        sstr = util.deflate_long(s, 0)
-        if len(rstr) < 20:
-            rstr = zero_byte * (20 - len(rstr)) + rstr
-        if len(sstr) < 20:
-            sstr = zero_byte * (20 - len(sstr)) + sstr
-        m.add_string(rstr + sstr)
+        dss = DSA.construct((long(self.y), long(self.g), long(self.p), long(self.q), long(self.x)))
+
+        if hasattr(dss, "sign"):
+            # PyCrypto
+            digest = SHA1.new(data).digest()
+            # generate a suitable k
+            qsize = len(util.deflate_long(self.q, 0))
+            while True:
+                k = util.inflate_long(os.urandom(qsize), 1)
+                if (k > 2) and (k < self.q):
+                    break
+            r, s = dss.sign(util.inflate_long(digest, 1), k)
+            # apparently, in rare cases, r or s may be shorter than 20 bytes!
+            rstr = util.deflate_long(r, 0)
+            sstr = util.deflate_long(s, 0)
+            if len(rstr) < 20:
+                rstr = zero_byte * (20 - len(rstr)) + rstr
+            if len(sstr) < 20:
+                sstr = zero_byte * (20 - len(sstr)) + sstr
+            m.add_string(rstr + sstr)
+        else:
+            # PyCryptodome
+            signer = DSS.new(dss, 'fips-186-3')
+            sig = signer.sign(SHA1.new(data))
+            m.add_string(sig)
         return m
 
     def verify_ssh_sig(self, data, msg):
@@ -129,13 +142,23 @@ class DSSKey (PKey):
                 return 0
             sig = msg.get_binary()
 
-        # pull out (r, s) which are NOT encoded as mpints
-        sigR = util.inflate_long(sig[:20], 1)
-        sigS = util.inflate_long(sig[20:], 1)
-        sigM = util.inflate_long(sha1(data).digest(), 1)
-
         dss = DSA.construct((long(self.y), long(self.g), long(self.p), long(self.q)))
-        return dss.verify(sigM, (sigR, sigS))
+        if hasattr(dss, "sign"):
+            # PyCrypto
+            # pull out (r, s) which are NOT encoded as mpints
+            sigR = util.inflate_long(sig[:20], 1)
+            sigS = util.inflate_long(sig[20:], 1)
+            sigM = util.inflate_long(SHA1.new(data).digest(), 1)
+            result = dss.verify(sigM, (sigR, sigS))
+        else:
+            # PyCryptodome
+            try:
+                verifier = DSS.new(dss, 'fips-186-3')
+                verifier.verify(SHA1.new(data), sig)
+                result = True
+            except ValueError:
+                result = False
+        return result
 
     def _encode_key(self):
         if self.x is None:

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -1646,7 +1646,7 @@ class Transport (threading.Thread, ClosingContextManager):
         elif name.endswith("-ctr"):
             # CTR modes, we need a counter
             counter = Counter.new(nbits=self._cipher_info[name]['block-size'] * 8, initial_value=util.inflate_long(iv, True))
-            return self._cipher_info[name]['class'].new(key, self._cipher_info[name]['mode'], iv, counter)
+            return self._cipher_info[name]['class'].new(key, self._cipher_info[name]['mode'], iv, counter=counter)
         else:
             return self._cipher_info[name]['class'].new(key, self._cipher_info[name]['mode'], iv)
 

--- a/setup.py
+++ b/setup.py
@@ -38,10 +38,18 @@ To install the `in-development version
 
 import sys
 try:
+    import platform
     from setuptools import setup
+
+    if platform.python_implementation() == 'PyPy' or\
+                      platform.system() == 'Windows':
+        crypto_lib = 'pycryptodome'
+    else:
+        crypto_lib = 'pycrypto >= 2.1, != 2.4'
+
     kw = {
         'install_requires': [
-            'pycrypto >= 2.1, != 2.4',
+            crypto_lib,
             'ecdsa >= 0.11',
         ],
     }

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ try:
                       platform.system() == 'Windows':
         crypto_lib = 'pycryptodome'
     else:
-        crypto_lib = 'pycrypto >= 2.1, != 2.4'
+        crypto_lib = 'pycrypto >= 2.5'
 
     kw = {
         'install_requires': [

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -277,6 +277,12 @@ class SSHClientTest (unittest.TestCase):
         # in py3...
         if not PY2:
             return
+
+        # PyPy does not use GC
+        import platform
+        if platform.python_implementation() == 'PyPy':
+            return
+
         threading.Thread(target=self._run).start()
         host_key = paramiko.RSAKey.from_private_key_file(test_path('test_rsa.key'))
         public_host_key = paramiko.RSAKey(data=host_key.asbytes())


### PR DESCRIPTION
This patch makes paramiko work with PyCryptodome in addition to PyCrypto.
With the former, paramiko can run under PyPy.