### PR TITLE
Prevent SFTP get() from emptying files (fixes #724)

### DIFF
--- a/paramiko/sftp_client.py
+++ b/paramiko/sftp_client.py
@@ -717,11 +717,20 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
         .. versionchanged:: 1.7.4
             Added the ``callback`` param
         """
-        with open(localpath, 'wb') as fl:
-            size = self.getfo(remotepath, fl, callback)
-        s = os.stat(localpath)
-        if s.st_size != size:
-            raise IOError('size mismatch in get!  %d != %d' % (s.st_size, size))
+        backuppath = '{0}.paramiko_bak'.format(localpath)
+        if os.path.isfile(localpath):
+            os.rename(localpath, backuppath)
+        try:
+            with open(localpath, 'wb') as fl:
+                size = self.getfo(remotepath, fl, callback)
+            s = os.stat(localpath)
+            if s.st_size != size:
+                raise IOError('size mismatch in get!  %d != %d' % (s.st_size, size))
+            if os.path.isfile(backuppath):
+                os.remove(backuppath)
+        except:
+            os.rename(backuppath, localpath)
+            raise
 
     ###  internals...
 

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -2,6 +2,9 @@
 Changelog
 =========
 
+* :bug:`724 (1.16+)` (via :issue:`724`) Prevent SFTP get() method from emptying
+  files when called on closed connections. Thanks to ``@dmitrytokarev`` for the
+  report and Adam (``@operatingops``) for the patch.
 * :support:`819 backported (>=1.15,<2.0)` Document how lacking ``gmp`` headers
   at install time can cause a significant performance hit if you build PyCrypto
   from source. (Most system-distributed packages already have this enabled.)


### PR DESCRIPTION
Fixes #724

The problem is that `getfo()` (the method that gets data from the SFTP server and writes it out) in `sftp_client.py` takes a file object, not a path, so `get()` (a convenience method that takes a path) opens the local file before it calls `getfo()`. Python's `open()` overwrites no matter what, even if it has no data to write. When `getfo()` errors the local file is overwritten with nothing. I added a test to cover this. I looked through the code's other uses of `open()` and didn't see any with this problem.

The bug was introduced when this line was removed: `file_size = self.stat(remotepath).st_size`. It wasn't used in the method, but if the connection was closed it caused an error before the `open()` call, which prevented the local file from being opened and then emptied. Adding it or something similar would be an interesting one-line fix, but I don't think it's the right way for two reasons:
1. I'd have to explain it in comments.
2. There's still a race condition where a connection dies because of network problems between the `stat()` call and the `open()` call. Although unlikely, it'd be almost impossible to reproduce.

I think the fix with the lowest impact is to modify `get()` to backup the local file and restore it if we get an error. Some details:
- I chose to backup and restore instead of downloading into a temp file so that if there are problems on the filesystem (permissions, etc.) it will fail before downloading, like it did before.
- This may not be atomic in all cases, especially on Windows. The original method wasn't atomic and I thought it was out of scope to address that while fixing #724. Making filesystem operations truly atomic in Python isn't straightforward.

After reading the contributing docs I used branch 1.16 since that's the oldest one with recent merges that has the bug. I tested the same change in master, though, just to make sure it'd work there. I'm a bit new to some of the details of the contributing process you use and if I used the wrong branch or anything just let me know and I'll fix it up.

I ran the tests with paramiko installed in editable mode in a virtualenv running Python 2 and a pyvenv running Python 3.

What do you think? Let me know if you think anything should be different and I'll rebase it in.
