### PR TITLE
Decoded data into str form for sys.stdout.write

### DIFF
--- a/demos/interactive.py
+++ b/demos/interactive.py
@@ -81,7 +81,7 @@ def windows_shell(chan):
                 sys.stdout.write('\r\n*** EOF ***\r\n\r\n')
                 sys.stdout.flush()
                 break
-            sys.stdout.write(data)
+            sys.stdout.write(data.decode())
             sys.stdout.flush()
         
     writer = threading.Thread(target=writeall, args=(chan,))


### PR DESCRIPTION
Decoding `data` into `str` as opposed to leaving it as a  `byte` avoids:
``` Python
Exception in thread Thread-3:
Traceback (most recent call last):
  File "C:\Users\isaac\AppData\Local\Programs\Python\Python36\lib\threading.py", line 916, in _bootstrap_inner
    self.run()
  File "C:\Users\isaac\AppData\Local\Programs\Python\Python36\lib\threading.py", line 864, in run
    self._target(*self._args, **self._kwargs)
  File "C:\Users\isaac\Source\Repos\paramiko\demos\interactive.py", line 84, in writeall
    sys.stdout.write(data)
TypeError: write() argument must be str, not bytes
```