### PR TITLE
Add HostKeys.clear_host

### DIFF
--- a/paramiko/hostkeys.py
+++ b/paramiko/hostkeys.py
@@ -189,6 +189,24 @@ class HostKeys (MutableMapping):
             return None
         return SubDict(hostname, entries, self)
 
+    def clear_host(self, hostname):
+        """
+        Remove a hostkey entry for a given hostname or IP.  Returns True if
+        entry was found or False if it wasn't.
+        :param str hostname: the hostname (or IP) to remove 
+        :return: boolean -> indicating whether entry was found 
+        """
+        entries = []
+        for e in self._entries:
+            for h in e.hostnames:
+                if h.startswith('|1|') and not hostname.startswith('|1|') and constant_time_bytes_eq(self.hash_host(hostname, h), h) or h == hostname:
+                    entries.append(e)
+        if len(entries) == 0:
+            return False
+        for e in entries:
+            self._entries.remove(e)
+        return True
+
     def check(self, hostname, key):
         """
         Return True if the given key is associated with the given hostname

--- a/tests/test_hostkeys.py
+++ b/tests/test_hostkeys.py
@@ -119,8 +119,9 @@ class HostKeysTest (unittest.TestCase):
     def test_5_dict(self):
         hostdict = paramiko.HostKeys('hostfile.temp')
         self.assertTrue('secure.example.com' in hostdict)
-        hostdict.clear_host('secure.example.com')
+        self.assertTrue(hostdict.clear_host('secure.example.com'))
         self.assertTrue('secure.example.com' not in hostdict)
+        self.assertFalse(hostdict.clear_host('secure.example.com'))
 
         hostdict = paramiko.HostKeys('hostfile.temp')
         self.assertTrue('secure.example.com' in hostdict)

--- a/tests/test_hostkeys.py
+++ b/tests/test_hostkeys.py
@@ -115,3 +115,16 @@ class HostKeysTest (unittest.TestCase):
         self.assertEqual(b'7EC91BB336CB6D810B124B1353C32396', fp)
         fp = hexlify(hostdict['secure.example.com']['ssh-dss'].get_fingerprint()).upper()
         self.assertEqual(b'4478F0B9A23CC5182009FF755BC1D26C', fp)
+
+    def test_5_dict(self):
+        hostdict = paramiko.HostKeys('hostfile.temp')
+        self.assertTrue('secure.example.com' in hostdict)
+        hostdict.clear_host('secure.example.com')
+        self.assertTrue('secure.example.com' not in hostdict)
+
+        hostdict = paramiko.HostKeys('hostfile.temp')
+        self.assertTrue('secure.example.com' in hostdict)
+        hostdict.clear_host('secure.example.com')
+        hostdict.save('hostfile.temp')
+        hostdict.load('hostfile.temp')
+        self.assertTrue('secure.example.com' not in hostdict)


### PR DESCRIPTION
I needed a method to clear an existing host a known_host file, so I added one.