### PR TITLE
Saving temporary buffer on timeout

### DIFF
--- a/paramiko/file.py
+++ b/paramiko/file.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Paramiko; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+import socket
+
 from paramiko.common import (
     linefeed_byte_value, crlf, cr_byte, linefeed_byte, cr_byte_value,
 )
@@ -286,6 +288,9 @@ class BufferedFile (ClosingContextManager):
                 break
             try:
                 new_data = self._read(n)
+            except socket.timeout:
+                self._rbuffer = line
+                raise
             except EOFError:
                 new_data = None
             if (new_data is None) or (len(new_data) == 0):


### PR DESCRIPTION
Fixes #1196 

`self._buffer` is copied (by ref) to the `line` variable, but since bytes type is immutable, adding data to the `line` further on, actually makes it to diverge from `self._buffer`. Therefore if timeout occurs, the data that was read during the `readline()` execution so far, gets lost.

The idea is to save temporary buffer back to the original if we hit timeout.