### PR TITLE
Fix issue #1157 broken pipe error when closing channel 

### DIFF
--- a/paramiko/buffered_pipe.py
+++ b/paramiko/buffered_pipe.py
@@ -85,6 +85,16 @@ class BufferedPipe (object):
         finally:
             self._lock.release()
 
+    def unlink_event(self):
+        """
+        Unlink an Event object from this buffer.
+        """
+        self._lock.acquire()
+        try:
+            self._event = None
+        finally:
+            self._lock.release()
+
     def feed(self, data):
         """
         Feed new data into this pipe.  This method is assumed to be called

--- a/paramiko/channel.py
+++ b/paramiko/channel.py
@@ -640,8 +640,11 @@ class Channel (ClosingContextManager):
             # only close the pipe when the user explicitly closes the channel.
             # otherwise they will get unpleasant surprises.  (and do it before
             # checking self.closed, since the remote host may have already
-            # closed the connection.)
+            # closed the connection.); must also unlink the pipe from in_buffer and
+            # in_stderr_buffer to avoid writing to an already closed pipe.
             if self._pipe is not None:
+                self.in_buffer.unlink_event()
+                self.in_stderr_buffer.unlink_event()
                 self._pipe.close()
                 self._pipe = None
 

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -929,3 +929,25 @@ class TransportTest(unittest.TestCase):
             # sendall() accepts a memoryview instance
             chan.sendall(memoryview(data))
             self.assertEqual(sfile.read(len(data)), data)
+
+    def test_transport_channel_close(self):
+        """
+        verify concurrent channel closing while feeding it with data
+        """
+        self.setup_test_server()
+
+        def channel_close_thread(chan):
+            chan.close()
+
+        threads = []
+        for i in range(100):
+            chan = self.tc.open_session()
+            # trigger internal pipe creation
+            chan.fileno()
+            t = threading.Thread(target=channel_close_thread, args=(chan,))
+            threads.append(t)
+            t.start()
+            chan._feed(b'')
+
+        for t in threads:
+            t.join()


### PR DESCRIPTION
This PR is intended to fix issue #1157. Added test case is a little artificial since I was not able to reproduce this with a more real life scenario in a unit test, but the issue is easy to trigger with real connections using sshtunnel for example. Test case still seems valid since in real code there are no explicit checks guarding this.