### PR TITLE
Select pref key

### DIFF
--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -119,10 +119,10 @@ class Transport (threading.Thread, ClosingContextManager):
         'hmac-md5-96',
         'hmac-sha1',
     )
-    _preferred_keys = (
+    _preferred_keys = tuple(ECDSAKey.supported_key_format_identifiers()) + (
         'ssh-rsa',
         'ssh-dss',
-    ) + tuple(ECDSAKey.supported_key_format_identifiers())
+    )
     _preferred_kex =  (
         'diffie-hellman-group1-sha1',
         'diffie-hellman-group14-sha1',

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -208,6 +208,8 @@ class Transport (threading.Thread, ClosingContextManager):
         'ssh-rsa': RSAKey,
         'ssh-dss': DSSKey,
         'ecdsa-sha2-nistp256': ECDSAKey,
+        'ecdsa-sha2-nistp384': ECDSAKey,
+        'ecdsa-sha2-nistp521': ECDSAKey,
     }
 
     _kex_info = {

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -414,3 +414,29 @@ class SSHClientTest (unittest.TestCase):
                             'Expected original SSHException in exception')
         else:
             self.assertFalse(False, 'SSHException was not thrown.')
+
+    def test_preferred_key_type(self):
+        """
+        Verify that setting an preferred key type doesn't break
+        """
+        threading.Thread(target=self._run).start()
+
+        self.tc = paramiko.SSHClient()
+        self.tc.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        try:
+          self.tc.connect(self.addr, self.port, username='slowdive', password='pygmalion', pref_key_type='ecdsa-sha2-nistp256')
+        except:
+          self.assertTrue(False, 'connect with a preferred key type failed')
+
+    def test_unknown_preferred_key_type(self):
+        """
+        Verify that setting a non-existent preferred key type doesn't break
+        """
+        threading.Thread(target=self._run).start()
+
+        self.tc = paramiko.SSHClient()
+        self.tc.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        try:
+          self.tc.connect(self.addr, self.port, username='slowdive', password='pygmalion', pref_key_type='banana')
+        except:
+          self.assertTrue(False, 'connect with an unknown preferred key type failed')

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -162,6 +162,21 @@ class TransportTest(unittest.TestCase):
         except TypeError:
             pass
 
+    def test_1a_security_options_set_key_types(self):
+        o = self.tc.get_security_options()
+        kt = o.key_types
+
+        try:
+            o.key_types = kt
+        except:
+            self.assertTrue(False)
+
+        try:
+            o.key_types = ['banana']
+            self.assertTrue(False)
+        except:
+            pass
+
     def test_2_compute_key(self):
         self.tc.K = 123281095979686581523377256114209720774539068973101330872763622971399429481072519713536292772709507296759612401802191955568143056534122385270077606457721553469730659233569339356140085284052436697480759510519672848743794433460113118986816826624865291116513647975790797391795651716378444844877749505443714557929
         self.tc.H = b'\x0C\x83\x07\xCD\xE6\x85\x6F\xF3\x0B\xA9\x36\x84\xEB\x0F\x04\xC2\x52\x0E\x9E\xD3'

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -169,11 +169,11 @@ class TransportTest(unittest.TestCase):
         try:
             o.key_types = kt
         except:
-            self.assertTrue(False)
+            self.assertTrue(False, 'setting correct key_types failed')
 
         try:
             o.key_types = ['banana']
-            self.assertTrue(False)
+            self.assertTrue(False, 'setting incorrect key_types didn\'t fail')
         except:
             pass
 


### PR DESCRIPTION
Using Paramiko I've come across an impracticality.

Resent OpenSSH clients have a preference towards ECDSA keys, and therefore, such keys tend to end up in the known_hosts files. Paramiko on the other hand, tend to end up using RSA key types after initial negotiation., and as a result Paramiko is likely to fail host key verification even though a valid host key has previously been added to the known_hosts file by OpenSSH.

I've added functionality to the SSHClient.connect method to indicate preference towards a given type of key. Loading the know host keys prior to the call to connect enables you to identify a key type which is already in the known_hosts (if any) and instruct Paramiko to use this key type:

host = 'myserver.com'
ssh = paramiko.SSHClient()
ssh.load_host_keys(os.path.expanduser('~/.ssh/known_hosts'))

keys_of_all_known_hosts = ssh.get_host_keys()
pref_hkey_type = None
if host in keys_of_all_known_hosts:
    pref_hkey_type = keys_of_all_known_hosts[host].keys()[0]

ssh.connect(host, username='eddie', password='murphy', pref_key_type=pref_hkey_type)

During the process of developing this I've come across an issue in relation to setting of key_types through the SecurityOptions object. Getting the key_types from the SecurityOptions and setting the same values again directly afterwards would raise an exception. I have proposed a fix for this issue too.

I hope you'll find this useful, and please don't hesitate to contact me for further comments.


BR / Kasper Døring
