### PR TITLE
travis-ci: update pypy test run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "pypy-5.4.1"
+  - "pypy-5.6.0"
 install:
   # Self-install for setup.py-driven deps
   - pip install -e .


### PR DESCRIPTION
I found the magic incantation to get the full list of available python/pypy versions:
https://github.com/travis-ci/travis-ci/issues/6727#issuecomment-307186234

Hopefully this is faster and more reliable ...