### PR TITLE
Fix hostname canonicalization with GSSAPI

### DIFF
--- a/demos/demo_simple.py
+++ b/demos/demo_simple.py
@@ -77,8 +77,6 @@ try:
     if not UseGSSAPI or (not UseGSSAPI and not DoGSSAPIKeyExchange):
         client.connect(hostname, port, username, password)
     else:
-        # SSPI works only with the FQDN of the target host
-        hostname = socket.getfqdn(hostname)
         try:
             client.connect(hostname, port, username, gss_auth=UseGSSAPI,
                            gss_kex=DoGSSAPIKeyExchange)

--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -226,6 +226,7 @@ class SSHClient (ClosingContextManager):
         gss_kex=False,
         gss_deleg_creds=True,
         gss_host=None,
+        gss_trust_dns=True,
         banner_timeout=None
     ):
         """
@@ -276,6 +277,9 @@ class SSHClient (ClosingContextManager):
         :param bool gss_deleg_creds: Delegate GSS-API client credentials or not
         :param str gss_host:
             The targets name in the kerberos database. default: hostname
+        :param gss_trust_dns: Indicates whether or not the DNS is trusted to
+                              securely canonicalize the name of the host being
+                              connected to (default `True`).
         :param float banner_timeout: an optional timeout (in seconds) to wait
             for the SSH banner to be presented.
 
@@ -326,9 +330,9 @@ class SSHClient (ClosingContextManager):
         t = self._transport = Transport(sock, gss_kex=gss_kex, gss_deleg_creds=gss_deleg_creds)
         t.use_compression(compress=compress)
         if gss_kex and gss_host is None:
-            t.set_gss_host(hostname)
+            t.set_gss_host(hostname, gss_trust_dns)
         elif gss_kex and gss_host is not None:
-            t.set_gss_host(gss_host)
+            t.set_gss_host(gss_host, gss_trust_dns)
         else:
             pass
         if self._log_channel is not None:
@@ -376,9 +380,11 @@ class SSHClient (ClosingContextManager):
         else:
             key_filenames = key_filename
         if gss_host is None:
-            gss_host = hostname
+            t.set_gss_host(hostname, gss_trust_dns)
+        else:
+            t.set_gss_host(gss_host, gss_trust_dns)
         self._auth(username, password, pkey, key_filenames, allow_agent,
-                   look_for_keys, gss_auth, gss_kex, gss_deleg_creds, gss_host)
+                   look_for_keys, gss_auth, gss_kex, gss_deleg_creds, t.gss_host)
 
     def close(self):
         """

--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -279,7 +279,7 @@ class SSHClient (ClosingContextManager):
             The targets name in the kerberos database. default: hostname
         :param gss_trust_dns: Indicates whether or not the DNS is trusted to
                               securely canonicalize the name of the host being
-                              connected to (default `True`).
+                              connected to (default ``True``).
         :param float banner_timeout: an optional timeout (in seconds) to wait
             for the SSH banner to be presented.
 
@@ -329,12 +329,11 @@ class SSHClient (ClosingContextManager):
 
         t = self._transport = Transport(sock, gss_kex=gss_kex, gss_deleg_creds=gss_deleg_creds)
         t.use_compression(compress=compress)
-        if gss_kex and gss_host is None:
+        if gss_host is None:
             t.set_gss_host(hostname, gss_trust_dns)
-        elif gss_kex and gss_host is not None:
-            t.set_gss_host(gss_host, gss_trust_dns)
-        else:
-            pass
+        elif gss_host is not None:
+            # Don't canonicalize gss_host
+            t.set_gss_host(gss_host, False)
         if self._log_channel is not None:
             t.set_log_channel(self._log_channel)
         if banner_timeout is not None:
@@ -379,10 +378,7 @@ class SSHClient (ClosingContextManager):
             key_filenames = [key_filename]
         else:
             key_filenames = key_filename
-        if gss_host is None:
-            t.set_gss_host(hostname, gss_trust_dns)
-        else:
-            t.set_gss_host(gss_host, gss_trust_dns)
+
         self._auth(username, password, pkey, key_filenames, allow_agent,
                    look_for_keys, gss_auth, gss_kex, gss_deleg_creds, t.gss_host)
 

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -284,10 +284,12 @@ class Transport (threading.Thread, ClosingContextManager):
         """
         self.active = False
         self._sshclient = None
+        self.hostname = None
 
         if isinstance(sock, string_types):
             # convert "host:port" into (host, port)
             hl = sock.split(':', 1)
+            self.hostname = hl[0]
             if len(hl) == 1:
                 sock = (hl[0], 22)
             else:
@@ -295,6 +297,7 @@ class Transport (threading.Thread, ClosingContextManager):
         if type(sock) is tuple:
             # connect to the given (host, port)
             hostname, port = sock
+            self.hostname = hostname
             reason = 'No suitable address family'
             for (family, socktype, proto, canonname, sockaddr) in socket.getaddrinfo(hostname, port, socket.AF_UNSPEC, socket.SOCK_STREAM):
                 if socktype == socket.SOCK_STREAM:
@@ -436,19 +439,17 @@ class Transport (threading.Thread, ClosingContextManager):
         """
         return SecurityOptions(self)
 
-    def set_gss_host(self, gss_host, gss_trust_dns):
+    def set_gss_host(self, gss_host, dns_lookup):
         """
         Setter for C{gss_host} if GSS-API Key Exchange is performed.
 
         :param str gss_host: The targets name in the kerberos database
                              Default: The name of the host to connect to
-        :param gss_trust_dns: Indicates whether or not the DNS is trusted to
-                              securely canonicalize the name of the host being
-                              connected to (default `True`).
+        :param dns_lookup:   Indicates whether or not ``gss_host`` should be
+                             canonicalized (default ``True``).
         :rtype: Void
         """
-        # We need the FQDN to get this working with SSPI
-        if gss_trust_dns:
+        if dns_lookup:
             self.gss_host = socket.getfqdn(gss_host)
         else:
             self.gss_host = gss_host
@@ -1085,8 +1086,7 @@ class Transport (threading.Thread, ClosingContextManager):
             Whether to delegate GSS-API client credentials.
         :param gss_trust_dns: Indicates whether or not the DNS is trusted to
                               securely canonicalize the name of the host being
-                              connected to (default `True`).
-
+                              connected to (default ``True``).
         :raises SSHException: if the SSH2 negotiation fails, the host key
             supplied by the server is incorrect, or authentication fails.
         """
@@ -1094,7 +1094,9 @@ class Transport (threading.Thread, ClosingContextManager):
             self._preferred_keys = [hostkey.get_name()]
 
         if gss_host is not None:
-            self.set_gss_host(gss_host, gss_trust_dns)
+            self.set_gss_host(gss_host, False)
+        else:
+            self.set_gss_host(self.hostname, gss_trust_dns)
 
         self.start_client()
 

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -1095,7 +1095,7 @@ class Transport (threading.Thread, ClosingContextManager):
 
         if gss_host is not None:
             self.set_gss_host(gss_host, False)
-        else:
+        elif self.hostname is not None:
             self.set_gss_host(self.hostname, gss_trust_dns)
 
         self.start_client()


### PR DESCRIPTION
I added the parameter ``gss_trust_dns`` in ``client.py`` and ``transport.py``. Set by default to ``True`` the parameter indicates whether or not the DNS is trusted to securely canonicalize the hostname of the target host. If set to ``False`` the hostname entered will be passed to GSSAPI.
This option behaves like ``GSSAPITrustDNS`` from OpenSSH.

Also, the option ``gss_host``, if set, can be used to override the hostname for GSSAPI and therefore is considered as the equivalent to ``GSSAPIServerIdentity`` from OpenSSH.

This pull should fix issue #915.