### PR TITLE
Change ProxyCommand.close to use Popen.close/poll

### DIFF
--- a/paramiko/proxy.py
+++ b/paramiko/proxy.py
@@ -105,7 +105,8 @@ class ProxyCommand(ClosingContextManager):
             raise ProxyCommandFailure(' '.join(self.cmd), e.strerror)
 
     def close(self):
-        os.kill(self.process.pid, signal.SIGTERM)
+        self.process.kill()
+        self.process.poll()
 
     @property
     def closed(self):


### PR DESCRIPTION
This fixes the 'zombie process' left when using ProxyCommand. Popen.poll() is needed to update the return code.

From the [docs](https://docs.python.org/3/library/subprocess.html#subprocess.Popen.poll):

> Popen.poll()
>    Check if child process has terminated. Set and return returncode attribute.

@bitprophet - I based this on https://github.com/paramiko/paramiko/commit/228ed87e2f4b7314e4cfb67ee462550c5f20edef, fixes https://github.com/paramiko/paramiko/issues/789
