### PR TITLE
client: prefer keytype from known_hosts, more ecdsa server hostkey support

### DIFF
--- a/paramiko/auth_handler.py
+++ b/paramiko/auth_handler.py
@@ -416,8 +416,8 @@ class AuthHandler (object):
             except SSHException as e:
                 self.transport._log(INFO, 'Auth rejected: public key: %s' % str(e))
                 key = None
-            except:
-                self.transport._log(INFO, 'Auth rejected: unsupported or mangled public key')
+            except Exception as e:
+                self.transport._log(INFO, 'Auth rejected: unsupported or mangled public key: %s' % str(e))
                 key = None
             if key is None:
                 self._disconnect_no_more_auth()

--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -335,36 +335,38 @@ class SSHClient (ClosingContextManager):
             t.set_log_channel(self._log_channel)
         if banner_timeout is not None:
             t.banner_timeout = banner_timeout
-        t.start_client(timeout=timeout)
-        t.set_sshclient(self)
-        ResourceManager.register(self, t)
-
-        server_key = t.get_remote_server_key()
-        keytype = server_key.get_name()
 
         if port == SSH_PORT:
             server_hostkey_name = hostname
         else:
             server_hostkey_name = "[%s]:%d" % (hostname, port)
+        our_server_keys = None
 
         # If GSS-API Key Exchange is performed we are not required to check the
         # host key, because the host is authenticated via GSS-API / SSPI as
         # well as our client.
         if not self._transport.use_gss_kex:
-            our_server_key = self._system_host_keys.get(server_hostkey_name,
-                                                         {}).get(keytype, None)
-            if our_server_key is None:
-                our_server_key = self._host_keys.get(server_hostkey_name,
-                                                     {}).get(keytype, None)
-            if our_server_key is None:
-                # will raise exception if the key is rejected; let that fall out
-                self._policy.missing_host_key(self, server_hostkey_name,
-                                              server_key)
-                # if the callback returns, assume the key is ok
-                our_server_key = server_key
+            our_server_keys = self._system_host_keys.get(server_hostkey_name)
+            if our_server_keys is None:
+                our_server_keys = self._host_keys.get(server_hostkey_name)
+            if our_server_keys is not None:
+                t._preferred_keys = list(our_server_keys.keys())
 
-            if server_key != our_server_key:
-                raise BadHostKeyException(hostname, server_key, our_server_key)
+        t.start_client(timeout=timeout)
+        t.set_sshclient(self)
+        ResourceManager.register(self, t)
+
+        if not self._transport.use_gss_kex:
+            server_key = t.get_remote_server_key()
+            if our_server_keys is None:
+                # will raise exception if the key is rejected; let that fall out
+                self._policy.missing_host_key(self, server_hostkey_name, server_key)
+            else:
+                our_key = our_server_keys.get(server_key.get_name())
+                if our_key != server_key:
+                    if our_key is None:
+                        our_key = list(our_server_keys.values())[0]
+                    raise BadHostKeyException(hostname, server_key, our_key)
 
         if username is None:
             username = getpass.getuser()

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -2018,6 +2018,9 @@ class Transport (threading.Thread, ClosingContextManager):
         self.host_key_type = agreed_keys[0]
         if self.server_mode and (self.get_server_key() is None):
             raise SSHException('Incompatible ssh peer (can\'t match requested host key type)')
+        self._log_agreement(
+            'HostKey', agreed_keys[0], agreed_keys[0]
+        )
 
         if self.server_mode:
             agreed_local_ciphers = list(filter(self._preferred_ciphers.__contains__,

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -207,8 +207,8 @@ class Transport (threading.Thread, ClosingContextManager):
     _key_info = {
         'ssh-rsa': RSAKey,
         'ssh-dss': DSSKey,
-        'ecdsa-sha2-nistp256': ECDSAKey,
     }
+    _key_info.update((name, ECDSAKey) for name in ECDSAKey.supported_key_format_identifiers())
 
     _kex_info = {
         'diffie-hellman-group1-sha1': KexGroup1,

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -119,10 +119,10 @@ class Transport (threading.Thread, ClosingContextManager):
         'hmac-md5-96',
         'hmac-sha1',
     )
-    _preferred_keys = (
+    _preferred_keys = tuple(ECDSAKey.supported_key_format_identifiers()) + (
         'ssh-rsa',
         'ssh-dss',
-    ) + tuple(ECDSAKey.supported_key_format_identifiers())
+    )
     _preferred_kex =  (
         'diffie-hellman-group1-sha1',
         'diffie-hellman-group14-sha1',

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+* :bug:`865` prefer ssh host key which is the same type as in known_hosts.
+  Commonly an ecdsa key is in known_hosts but SSHClient gets an rsa key.
+  Also, consider different key types a mismatch rather than "missing".
+  Also, prefer ecdsa over rsa if no known key yet, to match openssh client.
 * :release:`2.1.2 <2017-02-20>`
 * :release:`2.0.5 <2017-02-20>`
 * :release:`1.18.2 <2017-02-20>`


### PR DESCRIPTION
fixes #865 

Note that `Transport.connect()` already does something similar: if a hostkey is passed, it sets `_preferred_keys` to the type of that hostkey. (But SSHClient does not use Transport.connect(), it uses the alternative `start_client()` for more control.)

See commit messages for more details. Also, I'll be doing a bit more testing with different sets of key types available on the server, just to be sure...