### PR TITLE
sftp: fix BytesWarning: str() on a bytes instance

### DIFF
--- a/paramiko/sftp_client.py
+++ b/paramiko/sftp_client.py
@@ -341,7 +341,7 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
         handle = msg.get_binary()
         self._log(
             DEBUG,
-            'open(%r, %r) -> %s' % (filename, mode, hexlify(handle)))
+            'open(%r, %r) -> %s' % (filename, mode, u(hexlify(handle))))
         return SFTPFile(self, handle, mode, bufsize)
 
     # Python continues to vacillate about "open" vs "file"...

--- a/paramiko/sftp_file.py
+++ b/paramiko/sftp_file.py
@@ -30,7 +30,7 @@ import time
 from paramiko.common import DEBUG
 
 from paramiko.file import BufferedFile
-from paramiko.py3compat import long
+from paramiko.py3compat import u, long
 from paramiko.sftp import (
     CMD_CLOSE, CMD_READ, CMD_DATA, SFTPError, CMD_WRITE, CMD_STATUS, CMD_FSTAT,
     CMD_ATTRS, CMD_FSETSTAT, CMD_EXTENDED,
@@ -83,7 +83,7 @@ class SFTPFile (BufferedFile):
         # __del__.)
         if self._closed:
             return
-        self.sftp._log(DEBUG, 'close(%s)' % hexlify(self.handle))
+        self.sftp._log(DEBUG, 'close(%s)' % u(hexlify(self.handle)))
         if self.pipelined:
             self.sftp._finish_responses(self)
         BufferedFile.close(self)


### PR DESCRIPTION
when running the code with python3 we get BytesWarning as what we
receive from hexlify() function is bytes. Use u() from py3compat to
overcome the issue.