### PR TITLE
Try second factor in case GSS or password auth requested it

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -226,7 +226,8 @@ class SSHClient (ClosingContextManager):
         gss_kex=False,
         gss_deleg_creds=True,
         gss_host=None,
-        banner_timeout=None
+        banner_timeout=None,
+        interactive_handler=None
     ):
         """
         Connect to an SSH server and authenticate to it.  The server's host key
@@ -377,7 +378,7 @@ class SSHClient (ClosingContextManager):
         if gss_host is None:
             gss_host = hostname
         self._auth(username, password, pkey, key_filenames, allow_agent,
-                   look_for_keys, gss_auth, gss_kex, gss_deleg_creds, gss_host)
+                   look_for_keys, gss_auth, gss_kex, gss_deleg_creds, gss_host, interactive_handler)
 
     def close(self):
         """
@@ -486,7 +487,7 @@ class SSHClient (ClosingContextManager):
         return self._transport
 
     def _auth(self, username, password, pkey, key_filenames, allow_agent,
-              look_for_keys, gss_auth, gss_kex, gss_deleg_creds, gss_host):
+              look_for_keys, gss_auth, gss_kex, gss_deleg_creds, gss_host, interactive_handler):
         """
         Try, in order:
 
@@ -519,9 +520,12 @@ class SSHClient (ClosingContextManager):
         # why should we do that again?
         if gss_auth:
             try:
-                self._transport.auth_gssapi_with_mic(username, gss_host,
-                                                     gss_deleg_creds)
-                return
+                self._log(DEBUG, 'Trying GSS auth')
+                allowed_types = set(self._transport.auth_gssapi_with_mic(username, gss_host,
+                                                     gss_deleg_creds))
+                two_factor = (allowed_types & two_factor_types)
+                if not two_factor:
+                    return
             except Exception as e:
                 saved_exception = e
 
@@ -605,16 +609,28 @@ class SSHClient (ClosingContextManager):
 
         if password is not None:
             try:
-                self._transport.auth_password(username, password)
-                return
+                self._log(DEBUG, 'Trying password auth')
+                allowed_types = set(self._transport.auth_password(username, password))
+                two_factor = (allowed_types & two_factor_types)
+                if not two_factor:
+                    return
             except SSHException as e:
                 saved_exception = e
         elif two_factor:
             try:
-                self._transport.auth_interactive_dumb(username)
+                self._transport.auth_interactive_dumb(username, handler=interactive_handler)
                 return
             except SSHException as e:
                 saved_exception = e
+
+        if two_factor:
+            try:
+                self._log(DEBUG, 'Trying interactive')
+                self._transport.auth_interactive_dumb(username, handler=interactive_handler)
+                return
+            except SSHException as e:
+                saved_exception = e
+
 
         # if we got an auth-failed exception earlier, re-raise it
         if saved_exception is not None:


### PR DESCRIPTION
Paramiko just returns in case GSS or password authentication is failed.
In case you have a second factor we need to proceed to some kind of
interactive handler.
I added optional interactive_handler parameter to the `connect` method.
In case GSS or password auth returned some set of allowed
authentication types and it matches types used for a second factor, I
try interactive auth using supplied handler