### PR TITLE
fix 64 bit issue with user SID

### DIFF
--- a/paramiko/_winapi.py
+++ b/paramiko/_winapi.py
@@ -361,5 +361,5 @@ def get_security_attributes_for_user(user=None):
     ctypes.windll.advapi32.InitializeSecurityDescriptor(ctypes.byref(SD),
         SECURITY_DESCRIPTOR.REVISION)
     ctypes.windll.advapi32.SetSecurityDescriptorOwner(ctypes.byref(SD),
-        ctypes.cast(user.SID,ctypes.c_longlong), 0)
+        ctypes.cast(user.SID,ctypes.c_long), 0)
     return SA

--- a/paramiko/_winapi.py
+++ b/paramiko/_winapi.py
@@ -361,5 +361,5 @@ def get_security_attributes_for_user(user=None):
     ctypes.windll.advapi32.InitializeSecurityDescriptor(ctypes.byref(SD),
         SECURITY_DESCRIPTOR.REVISION)
     ctypes.windll.advapi32.SetSecurityDescriptorOwner(ctypes.byref(SD),
-        user.SID, 0)
+        ctypes.cast(user.SID,ctypes.c_longlong), 0)
     return SA


### PR DESCRIPTION
force user SID to be cast as long, brought up in #758
I haven't tested this on 32 bit environments, so I'd do that before merging.