### PR TITLE
Exclude _winapi from coverage

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [wheel]
 universal = 1
+
+[coverage:run]
+omit = paramiko/_winapi.py


### PR DESCRIPTION
Consider this technique or similar (I haven't tested this) to exclude the _winapi.py from coverage, as it's covered by jaraco.windows instead.