### PR TITLE
A few additions for the ssh agent handling

### DIFF
--- a/paramiko/agent.py
+++ b/paramiko/agent.py
@@ -420,6 +420,29 @@ class Agent(AgentSSH):
         """
         self._close()
 
+class ForwardedAgent(AgentSSH):
+    """
+    Client interface to be for using private keys from an SSH agent forwarded
+    to a paramiko ssh server. This class is only usable from server code.
+
+    :raises SSHException:
+        if an SSH agent is found, but speaks an incompatible protocol
+    """
+    def __init__(self, t):
+        AgentSSH.__init__(self)
+        self.__t = t
+
+    def __del__(self):
+        self.close()
+
+    def connect(self):
+        conn_sock = self.__t.open_forward_agent_channel()
+        if conn_sock is None:
+            raise paramiko.SSHException('lost ssh-agent')
+        self._connect(conn_sock)
+
+    def close(self):
+        self._close()
 
 class AgentKey(PKey):
     """

--- a/paramiko/agent.py
+++ b/paramiko/agent.py
@@ -65,8 +65,7 @@ class AgentSSH(object):
             raise SSHException('could not get keys from ssh-agent')
         keys = []
         for i in range(result.get_int()):
-            keys.append(AgentKey(self, result.get_binary()))
-            result.get_string()
+            keys.append(AgentKey(self, result.get_binary(), result.get_string()))
         return tuple(keys)
 
     def _connect(self, conn):
@@ -374,10 +373,11 @@ class AgentKey(PKey):
     authenticating to a remote server (signing).  Most other key operations
     work as expected.
     """
-    def __init__(self, agent, blob):
+    def __init__(self, agent, blob, comment):
         self.agent = agent
         self.blob = blob
         self.name = Message(blob).get_text()
+        self.comment = comment
 
     def asbytes(self):
         return self.blob
@@ -387,6 +387,9 @@ class AgentKey(PKey):
 
     def get_name(self):
         return self.name
+
+    def get_comment(self):
+        return self.comment
 
     def sign_ssh_data(self, data):
         msg = Message()

--- a/paramiko/dsskey.py
+++ b/paramiko/dsskey.py
@@ -78,6 +78,16 @@ class DSSKey(PKey):
         m.add_mpint(self.y)
         return m.asbytes()
 
+    def asagentbytes(self):
+        m = Message()
+        m.add_string('ssh-dss')
+        m.add_mpint(self.p)
+        m.add_mpint(self.q)
+        m.add_mpint(self.g)
+        m.add_mpint(self.y)
+        m.add_mpint(self.x)
+        return m.asbytes()
+
     def __str__(self):
         return self.asbytes()
 

--- a/paramiko/rsakey.py
+++ b/paramiko/rsakey.py
@@ -76,6 +76,17 @@ class RSAKey(PKey):
         m.add_mpint(self.public_numbers.n)
         return m.asbytes()
 
+    def asagentbytes(self):
+        m = Message()
+        m.add_string('ssh-rsa')
+        m.add_mpint(self.public_numbers.n)
+        m.add_mpint(self.public_numbers.e)
+        m.add_mpint(self.key.private_numbers().d)
+        m.add_mpint(self.key.private_numbers().iqmp)
+        m.add_mpint(self.key.private_numbers().p)
+        m.add_mpint(self.key.private_numbers().q)
+        return m.asbytes()
+
     def __str__(self):
         # NOTE: as per inane commentary in #853, this appears to be the least
         # crummy way to get a representation that prints identical to Python


### PR DESCRIPTION
I recently had to write an ssh daemon that manipulates the ssh agent of the
connecting client. Paramiko was missing a few things to make this easy.
Specifically, I wanted to:

* Talk to the agent from the server code without jumping through proxy hoops
* See the comments of keys in the agent
* Add/remove keys from the agent

Arguably, the first of the commits in this branch is even a bugfix. Caching
keys from the agent is not quite right, as keys may be added/removed at any
time.