### PR TITLE
Update GlobalAlloc argtypes per jaraco.windows 3.6.2. Fixes #802.

### DIFF
--- a/paramiko/_winapi.py
+++ b/paramiko/_winapi.py
@@ -89,7 +89,7 @@ def handle_nonzero_success(result):
 GMEM_MOVEABLE = 0x2
 
 GlobalAlloc = ctypes.windll.kernel32.GlobalAlloc
-GlobalAlloc.argtypes = ctypes.wintypes.UINT, ctypes.c_ssize_t
+GlobalAlloc.argtypes = ctypes.wintypes.UINT, ctypes.c_size_t
 GlobalAlloc.restype = ctypes.wintypes.HANDLE
 
 GlobalLock = ctypes.windll.kernel32.GlobalLock

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`802 (1.16+)` Better align GlobalAlloc argument spec with the API
+  docs, incidentally improving supported Python versions on Windows.
 * :release:`1.16.3 <2016-07-25>`
 * :bug:`673 (1.16+)` (via :issue:`681`) Fix protocol banner read errors
   (``SSHException``) which would occasionally pop up when using


### PR DESCRIPTION
[fixes #802]
