### PR TITLE
Don't attempt to obtain server keys if not used

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -365,7 +365,7 @@ class SSHClient (ClosingContextManager):
 
         t.start_client(timeout=timeout)
 
-        if not self._transport.use_gss_kex:
+        if not self._transport.use_gss_kex and look_for_keys:
             server_key = t.get_remote_server_key()
             if our_server_keys is None:
                 # will raise exception if the key is rejected


### PR DESCRIPTION
When the parameter "look_for_keys" is False, the connect() method should not attempt to obtain the server key. Note that this fix also works all the way back to Paramiko 1.12.0, where lines 315-332 should be indented under "if look_for_keys:".
We have been using Paramiko with expensive Raritan Power Strips that are SSH enabled. These devices use "username" and "password" authentication. We have thousands of test devices on a subnet, and this proves to be the most convenient automated switching to use, and it's safe.
With our fix, connect() works correctly, and has been using this fix for 4 years. Please add it ASAP, as we're now installing your product using "pip install paramiko".  Thanks much!