### PR TITLE
transport: change order of preferred kex and hmac algorithms

### DIFF
--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -120,10 +120,10 @@ class Transport(threading.Thread, ClosingContextManager):
     _preferred_macs = (
         'hmac-sha2-256',
         'hmac-sha2-512',
+        'hmac-sha1',
         'hmac-md5',
         'hmac-sha1-96',
         'hmac-md5-96',
-        'hmac-sha1',
     )
     _preferred_keys = (
         'ecdsa-sha2-nistp256',
@@ -134,13 +134,13 @@ class Transport(threading.Thread, ClosingContextManager):
         'ssh-dss',
     )
     _preferred_kex = (
-        'diffie-hellman-group1-sha1',
-        'diffie-hellman-group14-sha1',
-        'diffie-hellman-group-exchange-sha1',
-        'diffie-hellman-group-exchange-sha256',
         'ecdh-sha2-nistp256',
         'ecdh-sha2-nistp384',
         'ecdh-sha2-nistp521',
+        'diffie-hellman-group-exchange-sha256',
+        'diffie-hellman-group-exchange-sha1',
+        'diffie-hellman-group14-sha1',
+        'diffie-hellman-group1-sha1',
     )
     _preferred_compression = ('none',)
 


### PR DESCRIPTION
to match the openssh client

follow-up to https://github.com/paramiko/paramiko/pull/951#issuecomment-306587838

collected evidence:

> debug2: kex_parse_kexinit: curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group-exchange-sha1,diffie-hellman-group14-sha1,diffie-hellman-group1-sha1

> debug2: kex_parse_kexinit: umac-64-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha1-etm@openssh.com,umac-64@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-sha1,hmac-md5-etm@openssh.com,hmac-ripemd160-etm@openssh.com,hmac-sha1-96-etm@openssh.com,hmac-md5-96-etm@openssh.com,hmac-md5,hmac-ripemd160,hmac-ripemd160@openssh.com,hmac-sha1-96,hmac-md5-96

re: hmac-md5, hmac-sha1-96, and hmac-md5-96: probably not "insecure" or "dangerous" https://security.stackexchange.com/a/39761