### PR TITLE
Fix failure in listdir when server uses a locale (2.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,11 @@ python:
   - "3.5"
   - "3.6"
   - "pypy-5.4.1"
+addons:
+  apt:
+    packages:
+      # Include language pack for locale testing
+      - language-pack-ko
 install:
   # Self-install for setup.py-driven deps
   - pip install -e .

--- a/paramiko/py3compat.py
+++ b/paramiko/py3compat.py
@@ -1,5 +1,6 @@
-import sys
 import base64
+import sys
+import time
 
 __all__ = ['PY2', 'string_types', 'integer_types', 'text_type', 'bytes_types',
            'bytes', 'long', 'input', 'decodebytes', 'encodebytes',
@@ -10,6 +11,9 @@ __all__ = ['PY2', 'string_types', 'integer_types', 'text_type', 'bytes_types',
 PY2 = sys.version_info[0] < 3
 
 if PY2:
+    import __builtin__ as builtins
+    import locale
+
     string_types = basestring  # NOQA
     text_type = unicode  # NOQA
     bytes_types = str
@@ -19,8 +23,6 @@ if PY2:
     input = raw_input  # NOQA
     decodebytes = base64.decodestring
     encodebytes = base64.encodestring
-
-    import __builtin__ as builtins
 
 
     def bytestring(s):  # NOQA
@@ -96,6 +98,11 @@ if PY2:
         # 64-bit
         MAXSIZE = int((1 << 63) - 1)        # NOQA
     del X
+
+    def strftime(format, t):
+        """Same as time.strftime but returns unicode."""
+        _, encoding = locale.getlocale(locale.LC_TIME)
+        return time.strftime(format, t).decode(encoding or 'ascii')
 else:
     import collections
     import struct
@@ -162,3 +169,5 @@ else:
     next = next
 
     MAXSIZE = sys.maxsize       # NOQA
+
+    strftime = time.strftime    # NOQA

--- a/paramiko/sftp_attr.py
+++ b/paramiko/sftp_attr.py
@@ -19,7 +19,7 @@
 import stat
 import time
 from paramiko.common import x80000000, o700, o70, xffffffff
-from paramiko.py3compat import long, b
+from paramiko.py3compat import long, PY2, strftime
 
 
 class SFTPAttributes (object):
@@ -169,7 +169,7 @@ class SFTPAttributes (object):
             out += '-xSs'[suid + (n & 1)]
         return out
 
-    def __str__(self):
+    def _as_text(self):
         """create a unix-style long description of the file (like ls -l)"""
         if self.st_mode is not None:
             kind = stat.S_IFMT(self.st_mode)
@@ -202,13 +202,12 @@ class SFTPAttributes (object):
             # shouldn't really happen
             datestr = '(unknown date)'
         else:
+            time_tuple = time.localtime(self.st_mtime)
             if abs(time.time() - self.st_mtime) > 15552000:
                 # (15552000 = 6 months)
-                datestr = time.strftime(
-                    '%d %b %Y', time.localtime(self.st_mtime))
+                datestr = strftime('%d %b %Y', time_tuple)
             else:
-                datestr = time.strftime(
-                    '%d %b %H:%M', time.localtime(self.st_mtime))
+                datestr = strftime('%d %b %H:%M', time_tuple)
         filename = getattr(self, 'filename', '?')
 
         # not all servers support uid/gid
@@ -226,4 +225,10 @@ class SFTPAttributes (object):
             ks, uid, gid, size, datestr, filename)
 
     def asbytes(self):
-        return b(str(self))
+        return self._as_text().encode('utf-8')
+
+    if PY2:
+        __unicode__ = _as_text
+        __str__ = asbytes
+    else:
+        __str__ = _as_text

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -2,6 +2,9 @@
 Changelog
 =========
 
+* :bug:`985 (1.17+)` Fix listdir failure when server uses a locale. Now on
+  Python 2.7 `SFTPAttributes <paramiko.sftp_attr.SFTPAttributes>` will decode
+  abbreviated month names correctly rather than raise ``UnicodeDecodeError```.
 * :release:`2.0.6 <2017-06-09>`
 * :release:`1.18.3 <2017-06-09>`
 * :release:`1.17.5 <2017-06-09>`

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -18,6 +18,9 @@
 
 """Base classes and helpers for testing paramiko."""
 
+import functools
+import locale
+import os
 import unittest
 
 from paramiko.py3compat import (
@@ -37,3 +40,48 @@ def skipUnlessBuiltin(name):
     if getattr(builtins, name, None) is None:
         return skip("No builtin " + repr(name))
     return lambda func: func
+
+
+# List of locales which have non-ascii characters in all categories.
+# Omits most European languages which for instance may have only some months
+# with names that include accented characters.
+_non_ascii_locales = [
+    # East Asian locales
+    "ja_JP", "ko_KR", "zh_CN", "zh_TW",
+    # European locales with non-latin alphabets
+    "el_GR", "ru_RU", "uk_UA",
+]
+# Also include UTF-8 versions of these locales
+_non_ascii_locales.extend([name + ".utf8" for name in _non_ascii_locales])
+
+
+def requireNonAsciiLocale(category_name="LC_ALL"):
+    """Run decorated test under a non-ascii locale or skip if not possible."""
+    if os.name != "posix":
+        return skip("Non-posix OSes don't really use C locales")
+    cat = getattr(locale, category_name)
+    return functools.partial(_decorate_with_locale, cat, _non_ascii_locales)
+
+
+def _decorate_with_locale(category, try_locales, test_method):
+    """Decorate test_method to run after switching to a different locale."""
+
+    def _test_under_locale(testself):
+        original = locale.setlocale(category)
+        while try_locales:
+            try:
+                locale.setlocale(category, try_locales[0])
+            except locale.Error:
+                # Mutating original list is ok, setlocale would keep failing
+                try_locales.pop(0)
+            else:
+                try:
+                    return test_method(testself)
+                finally:
+                    locale.setlocale(category, original)
+        skipTest = getattr(testself, "skipTest", None)
+        if skipTest is not None:
+            skipTest("No usable locales installed")
+
+    functools.update_wrapper(_test_under_locale, test_method)
+    return _test_under_locale

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -25,12 +25,15 @@ from paramiko.py3compat import (
     )
 
 
+skip = getattr(unittest, "skip", None)
+if skip is None:
+    def skip(reason):
+        """Stub skip decorator for Python 2.6 compatibility."""
+        return lambda func: None
+
+
 def skipUnlessBuiltin(name):
     """Skip decorated test if builtin name does not exist."""
     if getattr(builtins, name, None) is None:
-        skip = getattr(unittest, "skip", None)
-        if skip is None:
-            # Python 2.6 pseudo-skip
-            return lambda func: None
         return skip("No builtin " + repr(name))
     return lambda func: func


### PR DESCRIPTION
Fixes #985

SFTPAttributes uses the locale-aware %b directive for the
abbreviated month name with time.strftime, but was not
decoding the result on Python 2.7.

Add a strftime alias in py3compat that will always return
unicode, and resolve the mixing of bytes and text in
SFTPAttributes methods.

Add a test at the listdir level, and a more specific test
for the SFTPAttributes asbytes method.