### PR TITLE
primes: min and max should be inclusive

### DIFF
--- a/paramiko/primes.py
+++ b/paramiko/primes.py
@@ -113,12 +113,12 @@ class ModulusPack (object):
         good = -1
         # find nearest bitsize >= preferred
         for b in bitsizes:
-            if (b >= prefer) and (b < max) and (b < good or good == -1):
+            if (b >= prefer) and (b <= max) and (b < good or good == -1):
                 good = b
         # if that failed, find greatest bitsize >= min
         if good == -1:
             for b in bitsizes:
-                if (b >= min) and (b < max) and (b > good):
+                if (b >= min) and (b <= max) and (b > good):
                     good = b
         if good == -1:
             # their entire (min, max) range has no intersection with our range.


### PR DESCRIPTION
As seen in the [OpenSSH source code][1], the min and max values of the `diffie-hellman-group-exchange-*` key exchange types are supposed to be inclusive.

In the current state of the code and a standard /etc/ssh/moduli file, OpenSSH client sends min=1024, max=8192, prefer=8192, but paramiko returns one of the 7680 bits prime instead of one of the 8192 bits ones.

As far as I can see, the whole `ModulusPack` is untested, so not adding explicit tests for this.

[1]: https://github.com/openssh/openssh-portable/blob/master/kexgexc.c#L111