### PR TITLE
Update SSHConfig.parse to strip leading and trailing whitespace

### DIFF
--- a/paramiko/config.py
+++ b/paramiko/config.py
@@ -55,7 +55,9 @@ class SSHConfig (object):
         """
         host = {"host": ['*'], "config": {}}
         for line in file_obj:
-            line = line.rstrip('\r\n').lstrip()
+            # Strip any leading or trailing whitespace from the line.
+            # See https://github.com/paramiko/paramiko/issues/499 for more info.
+            line = line.strip()
             if not line or line.startswith('#'):
                 continue
             if '=' in line:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -30,6 +30,7 @@ from paramiko.py3compat import StringIO, byte_ord, b
 
 from tests.util import ParamikoTest
 
+# Note some lines in this configuration have trailing spaces on purpose
 test_config_file = """\
 Host *
     User robey
@@ -105,7 +106,7 @@ class UtilTest(ParamikoTest):
         self.assertEqual(config._config,
             [{'host': ['*'], 'config': {}}, {'host': ['*'], 'config': {'identityfile': ['~/.ssh/id_rsa'], 'user': 'robey'}},
             {'host': ['*.example.com'], 'config': {'user': 'bjork', 'port': '3333'}},
-            {'host': ['*'], 'config': {'crazy': 'something dumb  '}},
+            {'host': ['*'], 'config': {'crazy': 'something dumb'}},
             {'host': ['spoo.example.com'], 'config': {'crazy': 'something else'}}])
 
     def test_3_host_config(self):
@@ -114,14 +115,14 @@ class UtilTest(ParamikoTest):
         config = paramiko.util.parse_ssh_config(f)
 
         for host, values in {
-            'irc.danger.com':   {'crazy': 'something dumb  ',
+            'irc.danger.com':   {'crazy': 'something dumb',
                                 'hostname': 'irc.danger.com',
                                 'user': 'robey'},
-            'irc.example.com':  {'crazy': 'something dumb  ',
+            'irc.example.com':  {'crazy': 'something dumb',
                                 'hostname': 'irc.example.com',
                                 'user': 'robey',
                                 'port': '3333'},
-            'spoo.example.com': {'crazy': 'something dumb  ',
+            'spoo.example.com': {'crazy': 'something dumb',
                                 'hostname': 'spoo.example.com',
                                 'user': 'robey',
                                 'port': '3333'}


### PR DESCRIPTION
Fixes #499 

Based on 1.13 branch.

* Modified the relevant tests (`test_2_parse_config` and `test_3_host_config`) to make sure spaces and newlines were stripped.
* The existing test `test_13_config_dos_crlf_succeeds` ensures that `\r\n` is still handled correctly