### PR TITLE
Added Ed25519Key to __all__

### DIFF
--- a/paramiko/__init__.py
+++ b/paramiko/__init__.py
@@ -84,6 +84,7 @@ __all__ = [
     'PKey',
     'RSAKey',
     'DSSKey',
+    'Ed25519Key',
     'Message',
     'SSHException',
     'AuthenticationException',


### PR DESCRIPTION
PyCharm complains when I try to do:

from paramiko import Ed25519Key

It says Ed25519Key is missing from __all__.

This patch adds it to __all__ and then PyCharm stops complaining.