### PR TITLE
Add SSH_MSG_USERAUTH_REQUEST with boolean = FALSE, i.e. PK probe.

### DIFF
--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -1153,6 +1153,18 @@ class Transport (threading.Thread, ClosingContextManager):
         """
         return self.active and (self.auth_handler is not None) and self.auth_handler.is_authenticated()
 
+    def is_publickey_probe_ok(self):
+        """
+        Return true if this session is active and public key probe succeeded.
+
+        :return:
+            True if the session is still open and public key would be accepted
+            for authentication; False if key would not be accepted and/or 
+            the session is closed.
+        """
+        return self.active and (self.auth_handler is not None) and self.auth_handler.is_publickey_probe_ok()
+
+
     def get_username(self):
         """
         Return the username this connection is authenticated for.  If the

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -1283,7 +1283,7 @@ class Transport (threading.Thread, ClosingContextManager):
                 # attempt failed; just raise the original exception
                 raise e
 
-    def auth_publickey(self, username, key, event=None):
+    def auth_publickey(self, username, key, event=None, probe=False):
         """
         Authenticate to the server using a private key.  The key is used to
         sign data from the server, so it must include the private part.
@@ -1324,7 +1324,7 @@ class Transport (threading.Thread, ClosingContextManager):
         else:
             my_event = event
         self.auth_handler = AuthHandler(self)
-        self.auth_handler.auth_publickey(username, key, my_event)
+        self.auth_handler.auth_publickey(username, key, my_event, probe)
         if event is not None:
             # caller wants to wait for event themselves
             return []


### PR DESCRIPTION
This implements RFC 4252, section 7 querying whether
   authentication using the "publickey" method would be acceptable.
Calling transport.auth_publickey(username, key, event, probe = True) allows to test a given key, whether it would be accepted for authentication. Key can be a private or public key.
Server shall respond either with SSH_MSG_USERAUTH_FAILURE or SSH_MSG_USERAUTH_PK_OK. If SSH_MSG_USERAUTH_PK_OK is returned, transport.is_publickey_probe_ok() return true.
Can be used to test multiple keys within one session before authentication.

E.g.:

    for key in keys:
        kk = StringIO.StringIO(key)
        key1 = paramiko.RSAKey(file_obj=kk)
        print('Probing key %s' % hexlify(key1.get_fingerprint()))
        try:
            transport.auth_publickey(username, key1, probe = True)
            print('... success!')
            break
        except paramiko.SSHException:
            print('... nope.')

    if transport.is_publickey_probe_ok():
        print('Authenticating with key %s' % hexlify(key1.get_fingerprint()))
        try:
            transport.auth_publickey(username, key1)
            print('... success!')
            return
        except paramiko.SSHException:
            print('... nope.')


