### PR TITLE
Add file_obj handling to the Ed25519Key constructor

### DIFF
--- a/paramiko/ed25519key.py
+++ b/paramiko/ed25519key.py
@@ -45,7 +45,8 @@ def unpad(data):
 
 
 class Ed25519Key(PKey):
-    def __init__(self, msg=None, data=None, filename=None, password=None):
+    def __init__(self, msg=None, data=None, filename=None, password=None,
+                 file_obj=None):
         verifying_key = signing_key = None
         if msg is None and data is not None:
             msg = Message(data)
@@ -56,7 +57,11 @@ class Ed25519Key(PKey):
         elif filename is not None:
             with open(filename, "r") as f:
                 data = self._read_private_key("OPENSSH", f)
-                signing_key = self._parse_signing_key_data(data, password)
+        elif file_obj is not None:
+            data = self._read_private_key("OPENSSH", file_obj)
+
+        if filename or file_obj:
+            signing_key = self._parse_signing_key_data(data, password)
 
         if signing_key is None and verifying_key is None:
             raise ValueError("need a key")

--- a/tests/test_pkey.py
+++ b/tests/test_pkey.py
@@ -466,6 +466,12 @@ class KeyTest(unittest.TestCase):
         self.assertTrue(not pub.can_sign())
         self.assertEqual(key, pub)
 
+    def test_ed25519_load_from_file_obj(self):
+        with open(test_path('test_ed25519.key')) as pkey_fileobj:
+            key = Ed25519Key.from_private_key(pkey_fileobj)
+            self.assertEqual(key, key)
+            self.assertTrue(key.can_sign())
+
     def test_keyfile_is_actually_encrypted(self):
         # Read an existing encrypted private key
         file_ = test_path('test_rsa_password.key')

--- a/tests/test_pkey.py
+++ b/tests/test_pkey.py
@@ -469,8 +469,8 @@ class KeyTest(unittest.TestCase):
     def test_ed25519_load_from_file_obj(self):
         with open(test_path('test_ed25519.key')) as pkey_fileobj:
             key = Ed25519Key.from_private_key(pkey_fileobj)
-            self.assertEqual(key, key)
-            self.assertTrue(key.can_sign())
+        self.assertEqual(key, key)
+        self.assertTrue(key.can_sign())
 
     def test_keyfile_is_actually_encrypted(self):
         # Read an existing encrypted private key


### PR DESCRIPTION
This PR fixes `Ed25519Key.from_private_key`.