### PR TITLE
Transport.connect(): fix host key test

### DIFF
--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -1125,7 +1125,7 @@ class Transport(threading.Thread, ClosingContextManager):
         # check host key if we were given one
         # If GSS-API Key Exchange was performed, we are not required to check
         # the host key.
-        if (hostkey is not None) and not gss_kex:
+        if (hostkey is not None) and not self.gss_kex_used:
             key = self.get_remote_server_key()
             if (
                 key.get_name() != hostkey.get_name() or


### PR DESCRIPTION
Skip the host key check in ``Transport.connect()`` only, if the transport actually used gssapi-keyex.

Before this change, a MITM attack on the paramiko ssh client with ``gss_kex=True`` was possible by having a server that does not support gssapi-keyex and gives any or no host key.

This pull fixes the same issue as #1059, but for ``Transport.connect()``.