### PR TITLE
Issue #822 - Allow channel._handle_close to bypass session rekey block

### DIFF
--- a/paramiko/channel.py
+++ b/paramiko/channel.py
@@ -1068,7 +1068,7 @@ class Channel (ClosingContextManager):
             self.lock.release()
         for m in msgs:
             if m is not None:
-                self.transport._send_user_message(m)
+                self.transport._send_user_message(m, True)
 
     ###  internals...
 

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -1582,10 +1582,16 @@ class Transport (threading.Thread, ClosingContextManager):
     def _send_message(self, data):
         self.packetizer.send_message(data)
 
-    def _send_user_message(self, data):
+    def _send_user_message(self, data, ignore_rekey_lock=False):
         """
         send a message, but block if we're in key negotiation.  this is used
         for user-initiated requests.
+
+        :param obj data:
+            Message object to send
+        param bool ignore_rekey_lock:
+            Prevent blocking during rekey, used by channel._handle_close to
+            prevent a key negotiation from blocking the channel close message
         """
         start = time.time()
         while True:
@@ -1595,6 +1601,8 @@ class Transport (threading.Thread, ClosingContextManager):
                 return
             self.clear_to_send_lock.acquire()
             if self.clear_to_send.is_set():
+                break
+            if ignore_rekey_lock:
                 break
             self.clear_to_send_lock.release()
             if time.time() > start + self.clear_to_send_timeout:


### PR DESCRIPTION
This PR attempts to address Issue #822 opened by @mathrick 

The change adds an argument to `transport._send_user_message` that allows the message to be sent during key negotiation.  `channel._handle_close` is modified to set this argument to `True` to enable the closure of a channel even after a rekey has been requested by the client. Normally this closure message (`cMSG_CHANNEL_CLOSE`) would be blocked in `transport._send_user_message` until after the rekey process has completed.  In some cases, as demonstrated in Issue #822, this never occurs and the connection errors out.

After implementing this change the demo code in Issue #822 was able to run for at least 700 loop iterations.  Prior to the change the best I was able to achieve was 4 iterations before hitting the issue.