### PR TITLE
Fix mpint serialization to properly handle zero.

### DIFF
--- a/paramiko/util.py
+++ b/paramiko/util.py
@@ -60,6 +60,8 @@ deflate_ff = max_byte if PY2 else 0xff
 def deflate_long(n, add_sign_padding=True):
     """turns a long-int into a normalized byte string (adapted from Crypto.Util.number)"""
     # after much testing, this algorithm was deemed to be the fastest
+    if n == 0:
+        return b''
     s = bytes()
     n = long(n)
     while (n != 0) and (n != -1):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -530,4 +530,4 @@ Host *
         )
         
     def test_deflate_long_zero(self):
-        self.assertEqual(paramiko.util.deflate_long(0), b'\x00\x00\x00\x00')
+        self.assertEqual(paramiko.util.deflate_long(0), b'')

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -528,3 +528,6 @@ Host *
             config.lookup('some-random-host')['proxycommand'],
             'default-proxy'
         )
+        
+    def test_deflate_long_zero(self):
+        self.assertEqual(paramiko.util.deflate_long(0), b'\x00\x00\x00\x00')


### PR DESCRIPTION
Paramiko incorrectly handles the zero case of serializing the `mpint` type. See examples from [RFC 4251 section 5](https://www.ietf.org/rfc/rfc4251.txt) regarding the `mpint` type. Paramiko fails the first example and encodes zero as `b'\x00\x00\x00\x01\x00'` which functionally isn't incorrect but is still contrary to the RFC which states "The value zero MUST be stored as a string with zero bytes of data."