### PR TITLE
hostkeys: fix raising KeyError in SubDict.__delitem__()

### DIFF
--- a/paramiko/hostkeys.py
+++ b/paramiko/hostkeys.py
@@ -151,6 +151,7 @@ class HostKeys (MutableMapping):
                 for e in list(self._entries):
                     if e.key.get_name() == key:
                         self._entries.remove(e)
+                        break
                 else:
                     raise KeyError(key)
 

--- a/tests/test_hostkeys.py
+++ b/tests/test_hostkeys.py
@@ -127,3 +127,20 @@ class HostKeysTest (unittest.TestCase):
             pass # Good
         else:
             assert False, "Entry was not deleted from HostKeys on delitem!"
+
+    def test_entry_delitem(self):
+        hostdict = paramiko.HostKeys('hostfile.temp')
+        target = 'happy.example.com'
+        entry = hostdict[target]
+        key_type_list = [ key_type for key_type in entry ]
+        for key_type in key_type_list:
+            del entry[key_type]
+
+        # will KeyError if not present
+        for key_type in key_type_list:
+            try:
+                del entry[key_type]
+            except KeyError:
+                pass # Good
+            else:
+                assert False, "Key was not deleted from Entry on delitem!"


### PR DESCRIPTION
If the specified key type is found out, the exception KeyError should
not happen.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>