### PR TITLE
Fix a false authentication exception raised during auth handler cleaning up

### DIFF
--- a/paramiko/auth_handler.py
+++ b/paramiko/auth_handler.py
@@ -207,6 +207,10 @@ class AuthHandler (object):
             event.wait(0.1)
             if not self.transport.is_active():
                 e = self.transport.get_exception()
+                if e is None and self.is_authenticated():
+                    # no error, but the transport became deactivated
+                    # e.g. a disconnect happened while we entered the loop
+                    break
                 if (e is None) or issubclass(e.__class__, EOFError):
                     e = AuthenticationException('Authentication failed.')
                 raise e


### PR DESCRIPTION
I have a unit test for a proxy server that uses paramiko as a test ssh client / server, that will quite reliably raise an incorrect client authentication error in response toserver disconnection messages. I think this is because there's a timing sensitive loop in `auth_handler.wait_for_response`. This patch is my attempt to address this with the smallest possible change.

change the logic used in auth_handler.wait_for_response exception
raising when transport is inactive

it's possible to enter the auth_handler wait_for response failure
handler during cleanup, if the authentication has completed without
error just as the transport.active flag gets switched (e.g. in
response to a disconnect message. In this state, we have
authenticated: true , but transport.active: false, which causes an
inappropriate AuthenticationException to be raised. The patch just
adds an additional check of the authenticated flag before raising this
error.