### PR TITLE
open() function does not support setting file permissions

### DIFF
--- a/paramiko/pkey.py
+++ b/paramiko/pkey.py
@@ -333,8 +333,7 @@ class PKey(object):
 
         :raises IOError: if there was an error writing the file.
         """
-        with open(filename, 'w', o600) as f:
-            # grrr... the mode doesn't always take hold
+        with open(filename, 'w') as f:
             os.chmod(filename, o600)
             self._write_private_key(f, key, format)
 


### PR DESCRIPTION
The open() function does not support setting file permissions[1]. The
code was setting the buffer to 0o600. Remove the attempted file
permission value.

[1] https://docs.python.org/2/library/functions.html#open

Change-Id: I582e226f8bc76e877c7da686f36e2efa33f0d24f
