### PR TITLE
SSHClient: request host key type from known_hosts

### DIFF
--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -2098,6 +2098,9 @@ class Transport(threading.Thread, ClosingContextManager):
         self.host_key_type = agreed_keys[0]
         if self.server_mode and (self.get_server_key() is None):
             raise SSHException('Incompatible ssh peer (can\'t match requested host key type)') # noqa
+        self._log_agreement(
+            'HostKey', agreed_keys[0], agreed_keys[0]
+        )
 
         if self.server_mode:
             agreed_local_ciphers = list(filter(

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+* :bug:`865` SSHClient requests the type of host key it has (e.g. from
+  known_hosts) and does not consider a different type to be a "Missing"
+  host key. This fixes a common case where an ecdsa key is in known_hosts and
+  the server also has an rsa host key. Thanks to Pierce Lopez.
 * :bug:`741` (also :issue:`809`, :issue:`772`; all via :issue:`912`) Writing
   encrypted/password-protected private key files was silently broken since 2.0
   due to an incorrect API call; this has been fixed.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -118,7 +118,11 @@ class SSHClientTest (unittest.TestCase):
             allowed_keys = FINGERPRINTS.keys()
         self.socks, addr = self.sockl.accept()
         self.ts = paramiko.Transport(self.socks)
-        host_key = paramiko.RSAKey.from_private_key_file(test_path('test_rsa.key'))
+        keypath = test_path('test_rsa.key')
+        host_key = paramiko.RSAKey.from_private_key_file(keypath)
+        self.ts.add_server_key(host_key)
+        keypath = test_path('test_ecdsa_256.key')
+        host_key = paramiko.ECDSAKey.from_private_key_file(keypath)
         self.ts.add_server_key(host_key)
         server = NullServer(allowed_keys=allowed_keys)
         if delay:
@@ -242,8 +246,9 @@ class SSHClientTest (unittest.TestCase):
         verify that SSHClient's AutoAddPolicy works.
         """
         threading.Thread(target=self._run).start()
-        host_key = paramiko.RSAKey.from_private_key_file(test_path('test_rsa.key'))
-        public_host_key = paramiko.RSAKey(data=host_key.asbytes())
+        hostname = '[%s]:%d' % (self.addr, self.port)
+        key_file = test_path('test_ecdsa_256.key')
+        public_host_key = paramiko.ECDSAKey.from_private_key_file(key_file)
 
         self.tc = paramiko.SSHClient()
         self.tc.set_missing_host_key_policy(paramiko.AutoAddPolicy())
@@ -256,7 +261,8 @@ class SSHClientTest (unittest.TestCase):
         self.assertEqual('slowdive', self.ts.get_username())
         self.assertEqual(True, self.ts.is_authenticated())
         self.assertEqual(1, len(self.tc.get_host_keys()))
-        self.assertEqual(public_host_key, self.tc.get_host_keys()['[%s]:%d' % (self.addr, self.port)]['ssh-rsa'])
+        new_host_key = list(self.tc.get_host_keys()[hostname].values())[0]
+        self.assertEqual(public_host_key, new_host_key)
 
     def test_5_save_host_keys(self):
         """
@@ -379,6 +385,52 @@ class SSHClientTest (unittest.TestCase):
             password='pygmalion',
         )
         self._test_connection(**kwargs)
+
+    def _client_host_key_bad(self, host_key):
+        threading.Thread(target=self._run).start()
+        hostname = '[%s]:%d' % (self.addr, self.port)
+
+        self.tc = paramiko.SSHClient()
+        self.tc.set_missing_host_key_policy(paramiko.WarningPolicy())
+        known_hosts = self.tc.get_host_keys()
+        known_hosts.add(hostname, host_key.get_name(), host_key)
+
+        self.assertRaises(
+            paramiko.BadHostKeyException,
+            self.tc.connect,
+            password='pygmalion',
+            **self.connect_kwargs
+        )
+
+    def _client_host_key_good(self, ktype, kfile):
+        threading.Thread(target=self._run).start()
+        hostname = '[%s]:%d' % (self.addr, self.port)
+
+        self.tc = paramiko.SSHClient()
+        self.tc.set_missing_host_key_policy(paramiko.RejectPolicy())
+        host_key = ktype.from_private_key_file(test_path(kfile))
+        known_hosts = self.tc.get_host_keys()
+        known_hosts.add(hostname, host_key.get_name(), host_key)
+
+        self.tc.connect(password='pygmalion', **self.connect_kwargs)
+        self.event.wait(1.0)
+        self.assertTrue(self.event.is_set())
+        self.assertTrue(self.ts.is_active())
+        self.assertEqual(True, self.ts.is_authenticated())
+
+    def test_host_key_negotiation_1(self):
+        host_key = paramiko.ECDSAKey.generate()
+        self._client_host_key_bad(host_key)
+
+    def test_host_key_negotiation_2(self):
+        host_key = paramiko.RSAKey.generate(2048)
+        self._client_host_key_bad(host_key)
+
+    def test_host_key_negotiation_3(self):
+        self._client_host_key_good(paramiko.ECDSAKey, 'test_ecdsa_256.key')
+
+    def test_host_key_negotiation_4(self):
+        self._client_host_key_good(paramiko.RSAKey, 'test_rsa.key')
 
     def test_update_environment(self):
         """


### PR DESCRIPTION
fixes #865 

one part of an alternative set of PRs to #899 

I only backported this to 2.1 because there were some changes around `t.start_client()` in 2.0 and 2.1 which make forward-merging have possibly tricky conflicts there. I can backport further if you would like, and won't mind the conflict resolution when forward-merging :)