### PR TITLE
Add back-reference from Transport to the SSHClient that created it

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -336,6 +336,7 @@ class SSHClient (ClosingContextManager):
         if banner_timeout is not None:
             t.banner_timeout = banner_timeout
         t.start_client(timeout=timeout)
+        t.set_sshclient(self)
         ResourceManager.register(self, t)
 
         server_key = t.get_remote_server_key()

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -283,6 +283,7 @@ class Transport (threading.Thread, ClosingContextManager):
             arguments.
         """
         self.active = False
+        self._sshclient = None
 
         if isinstance(sock, string_types):
             # convert "host:port" into (host, port)
@@ -642,6 +643,9 @@ class Transport (threading.Thread, ClosingContextManager):
         Transport._modulus_pack = None
         return False
 
+    def set_sshclient(self, sshclient):
+        self._sshclient = sshclient
+
     def close(self):
         """
         Close this session, and any open channels that are tied to it.
@@ -652,6 +656,7 @@ class Transport (threading.Thread, ClosingContextManager):
         for chan in list(self._channels.values()):
             chan._unlink()
         self.sock.close()
+        self._sshclient = None
 
     def get_remote_server_key(self):
         """


### PR DESCRIPTION
In some cases, the SSH client is created, the command is executed, the
streams are extracted, and the explicit reference to SSHClient is then
discarded (since it was e.g. created in a function that only returns the
streams). In this case, the SHSClient may be garbage collected, and the
connection's state is undefined.

This fix adds a reference from Transport to the SSHClient that created
it. The streams have a reference to the Channel, which references the
Transport. Now that the Transport references the SSHClient, it won't be
garbage collected until it is closed.

Closes-Bug: #44
Related-Bug: #344