### PR TITLE
Add type declarations for Windows API per jaraco.windows 3.6.1.

### DIFF
--- a/paramiko/_winapi.py
+++ b/paramiko/_winapi.py
@@ -118,6 +118,18 @@ CreateFileMapping.restype = ctypes.wintypes.HANDLE
 MapViewOfFile = ctypes.windll.kernel32.MapViewOfFile
 MapViewOfFile.restype = ctypes.wintypes.HANDLE
 
+UnmapViewOfFile = ctypes.windll.kernel32.UnmapViewOfFile
+UnmapViewOfFile.argtypes = ctypes.wintypes.HANDLE,
+
+RtlMoveMemory = ctypes.windll.kernel32.RtlMoveMemory
+RtlMoveMemory.argtypes = (
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+    ctypes.c_size_t,
+)
+
+ctypes.windll.kernel32.LocalFree.argtypes = ctypes.wintypes.HLOCAL,
+
 #####################
 # jaraco.windows.mmap
 
@@ -306,6 +318,13 @@ class SECURITY_ATTRIBUTES(ctypes.Structure):
     def descriptor(self, value):
         self._descriptor = value
         self.lpSecurityDescriptor = ctypes.addressof(value)
+
+
+ctypes.windll.advapi32.SetSecurityDescriptorOwner.argtypes = (
+    ctypes.POINTER(SECURITY_DESCRIPTOR),
+    ctypes.c_void_p,
+    ctypes.wintypes.BOOL,
+)
 
 #########################
 # jaraco.windows.security

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -3,6 +3,8 @@ Changelog
 =========
 
 * :release:`1.16.2 <2016-06-21>`
+* :bug:`758 (1.16+)` Apply type definitions to ``_winapi`` module from
+  jaraco.windows 3.6.1.
 * :bug:`520 (1.16+)` (Partial fix) Fix at least one instance of race condition
   driven threading hangs at end of the Python interpreter session. (Includes a
   docs update as well - always make sure to ``.close()`` your clients!)

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -105,7 +105,7 @@ Changelog
   :issue:`581`, and a bunch of other duplicates besides) Add support for SHA-2
   based key exchange (kex) algorithm ``diffie-hellman-group-exchange-sha256``
   and (H)MAC algorithms ``hmac-sha2-256`` and ``hmac-sha2-512``.
-  
+
   This change includes tweaks to debug-level logging regarding
   algorithm-selection handshakes; the old all-in-one log line is now multiple
   easier-to-read, printed-at-handshake-time log lines.
@@ -310,7 +310,7 @@ Changelog
   Plugaru.
 * :bug:`-` Fix logging error in sftp_client for filenames containing the '%'
   character. Thanks to Antoine Brenner.
-* :bug:`308` Fix regression in dsskey.py that caused sporadic signature 
+* :bug:`308` Fix regression in dsskey.py that caused sporadic signature
   verification failures. Thanks to Chris Rose.
 * :support:`299` Use deterministic signatures for ECDSA keys for improved
   security. Thanks to Alex Gaynor.
@@ -333,7 +333,7 @@ Changelog
 * :feature:`16` **Python 3 support!** Our test suite passes under Python 3, and
   it (& Fabric's test suite) continues to pass under Python 2. **Python 2.5 is
   no longer supported with this change!**
-  
+
   The merged code was built on many contributors' efforts, both code &
   feedback. In no particular order, we thank Daniel Goertzen, Ivan Kolodyazhny,
   Tomi Pieviläinen, Jason R. Coombs, Jan N. Schulze, ``@Lazik``, Dorian Pula,


### PR DESCRIPTION
As reported in the ticket, fixes #758.