### PR TITLE
Slow performance when using compression #60

### DIFF
--- a/paramiko/compress.py
+++ b/paramiko/compress.py
@@ -25,7 +25,8 @@ import zlib
 
 class ZlibCompressor (object):
     def __init__(self):
-        self.z = zlib.compressobj(9)
+        # Use the default level of zlib compression
+        self.z = zlib.compressobj()
 
     def __call__(self, data):
         return self.z.compress(data) + self.z.flush(zlib.Z_FULL_FLUSH)

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -2,6 +2,9 @@
 Changelog
 =========
 
+* :bug:`60` Improved the performance of compressed transport by using default
+  zlib compression level (which is 6) rather than the max level of 9 which is
+  very CPU intensive.
 * :support:`1012` (via :issue:`1016`) Enhance documentation around the new
   `SFTP.posix_rename <paramiko.sftp_client.SFTPClient.posix_rename>` method so
   it's referenced in the 'standard' ``rename`` method for increased visibility.


### PR DESCRIPTION
Looking at the performance of Paramiko when trying to copy a 1.3Gb CSV file, to be moved between two machines connected by a 100Mbps lan segment.  The root cause of the slow performance with compression is in the choice of compression level in paramiko/paramiko/compress.py

lib Compression level | Time to send (secs) | Data over WAN MBytes | Compression %
-- | -- | -- | --
0 | 117 | 1,301 | 0%
1 | 33 | 317 | 76%
2 | 35 | 291 | 78%
3 | 37 | 269 | 79%
4 | 41 | 266 | 80%
5 | 53 | 245 | 81%
6 | 64 | 232 | 82%
7 | 74 | 227 | 83%
8 | 159 | 221 | 83%
9 | 278 | 219 | 83%

The change here is to use the default level of zlib compression (6) rather than the max of 9 which is a bad trade off in CPU and time vs the actual gain on compression

