### PR TITLE
Avoid PacketizerTest.test_closed_3 to fail on platforms where errno.ETIME is not defined

### DIFF
--- a/tests/test_packetizer.py
+++ b/tests/test_packetizer.py
@@ -114,9 +114,13 @@ class PacketizerTest (unittest.TestCase):
         import signal
 
         class TimeoutError(Exception):
-            pass
+            def __init__(self, error_message):
+                if hasattr(errno, 'ETIME'):
+                    self.message = os.sterror(errno.ETIME)
+                else:
+                    self.messaage = error_message
 
-        def timeout(seconds=1, error_message=os.strerror(errno.ETIME)):
+        def timeout(seconds=1, error_message='Timer expired'):
             def decorator(func):
                 def _handle_timeout(signum, frame):
                     raise TimeoutError(error_message)


### PR DESCRIPTION
This changes define the proper Timer expired error message instead of raising
AttributeError when errno.ETIME is not available on the platform. fixes #862