### PR TITLE
Change check for port inside of transport

### DIFF
--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -302,12 +302,12 @@ class Transport(threading.Thread, ClosingContextManager):
 
         if isinstance(sock, string_types):
             # convert "host:port" into (host, port)
-            hl = sock.split(':', 1)
+            hl = sock.split(':')
             self.hostname = hl[0]
-            if len(hl) == 1:
-                sock = (hl[0], 22)
-            else:
+            if len(hl) == 2:
                 sock = (hl[0], int(hl[1]))
+            else:
+                sock = (sock, 22)
         if type(sock) is tuple:
             # connect to the given (host, port)
             hostname, port = sock


### PR DESCRIPTION
Changing the check for the port inside of transport so that now ipv6 is
recognized.

Previously, the code was split to see if there was a colon in it to determine port number, which would break it if you passed in an ipv6 address, the only way to do that was through a tuple. now it will only perform the port check if the length of the split is 1, seeing as the shortest ipv6 address you can have is "::1" which would result in a length of 3