### PR TITLE
getcwd return none

### DIFF
--- a/paramiko/sftp_client.py
+++ b/paramiko/sftp_client.py
@@ -626,6 +626,7 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
         .. versionadded:: 1.4
         """
         # TODO: make class initialize with self._cwd set to self.normalize('.')
+        if not self._cwd: chdir('.')
         return self._cwd and u(self._cwd)
 
     def _transfer_with_callback(self, reader, writer, file_size, callback):


### PR DESCRIPTION
when use paramiko, it is not easy to understand cwd is none
so we can give a default cwd to user