### PR TITLE
Fix rekeying with GSS-API key exchange

### DIFF
--- a/paramiko/kex_gss.py
+++ b/paramiko/kex_gss.py
@@ -206,15 +206,14 @@ class KexGSSGroup1(object):
         hm.add_mpint(self.e)
         hm.add_mpint(self.f)
         hm.add_mpint(K)
-        self.transport._set_K_H(K, sha1(str(hm)).digest())
+        H = sha1(str(hm)).digest()
+        self.transport._set_K_H(K, H)
         if srv_token is not None:
             self.kexgss.ssh_init_sec_context(target=self.gss_host,
                                              recv_token=srv_token)
-            self.kexgss.ssh_check_mic(mic_token,
-                                      self.transport.session_id)
+            self.kexgss.ssh_check_mic(mic_token, H)
         else:
-            self.kexgss.ssh_check_mic(mic_token,
-                                      self.transport.session_id)
+            self.kexgss.ssh_check_mic(mic_token, H)
         self.transport.gss_kex_used = True
         self.transport._activate_outbound()
 
@@ -583,11 +582,9 @@ class KexGSSGex(object):
         if srv_token is not None:
             self.kexgss.ssh_init_sec_context(target=self.gss_host,
                                              recv_token=srv_token)
-            self.kexgss.ssh_check_mic(mic_token,
-                                      self.transport.session_id)
+            self.kexgss.ssh_check_mic(mic_token, H)
         else:
-            self.kexgss.ssh_check_mic(mic_token,
-                                      self.transport.session_id)
+            self.kexgss.ssh_check_mic(mic_token, H)
         self.transport.gss_kex_used = True
         self.transport._activate_outbound()
 

--- a/tests/test_kex_gss.py
+++ b/tests/test_kex_gss.py
@@ -93,7 +93,7 @@ class GSSKexTest(unittest.TestCase):
         server = NullServer()
         self.ts.start_server(self.event, server)
 
-    def test_1_gsskex_and_auth(self):
+    def _test_gsskex_and_auth(self, gss_host, rekey=False):
         """
         Verify that Paramiko can handle SSHv2 GSS-API / SSPI authenticated
         Diffie-Hellman Key Exchange and user authentication with the GSS-API
@@ -106,16 +106,19 @@ class GSSKexTest(unittest.TestCase):
         self.tc.get_host_keys().add('[%s]:%d' % (self.hostname, self.port),
                                     'ssh-rsa', public_host_key)
         self.tc.connect(self.hostname, self.port, username=self.username,
-                        gss_auth=True, gss_kex=True)
+                        gss_auth=True, gss_kex=True, gss_host=gss_host)
 
         self.event.wait(1.0)
         self.assert_(self.event.is_set())
         self.assert_(self.ts.is_active())
         self.assertEquals(self.username, self.ts.get_username())
         self.assertEquals(True, self.ts.is_authenticated())
+        self.assertEquals(True, self.tc.get_transport().gss_kex_used)
 
         stdin, stdout, stderr = self.tc.exec_command('yes')
         schan = self.ts.accept(1.0)
+        if rekey:
+            self.tc.get_transport().renegotiate_keys()
 
         schan.send('Hello there.\n')
         schan.send_stderr('This is on stderr.\n')
@@ -129,3 +132,17 @@ class GSSKexTest(unittest.TestCase):
         stdin.close()
         stdout.close()
         stderr.close()
+
+    def test_1_gsskex_and_auth(self):
+        """
+        Verify that Paramiko can handle SSHv2 GSS-API / SSPI authenticated
+        Diffie-Hellman Key Exchange and user authentication with the GSS-API
+        context created during key exchange.
+        """
+        self._test_gsskex_and_auth(gss_host=None)
+
+    def test_2_gsskex_and_auth_rekey(self):
+        """
+        Verify that Paramiko can rekey.
+        """
+        self._test_gsskex_and_auth(gss_host=None, rekey=True)


### PR DESCRIPTION
A mandatory feature of the SSH protocol does not work with GSS-API key exchange. Any attempt to renegotiate the transport keys for a gss-kex type transport causes a MIC failure and closes transport. Because ssh initiates a rekey operation after the transfer of 1 GB data, this bug can be a serious problem.

In ``kex_gss.py`` the MIC of the transport session ID (H of the initial kex) was checked against the MIC of the new H created during rekey.   
Now the MIC verification is always performed for the hash H created during kex.

This pull should fix the bug. Also, there is a test case for rekeying with GSS-API created by @akruis.