### PR TITLE
Fixing invoke_shell reference to obsolete update_environment_variables

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -464,7 +464,7 @@ class SSHClient (ClosingContextManager):
         """
         chan = self._transport.open_session()
         chan.get_pty(term, width, height, width_pixels, height_pixels)
-        chan.update_environment_variables(environment or {})
+        chan.update_environment(environment or {})
         chan.invoke_shell()
         return chan
 


### PR DESCRIPTION
See issue #859 