### PR TITLE
compatibility import cleanup (foreport)

### DIFF
--- a/paramiko/hostkeys.py
+++ b/paramiko/hostkeys.py
@@ -20,16 +20,11 @@
 import binascii
 import os
 
+from collections import MutableMapping
 from hashlib import sha1
 from hmac import HMAC
 
 from paramiko.py3compat import b, u, encodebytes, decodebytes
-
-try:
-    from collections import MutableMapping
-except ImportError:
-    # noinspection PyUnresolvedReferences
-    from UserDict import DictMixin as MutableMapping
 
 from paramiko.dsskey import DSSKey
 from paramiko.rsakey import RSAKey

--- a/paramiko/kex_gss.py
+++ b/paramiko/kex_gss.py
@@ -40,7 +40,7 @@ This module provides GSS-API / SSPI Key Exchange as defined in :rfc:`4462`.
 import os
 from hashlib import sha1
 
-from paramiko.common import *  # noqa
+from paramiko.common import DEBUG, max_byte, zero_byte
 from paramiko import util
 from paramiko.message import Message
 from paramiko.py3compat import byte_chr, byte_mask, byte_ord

--- a/paramiko/primes.py
+++ b/paramiko/primes.py
@@ -25,7 +25,6 @@ import os
 from paramiko import util
 from paramiko.py3compat import byte_mask, long
 from paramiko.ssh_exception import SSHException
-from paramiko.common import *  # noqa
 
 
 def _roll_random(n):

--- a/paramiko/py3compat.py
+++ b/paramiko/py3compat.py
@@ -65,15 +65,8 @@ if PY2:
         return s
 
 
-    try:
-        import cStringIO
-
-        StringIO = cStringIO.StringIO   # NOQA
-    except ImportError:
-        import StringIO
-
-        StringIO = StringIO.StringIO    # NOQA
-
+    import cStringIO
+    StringIO = cStringIO.StringIO
     BytesIO = StringIO
 
 

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -319,14 +319,9 @@ class Transport (threading.Thread, ClosingContextManager):
         threading.Thread.__init__(self)
         self.setDaemon(True)
         self.sock = sock
-        # Python < 2.3 doesn't have the settimeout method - RogerB
-        try:
-            # we set the timeout so we can check self.active periodically to
-            # see if we should bail.  socket.timeout exception is never
-            # propagated.
-            self.sock.settimeout(self._active_check_timeout)
-        except AttributeError:
-            pass
+        # we set the timeout so we can check self.active periodically to
+        # see if we should bail. socket.timeout exception is never propagated.
+        self.sock.settimeout(self._active_check_timeout)
 
         # negotiated crypto parameters
         self.packetizer = Packetizer(sock)

--- a/paramiko/win_pageant.py
+++ b/paramiko/win_pageant.py
@@ -25,7 +25,7 @@ import array
 import ctypes.wintypes
 import platform
 import struct
-from paramiko.util import *  # noqa
+from paramiko.common import zero_byte
 from paramiko.py3compat import b
 
 try:


### PR DESCRIPTION
A forward port of #906 to 2.0 as requested in https://github.com/paramiko/paramiko/pull/906#issuecomment-282115502 a while ago.

Not including the fix for `SFTPClient.getfo()` since that was re-discovered and fixed in the recent flake8 workover.