### PR TITLE
Fix bug in handling multiple interactive queries

### DIFF
--- a/paramiko/auth_handler.py
+++ b/paramiko/auth_handler.py
@@ -597,7 +597,7 @@ class AuthHandler (object):
         for i in range(n):
             responses.append(m.get_text())
         result = self.transport.server_object.check_auth_interactive_response(responses)
-        if isinstance(type(result), InteractiveQuery):
+        if isinstance(result, InteractiveQuery):
             # make interactive query instead of response
             self._interactive_query(result)
             return


### PR DESCRIPTION
If repeated interaction is needed, check_auth_interactive_response returns an InteractiveQuery object. Unfortunately a bug caused it not to be recognized, causing autheintication to fail. This fixes said bug by properly looking at the type of the returned object.