### PR TITLE
travis-ci config: fix pypy version to 5.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "pypy-5.4.1"
+  - "pypy-5.3.1"
 install:
   # Self-install for setup.py-driven deps
   - pip install -e .


### PR DESCRIPTION
version 5.4.1 seems to work on travic-ci,
but that was never a released version of pypy
see http://doc.pypy.org/en/latest/index-of-whatsnew.html