### PR TITLE
Fix whitespacing in dependency version declaration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,8 +41,8 @@ try:
     from setuptools import setup
     kw = {
         'install_requires': [
-            'pycrypto >= 2.1, != 2.4',
-            'ecdsa >= 0.11',
+            'pycrypto >=2.1,!=2.4',
+            'ecdsa >=0.11',
         ],
     }
 except ImportError:


### PR DESCRIPTION
With recent setuptools the following error occurs

error in paramiko setup command: 'install_requires' must be a string \
or list of strings containing valid project/version requirement specifiers; \
Invalid requirement, parse error at "'!= 2.4'"

Simply dropping the whitespace is enough to fix

Signed-off-by: Justin Lecher <jlec@gentoo.org>