### PR TITLE
BACKPORT: Handle case when proxy command dies during a read

### DIFF
--- a/paramiko/proxy.py
+++ b/paramiko/proxy.py
@@ -80,6 +80,9 @@ class ProxyCommand(ClosingContextManager):
 
         :return: the string of bytes read, which may be shorter than requested
         """
+        if self.process.poll() is not None:
+            raise ProxyCommandFailure(' '.join(self.cmd), 'command died while trying to read')
+
         try:
             buffer = b''
             start = time.time()


### PR DESCRIPTION
If the proxy command dies during a read loop, we end up in a tight
loop that causes the process to max out a cpu until it's forcefully
killed.

In my experience, the easiest way to trigger this condition is to
use a proxy command and add some text to /etc/nologin on the
destination host (not the proxy host).

Another way to trigger this condition is to send a CTRL+C wile the
second command is running:

chan.exec_command('sleep 100')
stderr = chan.makefile_stderr('rb').read()