### PR TITLE
Simplify setup.py by always relying on setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,23 +31,10 @@ To install the `in-development version
 `pip install paramiko==dev`.
 '''
 
-# if someday we want to *require* setuptools, uncomment this:
-# (it will cause setuptools to be automatically downloaded)
-#import ez_setup
-#ez_setup.use_setuptools()
-
 import sys
-try:
-    from setuptools import setup
-    kw = {
-        'install_requires': [
-            'pycrypto>=2.1,!=2.4',
-            'ecdsa>=0.11',
-        ],
-    }
-except ImportError:
-    from distutils.core import setup
-    kw = {}
+
+from setuptools import setup
+
 
 if sys.platform == 'darwin':
     import setup_helper
@@ -89,5 +76,8 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
     ],
-    **kw
+    install_requires=[
+        'pycrypto>=2.1,!=2.4',
+        'ecdsa>=0.11',
+    ],
 )


### PR DESCRIPTION
It is installed everywhere now, there is no practical way to use python without it.