### PR TITLE
Decode before writing; handle both encodings

### DIFF
--- a/paramiko/sftp_client.py
+++ b/paramiko/sftp_client.py
@@ -596,7 +596,7 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
         size = 0
         while True:
             data = reader.read(32768)
-            writer.write(data)
+            writer.write(data.decode())
             size += len(data)
             if len(data) == 0:
                 break


### PR DESCRIPTION
Ran into the following error when trying to use `SFTPClient.getfo()` on py3.6:

```python
.tox/py36/lib/python3.6/site-packages/sandswitches/manage.py:195: in manage_config                        
    sftp.getfo(confpath, fxml)                                                                            
.tox/py36/lib/python3.6/site-packages/paramiko/sftp_client.py:699: in getfo                               
    reader=fr, writer=fl, file_size=file_size, callback=callback                                          
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
                                                                                                          
self = <paramiko.sftp_client.SFTPClient object at 0x7eff3bceccf8>                                         
reader = <paramiko.sftp_file.SFTPFile object at 0x7eff3bd0b080>                                           
writer = <_io.TextIOWrapper name='/tmp/root@sip-cannon.qa.sangoma.local-freeswitch-zpvwgw23.xml' mode='w' 
encoding='UTF-8'>                                                                                         
file_size = 361786, callback = None                                                                       
                                                                                                          
    def _transfer_with_callback(self, reader, writer, file_size, callback):                               
        size = 0                                                                                          
        while True:                                                                                       
            data = reader.read(32768)                                                                     
>           writer.write(data)                                                                            
E           TypeError: write() argument must be str, not bytes                                            
                                                                                                          
.tox/py36/lib/python3.6/site-packages/paramiko/sftp_client.py:599: TypeError                                                         
======================================== 1 error in 74.29 seconds =======================================
```

Simple decode seems to fix it for py2 and 3.
Let me know if I need to write a test or whatever.
Thanks!