### PR TITLE
fixed python3 crash on windows

### DIFF
--- a/demos/interactive.py
+++ b/demos/interactive.py
@@ -81,7 +81,7 @@ def windows_shell(chan):
                 sys.stdout.write('\r\n*** EOF ***\r\n\r\n')
                 sys.stdout.flush()
                 break
-            sys.stdout.write(data)
+            sys.stdout.write(u(data))
             sys.stdout.flush()
         
     writer = threading.Thread(target=writeall, args=(chan,))


### PR DESCRIPTION
sys.stdout.write takes a unicode string not bytes