### PR TITLE
2.1 - Add timeout to authentication step

### DIFF
--- a/paramiko/auth_handler.py
+++ b/paramiko/auth_handler.py
@@ -199,7 +199,7 @@ class AuthHandler (object):
                 raise e
             if event.is_set():
                 break
-            elif max_ts is not None and max_ts >= time.time():
+            if max_ts is not None and max_ts <= time.time():
                 raise AuthenticationException('Authentication timeout.')
 
         if not self.is_authenticated():

--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -226,7 +226,8 @@ class SSHClient (ClosingContextManager):
         gss_kex=False,
         gss_deleg_creds=True,
         gss_host=None,
-        banner_timeout=None
+        banner_timeout=None,
+        auth_timeout=None
     ):
         """
         Connect to an SSH server and authenticate to it.  The server's host key
@@ -278,7 +279,8 @@ class SSHClient (ClosingContextManager):
             The targets name in the kerberos database. default: hostname
         :param float banner_timeout: an optional timeout (in seconds) to wait
             for the SSH banner to be presented.
-
+        :param float auth_timeout: an optional timeout (in seconds) to wait for
+            an authentication response.
         :raises BadHostKeyException: if the server's host key could not be
             verified
         :raises AuthenticationException: if authentication failed
@@ -335,6 +337,8 @@ class SSHClient (ClosingContextManager):
             t.set_log_channel(self._log_channel)
         if banner_timeout is not None:
             t.banner_timeout = banner_timeout
+        if auth_timeout is not None:
+            t.auth_timeout = auth_timeout
         t.start_client(timeout=timeout)
         ResourceManager.register(self, t)
 

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -383,7 +383,7 @@ class Transport (threading.Thread, ClosingContextManager):
         self.completion_event = None    # user-defined event callbacks
         self.banner_timeout = 15        # how long (seconds) to wait for the SSH banner
         self.handshake_timeout = 15     # how long (seconds) to wait for the handshake to finish after SSH banner sent.
-        self.auth_timeout = 15          # how long (seconds) to wait for the auth response.
+        self.auth_timeout = 30          # how long (seconds) to wait for the auth response.
 
         # server mode:
         self.server_mode = False

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -383,7 +383,7 @@ class Transport (threading.Thread, ClosingContextManager):
         self.completion_event = None    # user-defined event callbacks
         self.banner_timeout = 15        # how long (seconds) to wait for the SSH banner
         self.handshake_timeout = 15     # how long (seconds) to wait for the handshake to finish after SSH banner sent.
-
+        self.auth_timeout = 15          # how long (seconds) to wait for the auth response.
 
         # server mode:
         self.server_mode = False

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -253,7 +253,7 @@ class AuthTest (unittest.TestCase):
             except:
                 etype, evalue, etb = sys.exc_info()
                 self.assertTrue(issubclass(etype, AuthenticationException))
-                self.assertIn('Authentication timeout', str(evalue))
+                self.assertTrue('Authentication timeout' in str(evalue))
         finally:
             # Restore value
             self.tc.auth_timeout = auth_timeout

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -60,6 +60,9 @@ class NullServer (paramiko.ServerInterface):
     def check_auth_password(self, username, password):
         if (username == 'slowdive') and (password == 'pygmalion'):
             return paramiko.AUTH_SUCCESSFUL
+        if (username == 'slowdive') and (password == 'unresponsive-server'):
+            time.sleep(5)
+            return paramiko.AUTH_SUCCESSFUL
         return paramiko.AUTH_FAILED
 
     def check_auth_publickey(self, username, key):
@@ -379,6 +382,24 @@ class SSHClientTest (unittest.TestCase):
             password='pygmalion',
         )
         self._test_connection(**kwargs)
+
+    def test_9_auth_timeout(self):
+        """
+        verify that the SSHClient has a configurable auth timeout
+        """
+        threading.Thread(target=self._run).start()
+        host_key = paramiko.RSAKey.from_private_key_file(test_path('test_rsa.key'))
+        public_host_key = paramiko.RSAKey(data=host_key.asbytes())
+
+        self.tc = paramiko.SSHClient()
+        self.tc.get_host_keys().add('[%s]:%d' % (self.addr, self.port), 'ssh-rsa', public_host_key)
+        # Connect with a half second auth timeout
+        kwargs = dict(self.connect_kwargs, password='unresponsive-server', auth_timeout=0.5)
+        self.assertRaises(
+            paramiko.AuthenticationException,
+            self.tc.connect,
+            **kwargs
+        )
 
     def test_update_environment(self):
         """


### PR DESCRIPTION
Ran into a problem with an SSH server that became non-responsive during authentication. The current behaviour of paramiko is to block while authenitcation is in progress leading to the client app hanging on an auth response. 

Change is to add an `auth_timeout` option and apply the timeout in the `wait_for_response` method of  `AuthHandler`.

Includes a test case for this additional code.