### PR TITLE
prefer ecdsa host key types

### DIFF
--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -122,9 +122,12 @@ class Transport (threading.Thread, ClosingContextManager):
         'hmac-sha1',
     )
     _preferred_keys = (
+        'ecdsa-sha2-nistp256',
+        'ecdsa-sha2-nistp384',
+        'ecdsa-sha2-nistp521',
         'ssh-rsa',
         'ssh-dss',
-    ) + tuple(ECDSAKey.supported_key_format_identifiers())
+    )
     _preferred_kex = (
         'diffie-hellman-group1-sha1',
         'diffie-hellman-group14-sha1',

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -2,6 +2,9 @@
 Changelog
 =========
 
+* :bug:`900` Prefer ecdsa-sha2-nistp(256|384|521) host key types, like
+  the openssh client does. Thanks ``@ncoult`` for the report and Pierce
+  Lopez for the patch.
 * :bug:`794` (via :issue:`981`) Prior support for ``ecdsa-sha2-nistp(384|521)``
   algorithms didn't fully extend to covering host keys, preventing connection
   to hosts which only offer these key types and no others. This is now fixed.


### PR DESCRIPTION
fixes #794 and #900 

second part of an alternative set of PRs to #899 