### PR TITLE
Fixes fatal error when missing known_hosts

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -136,7 +136,7 @@ class SSHClient (ClosingContextManager):
 
         # update local host keys from file (in case other SSH clients
         # have written to the known_hosts file meanwhile.
-        if self._host_keys_filename is not None:
+        if self._host_keys_filename is not None and os.path.isfile(self._host_keys_filename):
             self.load_host_keys(self._host_keys_filename)
 
         with open(filename, 'w') as f:


### PR DESCRIPTION
Quick fix that addresses #625 for the case where known_hosts does not exist.

Note: This does not create the parent directory, not sure the opinions on that, but it likely should, but the concern I would have is that the path to the known_host file could potentially be created outside our control, so it's not guaranteed we're working on ~/.ssh ...

Perhaps a compromise might be to add a test for the directory existing and report that as a clean failure or we just let the open Exception fire.