### PR TITLE
fixed bug: "UnicodeDecodeError: 'utf-8' codec ..."

### DIFF
--- a/paramiko/py3compat.py
+++ b/paramiko/py3compat.py
@@ -140,7 +140,7 @@ else:
     def u(s, encoding='utf8'):
         """cast bytes or unicode to unicode"""
         if isinstance(s, bytes):
-            return s.decode(encoding)
+            return s.decode(encoding,'ignore')
         elif isinstance(s, str):
             return s
         else:


### PR DESCRIPTION
There is an error reading stdout if contains any line with non utf-8 characters. The complete error is
 Traceback (most recent call last):
 File "/usr/local/lib/python3.4/dist-packages/flask/app.py", line 1997, in __call__
    return self.wsgi_app(environ, start_response)
  File "/usr/local/lib/python3.4/dist-packages/flask/app.py", line 1985, in wsgi_app
    response = self.handle_exception(e)
  File "/usr/local/lib/python3.4/dist-packages/flask/app.py", line 1540, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python3.4/dist-packages/flask/_compat.py", line 33, in reraise
    raise value
  File "/usr/local/lib/python3.4/dist-packages/flask/app.py", line 1982, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python3.4/dist-packages/flask/app.py", line 1614, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python3.4/dist-packages/flask/app.py", line 1517, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python3.4/dist-packages/flask/_compat.py", line 33, in reraise
    raise value
  File "/usr/local/lib/python3.4/dist-packages/flask/app.py", line 1612, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.4/dist-packages/flask/app.py", line 1598, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/carlos/python/netbeans/RemoteLog/remotelog/web/web.py", line 66, in detail
    result = search.search(server, request.form)
  File "/home/carlos/python/netbeans/RemoteLog/remotelog/web/searchremote.py", line 32, in search
    out = self.runCommand(server_remote,username,command,port,pathlog)
  File "/home/carlos/python/netbeans/RemoteLog/remotelog/web/searchremote.py", line 57, in runCommand
    for line in stdout:
  File "/usr/local/lib/python3.4/dist-packages/paramiko/file.py", line 117, in __next__
    line = self.readline()
  File "/usr/local/lib/python3.4/dist-packages/paramiko/file.py", line 312, in readline
    return line if self._flags & self.FLAG_BINARY else u(line)
  File "/usr/local/lib/python3.4/dist-packages/paramiko/py3compat.py", line 148, in u
    return s.decode(encoding)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xae in position 135: invalid start byte

I tried to catch this error to read the lines but it was not possible, because the error is in the last line:

stdin, stdout, stderr = client.exec_command(command,environment={'LANG':'en_US.utf8'})
        out = []
        textsize=0
        cont=0
        for line in stdout:

so I fixed like that.