### PR TITLE
ensure ed25519 password is bytes

### DIFF
--- a/paramiko/ed25519key.py
+++ b/paramiko/ed25519key.py
@@ -25,6 +25,7 @@ import six
 
 from paramiko.message import Message
 from paramiko.pkey import PKey
+from paramiko.py3compat import b
 from paramiko.ssh_exception import SSHException, PasswordRequiredException
 
 
@@ -113,7 +114,7 @@ class Ed25519Key(PKey):
         else:
             cipher = Transport._cipher_info[ciphername]
             key = bcrypt.kdf(
-                password=password,
+                password=b(password),
                 salt=bcrypt_salt,
                 desired_key_bytes=cipher["key-size"] + cipher["block-size"],
                 rounds=bcrypt_rounds,

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -2,6 +2,9 @@
 Changelog
 =========
 
+* :bug:`1039` Ed25519 auth key decryption raised an unexpected exception when
+  given a unicode password string (typical in python 3).
+  Report by Theodor van Nahl and fix by Pierce Lopez.
 * :support:`1012` (via :issue:`1016`) Enhance documentation around the new
   `SFTP.posix_rename <paramiko.sftp_client.SFTPClient.posix_rename>` method so
   it's referenced in the 'standard' ``rename`` method for increased visibility.


### PR DESCRIPTION
fixes #1039 

Side Note: I just noticed that this file imports "six", even though that's not explicitly a requirement in setup.py (but it's a requirement of cryptography)