### PR TITLE
Gracefully fail `gss-with-mic` to allow fallback to next authentication

### DIFF
--- a/paramiko/auth_handler.py
+++ b/paramiko/auth_handler.py
@@ -356,7 +356,7 @@ class AuthHandler (object):
             m.add_string(p[0])
             m.add_boolean(p[1])
         self.transport._send_message(m)
- 
+
     def _parse_userauth_request(self, m):
         if not self.transport.server_mode:
             # er, uh... what?
@@ -495,8 +495,9 @@ class AuthHandler (object):
                         m.add_string(token)
                         self.transport._send_message(m)
                 else:
-                    raise SSHException("Client asked to handle paket %s"
-                                       %MSG_NAMES[ptype])
+                    result = AUTH_FAILED
+                    self._send_auth_result(username, method, result)
+                    return
                 # check MIC
                 ptype, m = self.transport.packetizer.read_message()
                 if ptype == MSG_USERAUTH_GSSAPI_MIC:
@@ -568,7 +569,7 @@ class AuthHandler (object):
         lang = m.get_string()
         self.transport._log(INFO, 'Auth banner: %s' % banner)
         # who cares.
-    
+
     def _parse_userauth_info_request(self, m):
         if self.auth_method != 'keyboard-interactive':
             raise SSHException('Illegal info request from server')
@@ -580,14 +581,14 @@ class AuthHandler (object):
         for i in range(prompts):
             prompt_list.append((m.get_text(), m.get_boolean()))
         response_list = self.interactive_handler(title, instructions, prompt_list)
-        
+
         m = Message()
         m.add_byte(cMSG_USERAUTH_INFO_RESPONSE)
         m.add_int(len(response_list))
         for r in response_list:
             m.add_string(r)
         self.transport._send_message(m)
-    
+
     def _parse_userauth_info_response(self, m):
         if not self.transport.server_mode:
             raise SSHException('Illegal info response from server')


### PR DESCRIPTION
While researching issue https://github.com/paramiko/paramiko/issues/651, I discovered what I think is a bug in `_parse_userauth_request()`. If the authentication method is **gssapi-with-mic** and the ptype is not `MSG_USERAUTH_GSSAPI_TOKEN`, then the function raises an exception. I believe the correct response is to fail the request to allow the client to fallback to alternate methods.

I've applied and tested the patch associated with this pull request and it now works as expected.

I've also attached a copy of the Putty log to this message if you'd like to see the specifics of how it attempts authentication.

[putty.txt](https://github.com/paramiko/paramiko/files/75568/putty.txt)