### PR TITLE
always log socket.error with str() or repr()

### DIFF
--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -372,7 +372,7 @@ class Transport(threading.Thread, ClosingContextManager):
                     try:
                         retry_on_signal(lambda: sock.connect((hostname, port)))
                     except socket.error as e:
-                        reason = str(e)
+                        reason = str(e) or repr(e)
                     else:
                         break
             else:
@@ -2068,14 +2068,7 @@ class Transport(threading.Thread, ClosingContextManager):
                 self._log(DEBUG, "EOF in transport thread")
                 self.saved_exception = e
             except socket.error as e:
-                if type(e.args) is tuple:
-                    if e.args:
-                        emsg = "{} ({:d})".format(e.args[1], e.args[0])
-                    else:  # empty tuple, e.g. socket.timeout
-                        emsg = str(e) or repr(e)
-                else:
-                    emsg = e.args
-                self._log(ERROR, "Socket exception: " + emsg)
+                self._log(ERROR, "Socket exception: " + (str(e) or repr(e)))
                 self.saved_exception = e
             except Exception as e:
                 self._log(ERROR, "Unknown exception: " + str(e))


### PR DESCRIPTION
on rare occasion, assuming the tuple had two parts caused an exception

but no need to format the 2-tuple into a message anyway,
the class can do that itself

still fallback to repr() because I think I've seen empty str() result,
on very rare occasion

fixes #1046  and also just simplifies the code

I based this on 2.0 but it should be fine to re-target it to a later 2.x branch