### PR TITLE
compatibility import cleanup

### DIFF
--- a/paramiko/hostkeys.py
+++ b/paramiko/hostkeys.py
@@ -20,16 +20,11 @@
 import binascii
 import os
 
+from collections import MutableMapping
 from hashlib import sha1
 from hmac import HMAC
 
 from paramiko.py3compat import b, u, encodebytes, decodebytes
-
-try:
-    from collections import MutableMapping
-except ImportError:
-    # noinspection PyUnresolvedReferences
-    from UserDict import DictMixin as MutableMapping
 
 from paramiko.dsskey import DSSKey
 from paramiko.rsakey import RSAKey

--- a/paramiko/kex_gss.py
+++ b/paramiko/kex_gss.py
@@ -40,10 +40,10 @@ This module provides GSS-API / SSPI Key Exchange as defined in :rfc:`4462`.
 import os
 from hashlib import sha1
 
-from paramiko.common import *
+from paramiko.common import DEBUG, max_byte, zero_byte
 from paramiko import util
 from paramiko.message import Message
-from paramiko.py3compat import byte_chr, long, byte_mask, byte_ord
+from paramiko.py3compat import byte_chr, byte_mask, byte_ord
 from paramiko.ssh_exception import SSHException
 
 

--- a/paramiko/pipe.py
+++ b/paramiko/pipe.py
@@ -28,7 +28,6 @@ will trigger as readable in `select <select.select>`.
 import sys
 import os
 import socket
-from paramiko.py3compat import b
 
 
 def make_pipe():

--- a/paramiko/primes.py
+++ b/paramiko/primes.py
@@ -25,7 +25,6 @@ import os
 from paramiko import util
 from paramiko.py3compat import byte_mask, long
 from paramiko.ssh_exception import SSHException
-from paramiko.common import *
 
 
 def _roll_random(n):

--- a/paramiko/proxy.py
+++ b/paramiko/proxy.py
@@ -17,7 +17,6 @@
 # 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
 
 
-from datetime import datetime
 import os
 from shlex import split as shlsplit
 import signal

--- a/paramiko/py3compat.py
+++ b/paramiko/py3compat.py
@@ -63,15 +63,8 @@ if PY2:
         return s
 
 
-    try:
-        import cStringIO
-
-        StringIO = cStringIO.StringIO   # NOQA
-    except ImportError:
-        import StringIO
-
-        StringIO = StringIO.StringIO    # NOQA
-
+    import cStringIO
+    StringIO = cStringIO.StringIO
     BytesIO = StringIO
 
 

--- a/paramiko/sftp_client.py
+++ b/paramiko/sftp_client.py
@@ -699,8 +699,6 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
                 reader=fr, writer=fl, file_size=file_size, callback=callback
             )
 
-        return size
-
     def get(self, remotepath, localpath, callback=None):
         """
         Copy a remote file (``remotepath``) from the SFTP server to the local

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -313,14 +313,9 @@ class Transport (threading.Thread, ClosingContextManager):
         threading.Thread.__init__(self)
         self.setDaemon(True)
         self.sock = sock
-        # Python < 2.3 doesn't have the settimeout method - RogerB
-        try:
-            # we set the timeout so we can check self.active periodically to
-            # see if we should bail.  socket.timeout exception is never
-            # propagated.
-            self.sock.settimeout(self._active_check_timeout)
-        except AttributeError:
-            pass
+        # we set the timeout so we can check self.active periodically to
+        # see if we should bail. socket.timeout exception is never propagated.
+        self.sock.settimeout(self._active_check_timeout)
 
         # negotiated crypto parameters
         self.packetizer = Packetizer(sock)

--- a/paramiko/win_pageant.py
+++ b/paramiko/win_pageant.py
@@ -25,7 +25,7 @@ import array
 import ctypes.wintypes
 import platform
 import struct
-from paramiko.util import *
+from paramiko.common import zero_byte
 from paramiko.py3compat import b
 
 try:


### PR DESCRIPTION
Remove try/except blocks which were for supporting old versions of python which paramiko no longer supports.

cStringIO was actually used unconditionally before the python3 port: 0b7d0cf0a23e4f16f8552ae05a66539119e2e920 