### PR TITLE
Fix gss_host setting and cleanup its logic

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -354,9 +354,11 @@ class SSHClient (ClosingContextManager):
         )
         t.use_compression(compress=compress)
         t.set_gss_host(
-            kex_requested=gss_kex,
-            gss_host=gss_host,
+            # t.hostname may be None, but GSS-API requires a target name.
+            # Therefore use hostname as fallback.
+            gss_host=gss_host or hostname,
             trust_dns=gss_trust_dns,
+            gssapi_requested=gss_auth or gss_kex,
         )
         if self._log_channel is not None:
             t.set_log_channel(self._log_channel)


### PR DESCRIPTION
The parameter ``kex_requested`` is misleading, since setting ``gss_host``
is also required for gssapi-with-mic.  
Also, I changed the parameter order of ``set_gss_host()`` to preserve backwards compatibility.