### PR TITLE
Change raw_input() to input() for Python 3.x

### DIFF
--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -1395,7 +1395,10 @@ class Transport (threading.Thread, ClosingContextManager):
                     print(instructions.strip())
                 for prompt,show_input in prompt_list:
                     print(prompt.strip(),end=' ')
-                    answers.append(raw_input())
+                    if (sys.version_info > (3, 0)):
+                        answers.append(input())
+                    else:
+                        answers.append(raw_input())
                 return answers
         return self.auth_interactive(username, handler, submethods)
 


### PR DESCRIPTION
When using Python 3.x and connecting via `paramiko.SSHClient().connect(host, port, user, pkey)` to the server which forces two-factor authentication, function `auth_interactive_dumb` from `transport.py` is being invoked, where `raw_input()` is called. Of course it does not work in Python 3.x, therefore I'm changing it to `input()` and adding additional check for backwards compatibility with Python 2.x