### PR TITLE
paramiko.sftp_file.prefetch now backwards compatible

### DIFF
--- a/paramiko/sftp_file.py
+++ b/paramiko/sftp_file.py
@@ -405,7 +405,7 @@ class SFTPFile (BufferedFile):
         """
 
 	if file_size is None:
-		file_size = self.stat().st_size;
+            file_size = self.stat().st_size;
 
         # queue up async reads for the rest of the file
         chunks = []

--- a/paramiko/sftp_file.py
+++ b/paramiko/sftp_file.py
@@ -404,7 +404,7 @@ class SFTPFile (BufferedFile):
         .. versionadded:: 1.5.1
         """
 
-	if file_size is None:
+        if file_size is None:
             file_size = self.stat().st_size;
 
         # queue up async reads for the rest of the file

--- a/paramiko/sftp_file.py
+++ b/paramiko/sftp_file.py
@@ -389,7 +389,7 @@ class SFTPFile (BufferedFile):
         """
         self.pipelined = pipelined
 
-    def prefetch(self, file_size):
+    def prefetch(self, file_size=None):
         """
         Pre-fetch the remaining contents of this file in anticipation of future
         `.read` calls.  If reading the entire file, pre-fetching can
@@ -403,6 +403,10 @@ class SFTPFile (BufferedFile):
 
         .. versionadded:: 1.5.1
         """
+
+	if file_size is None:
+		file_size = self.stat().st_size;
+
         # queue up async reads for the rest of the file
         chunks = []
         n = self._realpos

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`676` paramiko.sftp_file.prefetch is now backwards compatible with
+  previous versions of paramiko (1.15 to 1.5)
 * :bug:`499` Strip trailing/leading whitespace from lines when parsing SSH
   config files - this brings things in line with OpenSSH behavior. Thanks to
   Alfredo Esteban for the original report and Nick Pillitteri for the patch.


### PR DESCRIPTION
This changes paramiko.sftp_file.prefetch so that it can accept 1 or 2 arguments for backwards compatibility.

In versions 1.5 - 1.15, paramiko.sftp_file.prefetch accepted only 1 argument (self), and it was assumed that the entire file would be read in. In the original 1.16 version, the file_size to be read in was obligated (one could not use a default argument). This caused a lack of backwards compatibility with older programs (such as bzr). Now the second input argument is optional; if it is not provided, then the file_size is read directly from the file. Otherwise, the user-provided input argument is used for the file_size.

