### PR TITLE
Fix tests

### DIFF
--- a/tox-requirements.txt
+++ b/tox-requirements.txt
@@ -1,3 +1,0 @@
-# Not sure why tox can't just read setup.py?
-cryptography >= 1.1
-pyasn1 >= 0.1.7

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
-envlist = py26,py27,py33,py34,pypy
+envlist = py{26,27,33,34,35,py}
 
 [testenv]
-commands = pip install -q -r tox-requirements.txt
-           python test.py
+commands = python test.py


### PR DESCRIPTION
This pull-request:
- adds test environment for python 3.5
- removes redundant pip command from tox.ini

---

Tox automates the creation of virtualenvs for each configured interpreter. Generates a package distribution according to setup.py. And finally installs that package in each environment before running the tests.

https://tox.readthedocs.io/en/latest/#what-is-tox

It is one of tox's features to also test dependencies are in place when running tests.
