### PR TITLE
Transport: fix the preferred KEX algorithms for gssapi-keyex (2.0)

### DIFF
--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -132,6 +132,11 @@ class Transport(threading.Thread, ClosingContextManager):
         'diffie-hellman-group-exchange-sha1',
         'diffie-hellman-group-exchange-sha256',
     )
+    _preferred_gsskex = (
+        'gss-gex-sha1-toWM5Slw5Ew8Mqkay+al2g==',
+        'gss-group14-sha1-toWM5Slw5Ew8Mqkay+al2g==',
+        'gss-group1-sha1-toWM5Slw5Ew8Mqkay+al2g==',
+    )
     _preferred_compression = ('none',)
 
     _cipher_info = {
@@ -333,12 +338,7 @@ class Transport(threading.Thread, ClosingContextManager):
         self.gss_host = None
         if self.use_gss_kex:
             self.kexgss_ctxt = GSSAuth("gssapi-keyex", gss_deleg_creds)
-            self._preferred_kex = ('gss-gex-sha1-toWM5Slw5Ew8Mqkay+al2g==',
-                                   'gss-group14-sha1-toWM5Slw5Ew8Mqkay+al2g==',
-                                   'gss-group1-sha1-toWM5Slw5Ew8Mqkay+al2g==',
-                                   'diffie-hellman-group-exchange-sha1',
-                                   'diffie-hellman-group14-sha1',
-                                   'diffie-hellman-group1-sha1')
+            self._preferred_kex = self._preferred_gsskex + self._preferred_kex
 
         # state used during negotiation
         self.kex_engine = None


### PR DESCRIPTION
Add additional KEX algorithms for gssapi-keyex in front of the
default preferred KEX algorithms, if gssapi-keyex is enabled.

Before this change, Transport used a hard coded (and out-dated) list of
algorithms, if gssapi-keyex was enabled.