### PR TITLE
transport: _key_info for ecdsa-sha2-nistp384 and -nistp521

### DIFF
--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -210,6 +210,8 @@ class Transport (threading.Thread, ClosingContextManager):
         'ssh-rsa': RSAKey,
         'ssh-dss': DSSKey,
         'ecdsa-sha2-nistp256': ECDSAKey,
+        'ecdsa-sha2-nistp384': ECDSAKey,
+        'ecdsa-sha2-nistp521': ECDSAKey,
     }
 
     _kex_info = {

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -2,6 +2,9 @@
 Changelog
 =========
 
+* :bug:`794` Finishing touches to support ecdsa-sha2-nistp384 and
+  ecdsa-sha2-nistp521 host keys. Thanks ``@ncoult`` and ``@kasdoe`` for
+  reports.
 * :support:`974 backported` Overhaul the codebase to be PEP-8, etc, compliant
   (i.e. passes the maintainer's preferred `flake8 <http://flake8.pycqa.org/>`_
   configuration) and add a ``flake8`` step to the Travis config. Big thanks to

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -165,6 +165,15 @@ class TransportTest(unittest.TestCase):
         except TypeError:
             pass
 
+    def test_1b_security_options_reset(self):
+        o = self.tc.get_security_options()
+        # should not throw any exceptions
+        o.ciphers = o.ciphers
+        o.digests = o.digests
+        o.key_types = o.key_types
+        o.kex = o.kex
+        o.compression = o.compression
+
     def test_2_compute_key(self):
         self.tc.K = 123281095979686581523377256114209720774539068973101330872763622971399429481072519713536292772709507296759612401802191955568143056534122385270077606457721553469730659233569339356140085284052436697480759510519672848743794433460113118986816826624865291116513647975790797391795651716378444844877749505443714557929
         self.tc.H = b'\x0C\x83\x07\xCD\xE6\x85\x6F\xF3\x0B\xA9\x36\x84\xEB\x0F\x04\xC2\x52\x0E\x9E\xD3'


### PR DESCRIPTION
To support host keys of these key types, which are already in _preferred_keys! This fixes the bug pointed out in #900 where the security options setter would fail with the list of key types the getter returned. So you couldn't get `key_types`, re-order or trim the list, and then set that list, because it would contain an un-supported type (even though you didn't add any).

I'm splitting this out from #911 because I think this fix is appropriate for release branches of paramiko. (If this is approved, I'll backport it to 1.8 as well).