### PR TITLE
increase Transport.clear_to_send_timeout

### DIFF
--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -371,7 +371,7 @@ class Transport (threading.Thread, ClosingContextManager):
         self.saved_exception = None
         self.clear_to_send = threading.Event()
         self.clear_to_send_lock = threading.Lock()
-        self.clear_to_send_timeout = 30.0
+        self.clear_to_send_timeout = 300.0
         self.log_name = 'paramiko.transport'
         self.logger = util.get_logger(self.log_name)
         self.packetizer.set_log(self.logger)


### PR DESCRIPTION
While it is good to timeout when nothing happens, 30 seconds is sometime
too short, specially in the context of cloud instances under heavy load.
Increase the default timeout to 300 to help with this use case.

It could be argued that a connection that is unresponsive during 30
seconds is as good as dead. However, even if that is sometime the case,
it is not a always true. And in any case it is not for paramiko to
decide. A TCP/IP connection will not timeout, even if the RTT is above
30 seconds, neither should paramiko.

From the application point of view, the communication channel is assumed
to be reliable once established. It would be needlessly complicated to
force the paramiko user to handle a new error case where a communication
channel may timeout and should be retried.

Signed-off-by: Loic Dachary <loic@dachary.org>