### PR TITLE
Clarify how certain timeouts work.

### DIFF
--- a/paramiko/channel.py
+++ b/paramiko/channel.py
@@ -575,8 +575,9 @@ class Channel (ClosingContextManager):
         argument can be a nonnegative float expressing seconds, or ``None``.
         If a float is given, subsequent channel read/write operations will
         raise a timeout exception if the timeout period value has elapsed
-        before the operation has completed.  Setting a timeout of ``None``
-        disables timeouts on socket operations.
+        before the operation has completed.  Elapsed time is measured since
+        the last operation, not since the channel opened.  Setting a timeout
+        of ``None`` disables timeouts on socket operations.
 
         ``chan.settimeout(0.0)`` is equivalent to ``chan.setblocking(0)``;
         ``chan.settimeout(None)`` is equivalent to ``chan.setblocking(1)``.

--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -462,7 +462,8 @@ class SSHClient (ClosingContextManager):
             interpreted the same way as by the built-in ``file()`` function in
             Python
         :param int timeout:
-            set command's channel timeout. See `.Channel.settimeout`
+            set command's channel timeout in seconds since last i/o
+            operation. See `.Channel.settimeout`
         :param dict environment:
             a dict of shell environment variables, to be merged into the
             default environment that the remote command executes within.


### PR DESCRIPTION
Document explicitly when timeouts aren't relative to when the connection opened.