### PR TITLE
Add support for PyCryptodome (and PyPy)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "pypy"
 install:
   # Self-install for setup.py-driven deps
   - pip install -e .

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Requirements
 
 - `Python <http://www.python.org/>`_ 2.6, 2.7, or 3.3+ (3.2 should also work,
   but it is not recommended)
-- `pycrypto <https://www.dlitz.net/software/pycrypto/>`_ 2.1+
+- `pycrypto <https://www.dlitz.net/software/pycrypto/>`_ 2.5+ or `pycryptodome <http://www.pycryptodome.org/>`_
 - `ecdsa <https://pypi.python.org/pypi/ecdsa>`_ 0.11+
 
 

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Requirements
 
 - `Python <http://www.python.org/>`_ 2.6, 2.7, or 3.3+ (3.2 should also work,
   but it is not recommended)
-- `pycrypto <https://www.dlitz.net/software/pycrypto/>`_ 2.5+ or `pycryptodome <http://www.pycryptodome.org/>`_
+- `pycryptodomex <http://www.pycryptodome.org/>`_
 - `ecdsa <https://pypi.python.org/pypi/ecdsa>`_ 0.11+
 
 

--- a/paramiko/dsskey.py
+++ b/paramiko/dsskey.py
@@ -21,9 +21,14 @@ DSS keys.
 """
 
 import os
-from hashlib import sha1
 
 from Crypto.PublicKey import DSA
+from Crypto.Hash import SHA as SHA1
+try:
+    # Only in Pycryptodome
+    from Crypto.Signature import DSS
+except ImportError:
+    pass
 
 from paramiko import util
 from paramiko.common import zero_byte
@@ -98,25 +103,33 @@ class DSSKey (PKey):
         return self.x is not None
 
     def sign_ssh_data(self, data):
-        digest = sha1(data).digest()
-        dss = DSA.construct((long(self.y), long(self.g), long(self.p), long(self.q), long(self.x)))
-        # generate a suitable k
-        qsize = len(util.deflate_long(self.q, 0))
-        while True:
-            k = util.inflate_long(os.urandom(qsize), 1)
-            if (k > 2) and (k < self.q):
-                break
-        r, s = dss.sign(util.inflate_long(digest, 1), k)
         m = Message()
         m.add_string('ssh-dss')
-        # apparently, in rare cases, r or s may be shorter than 20 bytes!
-        rstr = util.deflate_long(r, 0)
-        sstr = util.deflate_long(s, 0)
-        if len(rstr) < 20:
-            rstr = zero_byte * (20 - len(rstr)) + rstr
-        if len(sstr) < 20:
-            sstr = zero_byte * (20 - len(sstr)) + sstr
-        m.add_string(rstr + sstr)
+        dss = DSA.construct((long(self.y), long(self.g), long(self.p), long(self.q), long(self.x)))
+
+        if hasattr(dss, "sign"):
+            # PyCrypto
+            digest = SHA1.new(data).digest()
+            # generate a suitable k
+            qsize = len(util.deflate_long(self.q, 0))
+            while True:
+                k = util.inflate_long(os.urandom(qsize), 1)
+                if (k > 2) and (k < self.q):
+                    break
+            r, s = dss.sign(util.inflate_long(digest, 1), k)
+            # apparently, in rare cases, r or s may be shorter than 20 bytes!
+            rstr = util.deflate_long(r, 0)
+            sstr = util.deflate_long(s, 0)
+            if len(rstr) < 20:
+                rstr = zero_byte * (20 - len(rstr)) + rstr
+            if len(sstr) < 20:
+                sstr = zero_byte * (20 - len(sstr)) + sstr
+            m.add_string(rstr + sstr)
+        else:
+            # PyCryptodome
+            signer = DSS.new(dss, 'fips-186-3')
+            sig = signer.sign(SHA1.new(data))
+            m.add_string(sig)
         return m
 
     def verify_ssh_sig(self, data, msg):
@@ -129,13 +142,23 @@ class DSSKey (PKey):
                 return 0
             sig = msg.get_binary()
 
-        # pull out (r, s) which are NOT encoded as mpints
-        sigR = util.inflate_long(sig[:20], 1)
-        sigS = util.inflate_long(sig[20:], 1)
-        sigM = util.inflate_long(sha1(data).digest(), 1)
-
         dss = DSA.construct((long(self.y), long(self.g), long(self.p), long(self.q)))
-        return dss.verify(sigM, (sigR, sigS))
+        if hasattr(dss, "sign"):
+            # PyCrypto
+            # pull out (r, s) which are NOT encoded as mpints
+            sigR = util.inflate_long(sig[:20], 1)
+            sigS = util.inflate_long(sig[20:], 1)
+            sigM = util.inflate_long(SHA1.new(data).digest(), 1)
+            result = dss.verify(sigM, (sigR, sigS))
+        else:
+            # PyCryptodome
+            try:
+                verifier = DSS.new(dss, 'fips-186-3')
+                verifier.verify(SHA1.new(data), sig)
+                result = True
+            except ValueError:
+                result = False
+        return result
 
     def _encode_key(self):
         if self.x is None:

--- a/paramiko/pkey.py
+++ b/paramiko/pkey.py
@@ -25,7 +25,7 @@ from binascii import hexlify, unhexlify
 import os
 from hashlib import md5
 
-from Crypto.Cipher import DES3, AES
+from Cryptodome.Cipher import DES3, AES
 
 from paramiko import util
 from paramiko.common import o600, zero_byte

--- a/paramiko/rsakey.py
+++ b/paramiko/rsakey.py
@@ -22,9 +22,9 @@ RSA keys.
 
 import os
 
-from Crypto.PublicKey import RSA
-from Crypto.Hash import SHA as SHA1
-from Crypto.Signature import PKCS1_v1_5
+from Cryptodome.PublicKey import RSA
+from Cryptodome.Hash import SHA as SHA1
+from Cryptodome.Signature import PKCS1_v1_5
 
 from paramiko import util
 from paramiko.common import max_byte, zero_byte, one_byte

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -1646,7 +1646,7 @@ class Transport (threading.Thread, ClosingContextManager):
         elif name.endswith("-ctr"):
             # CTR modes, we need a counter
             counter = Counter.new(nbits=self._cipher_info[name]['block-size'] * 8, initial_value=util.inflate_long(iv, True))
-            return self._cipher_info[name]['class'].new(key, self._cipher_info[name]['mode'], iv, counter)
+            return self._cipher_info[name]['class'].new(key, self._cipher_info[name]['mode'], iv, counter=counter)
         else:
             return self._cipher_info[name]['class'].new(key, self._cipher_info[name]['mode'], iv)
 

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -64,11 +64,8 @@ from paramiko.ssh_exception import (SSHException, BadAuthenticationType,
                                     ChannelException, ProxyCommandFailure)
 from paramiko.util import retry_on_signal, ClosingContextManager, clamp_value
 
-from Crypto.Cipher import Blowfish, AES, DES3, ARC4
-try:
-    from Crypto.Util import Counter
-except ImportError:
-    from paramiko.util import Counter
+from Cryptodome.Cipher import Blowfish, AES, DES3, ARC4
+from Cryptodome.Util import Counter
 
 
 # for thread cleanup
@@ -1646,7 +1643,7 @@ class Transport (threading.Thread, ClosingContextManager):
         elif name.endswith("-ctr"):
             # CTR modes, we need a counter
             counter = Counter.new(nbits=self._cipher_info[name]['block-size'] * 8, initial_value=util.inflate_long(iv, True))
-            return self._cipher_info[name]['class'].new(key, self._cipher_info[name]['mode'], iv, counter=counter)
+            return self._cipher_info[name]['class'].new(key, self._cipher_info[name]['mode'], counter=counter)
         else:
             return self._cipher_info[name]['class'].new(key, self._cipher_info[name]['mode'], iv)
 

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ try:
                       platform.system() == 'Windows':
         crypto_lib = 'pycryptodome'
     else:
-        crypto_lib = 'pycrypto >= 2.1, != 2.4'
+        crypto_lib = 'pycrypto >= 2.5'
 
     kw = {
         'install_requires': [

--- a/setup.py
+++ b/setup.py
@@ -38,11 +38,19 @@ To install the `in-development version
 
 import sys
 try:
+    import platform
     from setuptools import setup
+
+    if platform.python_implementation() == 'PyPy' or\
+                      platform.system() == 'Windows':
+        crypto_lib = 'pycryptodome'
+    else:
+        crypto_lib = 'pycrypto >= 2.1, != 2.4'
+
     kw = {
         'install_requires': [
-            'pycrypto>=2.1,!=2.4',
-            'ecdsa>=0.11',
+            crypto_lib,
+            'ecdsa >= 0.11',
         ],
     }
 except ImportError:

--- a/setup.py
+++ b/setup.py
@@ -41,15 +41,9 @@ try:
     import platform
     from setuptools import setup
 
-    if platform.python_implementation() == 'PyPy' or\
-                      platform.system() == 'Windows':
-        crypto_lib = 'pycryptodome'
-    else:
-        crypto_lib = 'pycrypto >= 2.5'
-
     kw = {
         'install_requires': [
-            crypto_lib,
+            'pycryptodomex',
             'ecdsa >= 0.11',
         ],
     }

--- a/sites/www/index.rst
+++ b/sites/www/index.rst
@@ -3,7 +3,7 @@ Welcome to Paramiko!
 
 Paramiko is a Python (2.6+, 3.3+) implementation of the SSHv2 protocol [#]_,
 providing both client and server functionality. While it leverages a Python C
-extension for low level cryptography (`PyCrypto <http://pycrypto.org>`_),
+extension for low level cryptography (`PyCryptodome <https://www.pycryptodome.org>`_),
 Paramiko itself is a pure Python interface around SSH networking concepts.
 
 This website covers project information for Paramiko such as the changelog,

--- a/sites/www/installing.rst
+++ b/sites/www/installing.rst
@@ -49,40 +49,6 @@ If you're unsure which version to install, we have suggestions:
   carefully upgrade to whichever version they care to, when their release line
   stops being supported.
 
-
-PyCrypto
-========
-
-`PyCrypto <https://www.dlitz.net/software/pycrypto/>`_  provides the low-level
-(C-based) encryption algorithms we need to implement the SSH protocol. There
-are a couple gotchas associated with installing PyCrypto: its compatibility
-with Python's package tools, and the fact that it is a C-based extension.
-
-C extension
------------
-
-Unless you are installing from a precompiled source such as a Debian apt
-repository or RedHat RPM, or using :ref:`pypm <pypm>`, you will also need the
-ability to build Python C-based modules from source in order to install
-PyCrypto. Users on **Unix-based platforms** such as Ubuntu or Mac OS X will
-need the traditional C build toolchain installed (e.g. Developer Tools / XCode
-Tools on the Mac, or the ``build-essential`` package on Ubuntu or Debian Linux
--- basically, anything with ``gcc``, ``make`` and so forth) as well as the
-Python development libraries, often named ``python-dev`` or similar.
-
-For **Windows** users we recommend using :ref:`pypm`, installing a C
-development environment such as `Cygwin <http://cygwin.com>`_ or obtaining a
-precompiled Win32 PyCrypto package from `voidspace's Python modules page
-<http://www.voidspace.org.uk/python/modules.shtml#pycrypto>`_.
-
-.. note::
-    Some Windows users whose Python is 64-bit have found that the PyCrypto
-    dependency ``winrandom`` may not install properly, leading to ImportErrors.
-    In this scenario, you'll probably need to compile ``winrandom`` yourself
-    via e.g. MS Visual Studio.  See `Fabric #194
-    <https://github.com/fabric/fabric/issues/194>`_ for info.
-
-
 .. _pypm:
 
 ActivePython and PyPM

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -277,6 +277,12 @@ class SSHClientTest (unittest.TestCase):
         # in py3...
         if not PY2:
             return
+
+        # PyPy does not use GC
+        import platform
+        if platform.python_implementation() == 'PyPy':
+            return
+
         threading.Thread(target=self._run).start()
         host_key = paramiko.RSAKey.from_private_key_file(test_path('test_rsa.key'))
         public_host_key = paramiko.RSAKey(data=host_key.asbytes())

--- a/tests/test_packetizer.py
+++ b/tests/test_packetizer.py
@@ -25,7 +25,7 @@ from hashlib import sha1
 
 from tests.loop import LoopSocket
 
-from Crypto.Cipher import AES
+from Cryptodome.Cipher import AES
 
 from paramiko import Message, Packetizer, util
 from paramiko.common import byte_chr, zero_byte

--- a/tox-requirements.txt
+++ b/tox-requirements.txt
@@ -1,2 +1,2 @@
 # Not sure why tox can't just read setup.py?
-pycrypto
+pycryptodomex


### PR DESCRIPTION
Shamelessly resubmitting this pull request (was #646).
Maybe it is acceptable at least for a 1.x branch (not 2.x)?

===

This patch makes paramiko work with PyCryptodome instead of PyCrypto.
With the former, paramiko can run under PyPy (and way more easily on Windows!).