### PR TITLE
Smartcard pkcs11 support - refactor for code quality

### DIFF
--- a/paramiko/__init__.py
+++ b/paramiko/__init__.py
@@ -28,7 +28,6 @@ __author__ = "Jeff Forcier <jeff@bitprophet.org>"
 __license__ = "GNU Lesser General Public License (LGPL)"
 
 
-from paramiko.pkcs11 import pkcs11_open_session, pkcs11_close_session
 from paramiko.transport import SecurityOptions, Transport
 from paramiko.client import (
     SSHClient, MissingHostKeyPolicy, AutoAddPolicy, RejectPolicy,
@@ -115,6 +114,4 @@ __all__ = [
     'SSHConfig',
     'util',
     'io_sleep',
-    'pkcs11_open_session',
-    'pkcs11_close_session',
 ]

--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -227,7 +227,7 @@ class SSHClient(ClosingContextManager):
         gss_deleg_creds=True,
         gss_host=None,
         banner_timeout=None,
-        pkcs11session=None,
+        pkcs11_session=None,
         auth_timeout=None,
     ):
         """
@@ -295,8 +295,8 @@ class SSHClient(ClosingContextManager):
         :param float banner_timeout: an optional timeout (in seconds) to wait
             for the SSH banner to be presented.
         :param str pkcs11_session: The PKCS#11 session obtained by calling
-            `pkcs11.open_session`. Note that the caller is responsible for
-            calling `pkcs11.close_session` with that object at shutdown, as it
+            `.pkcs11.open_session`. Note that the caller is responsible for
+            calling `.pkcs11.close_session` with that object at shutdown, as it
             may be reused between multiple clients.
         :param float auth_timeout: an optional timeout (in seconds) to wait for
             an authentication response.
@@ -411,7 +411,7 @@ class SSHClient(ClosingContextManager):
             gss_host = hostname
         self._auth(username, password, pkey, key_filenames, allow_agent,
                    look_for_keys, gss_auth, gss_kex, gss_deleg_creds, gss_host,
-                   pkcs11session)
+                   pkcs11_session)
 
     def close(self):
         """
@@ -553,7 +553,7 @@ class SSHClient(ClosingContextManager):
 
     def _auth(self, username, password, pkey, key_filenames, allow_agent,
               look_for_keys, gss_auth, gss_kex, gss_deleg_creds, gss_host,
-              pkcs11session):
+              pkcs11_session):
         """
         Try, in order:
 
@@ -572,10 +572,10 @@ class SSHClient(ClosingContextManager):
         two_factor_types = set(['keyboard-interactive', 'password'])
 
         # PKCS11 / Smartcard authentication
-        if username is not None and pkcs11session is not None:
+        if username is not None and pkcs11_session is not None:
             try:
                 allowed_types = set(self._transport.auth_pkcs11(username,
-                                    pkcs11session))
+                                    pkcs11_session))
                 two_factor = (allowed_types & two_factor_types)
                 if not two_factor:
                     return

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -1375,10 +1375,10 @@ class Transport(threading.Thread, ClosingContextManager):
             return []
         return self.auth_handler.wait_for_response(my_event)
 
-    def auth_pkcs11(self, username, pkcs11session, event=None):
+    def auth_pkcs11(self, username, pkcs11_session, event=None):
         """
         :param str username: the username to authenticate as
-        :param str pkcs11session: session obtained from pkcs11_open_session
+        :param str pkcs11_session: session obtained from pkcs11_open_session
         :param .threading.Event event:
             an event to trigger when the authentication attempt is complete
             (whether it was successful or not)
@@ -1399,7 +1399,7 @@ class Transport(threading.Thread, ClosingContextManager):
         else:
             my_event = event
         self.auth_handler = AuthHandler(self)
-        self.auth_handler.auth_pkcs11(username, pkcs11session, my_event)
+        self.auth_handler.auth_pkcs11(username, pkcs11_session, my_event)
         if event is not None:
             # caller wants to wait for event themselves
             return []

--- a/tests/test_pkcs11.py
+++ b/tests/test_pkcs11.py
@@ -20,19 +20,14 @@ Test the used APIs for pkcs11
 
 import unittest
 import mock
-from paramiko.pkcs11 import (
-    PKCS11Exception, pkcs11_get_public_key, pkcs11_close_session,
-    pkcs11_open_session
-)
+from paramiko import pkcs11
+from paramiko.pkcs11 import PKCS11Exception 
 from paramiko.auth_handler import AuthHandler
 from paramiko.transport import Transport
 from tests.loop import LoopSocket
 
 
-test_rsa_public_key = b"ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAIEA049W6geFpm\
-sljTwfvI1UmKWWJPNFI74+vNKTk4dmzkQY2yAMs6FhlvhlI8ysU4oj71ZsRYMecHbBbxdN\
-79+JRFVYTKaLqjwGENeTd+yv4q+V2PvZv3fLnzApI3l7EJCqhWwJUHJ1jAkZzqDx0tyOL4u\
-oZpww3nmE0kb3y21tH4c="
+test_rsa_public_key = b"ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAIEA049W6geFpmsljTwfvI1UmKWWJPNFI74+vNKTk4dmzkQY2yAMs6FhlvhlI8ysU4oj71ZsRYMecHbBbxdN79+JRFVYTKaLqjwGENeTd+yv4q+V2PvZv3fLnzApI3l7EJCqhWwJUHJ1jAkZzqDx0tyOL4uoZpww3nmE0kb3y21tH4c=" # noqa
 
 
 class MockPKCS11Lib(object):
@@ -96,7 +91,7 @@ class Pkcs11Test(unittest.TestCase):
         """
         Test Getting Public Key
         """
-        public_key = pkcs11_get_public_key()
+        public_key = pkcs11.get_public_key()
         self.assertEqual(public_key, test_rsa_public_key.decode("utf-8"))
 
     @mock.patch('os.path.isfile', return_value=True)
@@ -105,10 +100,10 @@ class Pkcs11Test(unittest.TestCase):
     def test_2_pkcs11_close_session_success(self,
                                             mock_isfile,
                                             mock_loadlibrary):
-        pkcs11session = {"pkcs11provider": "/test/path/example"}
+        pkcs11_session = {"provider": "/test/path/example"}
         threw_exception = True
         try:
-            pkcs11_close_session(pkcs11session)
+            pkcs11.close_session(pkcs11_session)
         except Exception:
             threw_exception = False
         self.assertTrue(not threw_exception)
@@ -118,10 +113,10 @@ class Pkcs11Test(unittest.TestCase):
                 return_value=MockPKCS11Lib())
     def test_3_pkcs11_close_session_fail_nofile(self, mock_isfile,
                                                 mock_loadlibrary):
-        pkcs11session = {"pkcs11provider": "/test/path/example"}
+        pkcs11_session = {"provider": "/test/path/example"}
         threw_exception = False
         try:
-            pkcs11_close_session(pkcs11session)
+            pkcs11.close_session(pkcs11_session)
         except PKCS11Exception:
             threw_exception = True
         self.assertTrue(threw_exception)
@@ -135,7 +130,7 @@ class Pkcs11Test(unittest.TestCase):
                                    mock_popen,
                                    mock_isfile,
                                    mock_loadlibrary):
-        session = pkcs11_open_session("/test/provider/example", "1234")
+        session = pkcs11.open_session("/test/provider/example", "1234")
         self.assertEqual(0, session["session"].value)
         self.assertEqual(test_rsa_public_key.decode("utf-8"), session["public_key"])
         self.assertEqual(0, session["keyret"].value)
@@ -153,7 +148,7 @@ class Pkcs11Test(unittest.TestCase):
         self.assertEqual(testauth.auth_event, None)
         self.assertEqual(testauth.auth_method, 'publickey')
         self.assertEqual(testauth.username, "testuser")
-        self.assertEqual(testauth.pkcs11session, session)
+        self.assertEqual(testauth.pkcs11_session, session)
 
     @mock.patch('paramiko.auth_handler.AuthHandler._request_auth',
                 return_value=True)


### PR DESCRIPTION
Follow up to #827.  When I re-pushed to the original branch github forced the issue to close.

This adds pkcs11 support to enable using paramiko with smartcards.  I have a forked version of Ansible that uses this feature and its working great.

I have tested on python 2.7 and python 3.6.2

# Multithreading Example:

``` python
import paramiko
from multiprocessing import Queue
from threading import Thread

pkcs11provider="/usr/local/lib/opensc-pkcs11.so"
smartcard_pin="123456"

def do_it(q):
    session = q.get()
    ssh = paramiko.SSHClient()
    ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
    ssh.connect("HOSTNAME", username="USERNAME", pkcs11_session=session)
    stdin, stdout, stderr = ssh.exec_command("uname -a")
    for line in stdout:
        print(line)

q = Queue()
session = paramiko.pkcs11.open_session(pkcs11provider, smartcard_pin)
mythread = Thread(target=do_it, args=(q,))
q.put(session)
mythread.start()
mythread.join()
paramiko.pkcs11.close_session(session)
```
# Basic Example:

``` python
import paramiko

pkcs11provider="/usr/local/lib/opensc-pkcs11.so"
smartcard_pin="123456"

ssh = paramiko.SSHClient()
ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
session = paramiko.pkcs11.open_session(pkcs11provider, smartcard_pin)
ssh.connect("HOSTNAME", username="USERNAME", pkcs11_session=session)
paramiko.pkcs11.close_session(session)
stdin, stdout, stderr = ssh.exec_command("uname -a")
for line in stdout:
    print(line)
```

- David