### PR TITLE
server: Support pre-authentication banners

### DIFF
--- a/paramiko/auth_handler.py
+++ b/paramiko/auth_handler.py
@@ -36,6 +36,7 @@ from paramiko.common import (
     cMSG_USERAUTH_GSSAPI_MIC, MSG_USERAUTH_GSSAPI_RESPONSE,
     MSG_USERAUTH_GSSAPI_TOKEN, MSG_USERAUTH_GSSAPI_ERROR,
     MSG_USERAUTH_GSSAPI_ERRTOK, MSG_USERAUTH_GSSAPI_MIC, MSG_NAMES,
+    cMSG_USERAUTH_BANNER
 )
 from paramiko.message import Message
 from paramiko.py3compat import bytestring
@@ -225,6 +226,13 @@ class AuthHandler (object):
             m.add_byte(cMSG_SERVICE_ACCEPT)
             m.add_string(service)
             self.transport._send_message(m)
+            banner, language = self.transport.server_object.get_banner()
+            if banner:
+                m = Message()
+                m.add_byte(cMSG_USERAUTH_BANNER)
+                m.add_string(banner)
+                m.add_string(language)
+                self.transport._send_message(m)
             return
         # dunno this one
         self._disconnect_service_not_available()

--- a/paramiko/server.py
+++ b/paramiko/server.py
@@ -570,6 +570,17 @@ class ServerInterface (object):
         """
         return False
 
+    def get_banner(self):
+        """
+        A pre-login banner to display to the user. The message may span
+        multiple lines separated by crlf pairs. The language should be in
+        rfc3066 style, for example: en-US
+
+        The default implementation always returns ``(None, None)``.
+
+        :returns: A tuple containing the banner and language code.
+        """
+        return (None, None)
 
 class InteractiveQuery (object):
     """


### PR DESCRIPTION
In the same project that caused me to file #946, I now need to send pre-authentication banners. Wasn't too hard to implement and I think it may be useful for others, hence another pull request :)