### PR TITLE
gssauth trickledown fix (2.0)

### DIFF
--- a/paramiko/__init__.py
+++ b/paramiko/__init__.py
@@ -34,7 +34,7 @@ from paramiko.client import (
     WarningPolicy,
 )
 from paramiko.auth_handler import AuthHandler
-from paramiko.ssh_gss import GSSAuth, GSS_AUTH_AVAILABLE
+from paramiko.ssh_gss import GSSAuth, GSS_AUTH_AVAILABLE, GSS_EXCEPTIONS
 from paramiko.channel import Channel, ChannelFile
 from paramiko.ssh_exception import (
     SSHException, PasswordRequiredException, BadAuthenticationType,

--- a/paramiko/auth_handler.py
+++ b/paramiko/auth_handler.py
@@ -503,52 +503,13 @@ class AuthHandler (object):
             supported_mech = sshgss.ssh_gss_oids("server")
             # RFC 4462 says we are not required to implement GSS-API error
             # messages. See section 3.8 in http://www.ietf.org/rfc/rfc4462.txt
-            while True:
-                m = Message()
-                m.add_byte(cMSG_USERAUTH_GSSAPI_RESPONSE)
-                m.add_bytes(supported_mech)
-                self.transport._send_message(m)
-                ptype, m = self.transport.packetizer.read_message()
-                if ptype == MSG_USERAUTH_GSSAPI_TOKEN:
-                    client_token = m.get_string()
-                    # use the client token as input to establish a secure
-                    # context.
-                    try:
-                        token = sshgss.ssh_accept_sec_context(self.gss_host,
-                                                              client_token,
-                                                              username)
-                    except Exception:
-                        result = AUTH_FAILED
-                        self._send_auth_result(username, method, result)
-                        raise
-                    if token is not None:
-                        m = Message()
-                        m.add_byte(cMSG_USERAUTH_GSSAPI_TOKEN)
-                        m.add_string(token)
-                        self.transport._send_message(m)
-                else:
-                    result = AUTH_FAILED
-                    self._send_auth_result(username, method, result)
-                    return
-                # check MIC
-                ptype, m = self.transport.packetizer.read_message()
-                if ptype == MSG_USERAUTH_GSSAPI_MIC:
-                    break
-            mic_token = m.get_string()
-            try:
-                sshgss.ssh_check_mic(mic_token,
-                                     self.transport.session_id,
-                                     username)
-            except Exception:
-                result = AUTH_FAILED
-                self._send_auth_result(username, method, result)
-                raise
-            # TODO: Implement client credential saving.
-            # The OpenSSH server is able to create a TGT with the delegated
-            # client credentials, but this is not supported by GSS-API.
-            result = AUTH_SUCCESSFUL
-            self.transport.server_object.check_auth_gssapi_with_mic(
-                username, result)
+            m = Message()
+            m.add_byte(cMSG_USERAUTH_GSSAPI_RESPONSE)
+            m.add_bytes(supported_mech)
+            self.transport.auth_handler = GssapiWithMicAuthHandler(self, sshgss)
+            self.transport._expected_packet = (MSG_USERAUTH_GSSAPI_TOKEN, MSG_USERAUTH_REQUEST, MSG_SERVICE_REQUEST)
+            self.transport._send_message(m)
+            return
         elif method == "gssapi-keyex" and gss_auth:
             mic_token = m.get_string()
             sshgss = self.transport.kexgss_ctxt
@@ -657,4 +618,102 @@ class AuthHandler (object):
         MSG_USERAUTH_BANNER: _parse_userauth_banner,
         MSG_USERAUTH_INFO_REQUEST: _parse_userauth_info_request,
         MSG_USERAUTH_INFO_RESPONSE: _parse_userauth_info_response,
+    }
+
+
+class GssapiWithMicAuthHandler(object):
+    """A specialized Auth handler for gssapi-with-mic
+
+    During the GSSAPI token exchange we need a modified dispatch table,
+    because the packet type numbers are not unique.
+    """
+
+    method = "gssapi-with-mic"
+
+    def __init__(self, delegate, sshgss):
+        self._delegate = delegate
+        self.sshgss = sshgss
+
+    def abort(self):
+        self._restore_delegate_auth_handler()
+        return self._delegate.abort()
+
+    @property
+    def transport(self):
+        return self._delegate.transport
+
+    @property
+    def _send_auth_result(self):
+        return self._delegate._send_auth_result
+
+    @property
+    def auth_username(self):
+        return self._delegate.auth_username
+
+    @property
+    def gss_host(self):
+        return self._delegate.gss_host
+
+    def _restore_delegate_auth_handler(self):
+        self.transport.auth_handler = self._delegate
+
+    def _parse_userauth_gssapi_token(self, m):
+        client_token = m.get_string()
+        # use the client token as input to establish a secure
+        # context.
+        sshgss = self.sshgss
+        try:
+            token = sshgss.ssh_accept_sec_context(self.gss_host,
+                                                  client_token,
+                                                  self.auth_username)
+        except Exception as e:
+            self.transport.saved_exception = e
+            result = AUTH_FAILED
+            self._restore_delegate_auth_handler()
+            self._send_auth_result(self.auth_username, self.method, result)
+            raise
+        if token is not None:
+            m = Message()
+            m.add_byte(cMSG_USERAUTH_GSSAPI_TOKEN)
+            m.add_string(token)
+            self.transport._expected_packet = (MSG_USERAUTH_GSSAPI_TOKEN,
+                                               MSG_USERAUTH_GSSAPI_MIC,
+                                               MSG_USERAUTH_REQUEST)
+            self.transport._send_message(m)
+
+    def _parse_userauth_gssapi_mic(self, m):
+        mic_token = m.get_string()
+        sshgss = self.sshgss
+        username = self.auth_username
+        self._restore_delegate_auth_handler()
+        try:
+            sshgss.ssh_check_mic(mic_token,
+                                 self.transport.session_id,
+                                 username)
+        except Exception as e:
+            self.transport.saved_exception = e
+            result = AUTH_FAILED
+            self._send_auth_result(username, self.method, result)
+            raise
+        # TODO: Implement client credential saving.
+        # The OpenSSH server is able to create a TGT with the delegated
+        # client credentials, but this is not supported by GSS-API.
+        result = AUTH_SUCCESSFUL
+        self.transport.server_object.check_auth_gssapi_with_mic(username, result)
+        # okay, send result
+        self._send_auth_result(username, self.method, result)
+
+    def _parse_service_request(self, m):
+        self._restore_delegate_auth_handler()
+        return self._delegate._parse_service_request(m)
+
+    def _parse_userauth_request(self, m):
+        self._restore_delegate_auth_handler()
+        return self._delegate._parse_userauth_request(m)
+
+    _handler_table = {
+        MSG_SERVICE_REQUEST: _parse_service_request,
+        MSG_USERAUTH_REQUEST: _parse_userauth_request,
+        MSG_USERAUTH_GSSAPI_TOKEN: _parse_userauth_gssapi_token,
+        MSG_USERAUTH_GSSAPI_MIC: _parse_userauth_gssapi_mic,
     }

--- a/paramiko/auth_handler.py
+++ b/paramiko/auth_handler.py
@@ -263,9 +263,10 @@ class AuthHandler (object):
                     m = Message()
                     m.add_byte(cMSG_USERAUTH_GSSAPI_TOKEN)
                     try:
-                        m.add_string(sshgss.ssh_init_sec_context(self.gss_host,
-                                                                 mech,
-                                                                 self.username,))
+                        m.add_string(sshgss.ssh_init_sec_context(
+                            self.gss_host,
+                            mech,
+                            self.username,))
                     except GSS_EXCEPTIONS as e:
                         return self._handle_local_gss_failure(e)
                     self.transport._send_message(m)
@@ -274,10 +275,11 @@ class AuthHandler (object):
                         if ptype == MSG_USERAUTH_GSSAPI_TOKEN:
                             srv_token = m.get_string()
                             try:
-                                next_token = sshgss.ssh_init_sec_context(self.gss_host,
-                                                                         mech,
-                                                                         self.username,
-                                                                         srv_token)
+                                next_token = sshgss.ssh_init_sec_context(
+                                    self.gss_host,
+                                    mech,
+                                    self.username,
+                                    srv_token)
                             except GSS_EXCEPTIONS as e:
                                 return self._handle_local_gss_failure(e)
                             # After this step the GSSAPI should not return any
@@ -307,7 +309,7 @@ class AuthHandler (object):
                     maj_status = m.get_int()
                     min_status = m.get_int()
                     err_msg = m.get_string()
-                    m.get_string() # Lang tag - discarded
+                    m.get_string()  # Lang tag - discarded
                     raise SSHException("GSS-API Error:\nMajor Status: %s\n\
                                         Minor Status: %s\ \nError Message:\
                                          %s\n") % (str(maj_status),
@@ -400,7 +402,7 @@ class AuthHandler (object):
                 (self.auth_username != username)):
             self.transport._log(
                 WARNING,
-                'Auth rejected because the client attempted to change username in mid-flight' # noqa
+                'Auth rejected because the client attempted to change username in mid-flight'  # noqa
             )
             self._disconnect_no_more_auth()
             return
@@ -511,8 +513,11 @@ class AuthHandler (object):
             m = Message()
             m.add_byte(cMSG_USERAUTH_GSSAPI_RESPONSE)
             m.add_bytes(supported_mech)
-            self.transport.auth_handler = GssapiWithMicAuthHandler(self, sshgss)
-            self.transport._expected_packet = (MSG_USERAUTH_GSSAPI_TOKEN, MSG_USERAUTH_REQUEST, MSG_SERVICE_REQUEST)
+            self.transport.auth_handler = GssapiWithMicAuthHandler(self,
+                                                                   sshgss)
+            self.transport._expected_packet = (MSG_USERAUTH_GSSAPI_TOKEN,
+                                               MSG_USERAUTH_REQUEST,
+                                               MSG_SERVICE_REQUEST)
             self.transport._send_message(m)
             return
         elif method == "gssapi-keyex" and gss_auth:
@@ -617,7 +622,8 @@ class AuthHandler (object):
     def _handle_local_gss_failure(self, e):
         self.transport.saved_exception = e
         self.transport._log(DEBUG, "GSSAPI failure: %s" % str(e))
-        self.transport._log(INFO, 'Authentication (%s) failed.' % self.auth_method)
+        self.transport._log(INFO, 'Authentication (%s) failed.' %
+                            self.auth_method)
         self.authenticated = False
         self.username = None
         if self.auth_event is not None:
@@ -714,7 +720,8 @@ class GssapiWithMicAuthHandler(object):
         # The OpenSSH server is able to create a TGT with the delegated
         # client credentials, but this is not supported by GSS-API.
         result = AUTH_SUCCESSFUL
-        self.transport.server_object.check_auth_gssapi_with_mic(username, result)
+        self.transport.server_object.check_auth_gssapi_with_mic(username,
+                                                                result)
         # okay, send result
         self._send_auth_result(username, self.method, result)
 

--- a/paramiko/ssh_gss.py
+++ b/paramiko/ssh_gss.py
@@ -39,11 +39,15 @@ import sys
 """
 GSS_AUTH_AVAILABLE = True
 
+"""
+:var tuple GSS_EXCEPTIONS:
+    The exception types used by the underlying GSSAPI implementation.
+"""
+GSS_EXCEPTIONS = ()
+
 from pyasn1.type.univ import ObjectIdentifier
 from pyasn1.codec.der import encoder, decoder
 
-from paramiko.common import MSG_USERAUTH_REQUEST
-from paramiko.ssh_exception import SSHException
 
 """
 :var str _API: Constraint for the used API
@@ -52,14 +56,20 @@ _API = "MIT"
 
 try:
     import gssapi
+    GSS_EXCEPTIONS = (gssapi.GSSException,)
 except (ImportError, OSError):
     try:
+        import pywintypes
         import sspicon
         import sspi
         _API = "SSPI"
+        GSS_EXCEPTIONS = (pywintypes.error,)
     except ImportError:
         GSS_AUTH_AVAILABLE = False
         _API = None
+
+from paramiko.common import MSG_USERAUTH_REQUEST
+from paramiko.ssh_exception import SSHException
 
 
 def GSSAuth(auth_method, gss_deleg_creds=True):
@@ -438,9 +448,10 @@ class _SSH_SSPI(_SSH_GSSAuth):
                                                  targetspn=targ_name)
             error, token = self._gss_ctxt.authorize(recv_token)
             token = token[0].Buffer
-        except:
-            raise Exception("{0}, Target: {1}".format(sys.exc_info()[1],
-                                                      self._gss_host))
+        except pywintypes.error as e:
+            e.strerror += ", Target: {1}".format(e, self._gss_host)
+            raise
+
         if error == 0:
             """
             if the status is GSS_COMPLETE (error = 0) the context is fully

--- a/paramiko/ssh_gss.py
+++ b/paramiko/ssh_gss.py
@@ -33,25 +33,20 @@ import struct
 import os
 import sys
 
-"""
-:var bool GSS_AUTH_AVAILABLE:
-    Constraint that indicates if GSS-API / SSPI is available.
-"""
+
+#: A boolean constraint that indicates if GSS-API / SSPI is available.
 GSS_AUTH_AVAILABLE = True
 
-"""
-:var tuple GSS_EXCEPTIONS:
-    The exception types used by the underlying GSSAPI implementation.
-"""
+
+#: A tuple of the exception types used by the underlying GSSAPI implementation.
 GSS_EXCEPTIONS = ()
+
 
 from pyasn1.type.univ import ObjectIdentifier
 from pyasn1.codec.der import encoder, decoder
 
 
-"""
-:var str _API: Constraint for the used API
-"""
+#: :var str _API: Constraint for the used API
 _API = "MIT"
 
 try:
@@ -355,9 +350,9 @@ class _SSH_GSSAPI(_SSH_GSSAuth):
         if self._username is not None:
             # server mode
             mic_field = self._ssh_build_mic(self._session_id,
-                                        self._username,
-                                        self._service,
-                                        self._auth_method)
+                                            self._username,
+                                            self._service,
+                                            self._auth_method)
             self._gss_srv_ctxt.verify_mic(mic_field, mic_token)
         else:
             # for key exchange with gssapi-keyex

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -1838,6 +1838,8 @@ class Transport(threading.Thread, ClosingContextManager):
                     ):
                         handler = self.auth_handler._handler_table[ptype]
                         handler(self.auth_handler, m)
+                        if len(self._expected_packet) > 0:
+                            continue
                     else:
                         self._log(WARNING, 'Oops, unhandled type %d' % ptype)
                         msg = Message()


### PR DESCRIPTION
AuthHandler: handle "gssapi-with-mic" errors

Paramiko now tries other authentication methods, if "gssapi-with-mic" authentication fails (i.e. no kerberos ticket). Before this change, any failure of GSSAPI token exchange caused the transport to be closed.