### PR TITLE
Adding connect_timeout kwargs in Transport __init__

### DIFF
--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -288,7 +288,7 @@ class Transport(threading.Thread, ClosingContextManager):
             arguments.
         """
 
-        connect_timeout = kwargs.get('connect_timeout')
+        conn_timeout = kwargs.get('connect_timeout')
 
         self.active = False
 
@@ -312,8 +312,8 @@ class Transport(threading.Thread, ClosingContextManager):
                     # addr = sockaddr
                     sock = socket.socket(af, socket.SOCK_STREAM)
                     try:
-                        if connect_timeout and isinstance( connect_timeout, int ):
-                            sock.settimeout(connect_timeout)
+                        if conn_timeout and isinstance(conn_timeout, int):
+                            sock.settimeout(conn_timeout)
 
                         retry_on_signal(lambda: sock.connect((hostname, port)))
                     except socket.error as e:

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -241,7 +241,8 @@ class Transport(threading.Thread, ClosingContextManager):
                  default_window_size=DEFAULT_WINDOW_SIZE,
                  default_max_packet_size=DEFAULT_MAX_PACKET_SIZE,
                  gss_kex=False,
-                 gss_deleg_creds=True):
+                 gss_deleg_creds=True,
+                 **kwargs):
         """
         Create a new SSH session over an existing socket, or socket-like
         object.  This only creates the `.Transport` object; it doesn't begin
@@ -286,6 +287,9 @@ class Transport(threading.Thread, ClosingContextManager):
             Added the ``default_window_size`` and ``default_max_packet_size``
             arguments.
         """
+
+        connect_timeout = kwargs.get('connect_timeout')
+
         self.active = False
 
         if isinstance(sock, string_types):
@@ -308,6 +312,9 @@ class Transport(threading.Thread, ClosingContextManager):
                     # addr = sockaddr
                     sock = socket.socket(af, socket.SOCK_STREAM)
                     try:
+                        if connect_timeout and isinstance( connect_timeout, int ):
+                            sock.settimeout(connect_timeout)
+
                         retry_on_signal(lambda: sock.connect((hostname, port)))
                     except socket.error as e:
                         reason = str(e)


### PR DESCRIPTION
I had a problem where I would create a Transport object with a wrong port in socket tuple argument, and the object initialization would hang indefinitely.

I was using the Transport object in order to connect to an SFTP server, as per this : 
https://stackoverflow.com/questions/3635131/paramikos-sshclient-with-sftp

I have added a connect_timeout kwargs in the __init__ method. 

If you don't like kwargs, I can use a positional argument.

