### PR TITLE
Migrate to new PyPI website

### DIFF
--- a/sites/www/installing-1.x.rst
+++ b/sites/www/installing-1.x.rst
@@ -118,4 +118,4 @@ First, see the main install doc's notes: :ref:`gssapi` - everything there is
 required for Paramiko 1.x as well.
 
 Additionally, users of Paramiko 1.x, on all platforms, need a final dependency:
-`pyasn1 <https://pypi.python.org/pypi/pyasn1>`_ ``0.1.7`` or better.
+`pyasn1 <https://pypi.org/project/pyasn1/>`_ ``0.1.7`` or better.

--- a/sites/www/installing.rst
+++ b/sites/www/installing.rst
@@ -97,7 +97,7 @@ due to their infrequent utility & non-platform-agnostic requirements):
 
 * It hopefully goes without saying but **all platforms** need **a working
   installation of GSS-API itself**, e.g. Heimdal.
-* **Unix** needs `python-gssapi <https://pypi.python.org/pypi/python-gssapi/>`_
+* **Unix** needs `python-gssapi <https://pypi.org/project/python-gssapi/>`_
   ``0.6.1`` or better.
 
   .. note:: This library appears to only function on Python 2.7 and up.


### PR DESCRIPTION
According to [1], the PyPI website of pypi.python.org has changed
to https://pypi.org. This patch updates all references to the
legacy site.

[1] https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html

Signed-off-by: Eric Brown browne@vmware.com