### PR TITLE
allow ~ expansion inside proxycommand

### DIFF
--- a/paramiko/config.py
+++ b/paramiko/config.py
@@ -209,6 +209,7 @@ class SSHConfig (object):
                         ],
                         'proxycommand':
                         [
+                            ('~', homedir),
                             ('%h', config['hostname']),
                             ('%p', port),
                             ('%r', remoteuser)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -248,6 +248,19 @@ Host *
                 val
             )
 
+    def test_11_proxycommand_tilde_expansion(self):
+        """
+        Tilde (~) should be expanded inside ProxyCommand
+        """
+        config = paramiko.util.parse_ssh_config(StringIO("""
+Host test
+    ProxyCommand    ssh -F ~/.ssh/test_config bastion nc %h %p
+"""))
+        self.assertEqual(
+            'ssh -F %s/.ssh/test_config bastion nc test 22' % os.path.expanduser('~'),
+            host_config('test', config)['proxycommand']
+        )
+
     def test_11_host_config_test_negation(self):
         test_config_file = """
 Host www13.* !*.example.com


### PR DESCRIPTION
Hi paramiko,

this supertrivial patch adds support for ssh_config like this:

```
Host test
    Hostname        %h.domain.com
    ProxyCommand    ssh -F ~/.ssh/test_config bastion nc %h %p
```

so instead of looking for literal `~/` path it'll be nicely expanded to `/home/myuser/`.
