### PR TITLE
Test and dev dependencies cleanup and sync with Fabric

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,12 +24,12 @@ install:
   - pip install codecov # For codecov specifically
   - pip install -r dev-requirements.txt
 script:
+  # flake8 is now possible!
+  - flake8
   # All (including slow) tests, w/ coverage!
   - inv coverage
   # Ensure documentation builds, both sites, maxxed nitpicking
   - inv sites
-  # flake8 is now possible!
-  - flake8
 notifications:
   irc:
     channels: "irc.freenode.org#paramiko"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,7 +4,7 @@ invocations>=1.0,<2.0
 # NOTE: pytest-relaxed currently only works with pytest >=3, <3.3
 pytest>=3.2,<3.3
 pytest-relaxed==1.1.2
-#pytest-xdist for test dir watching and the inv guard task
+# pytest-xdist for test dir watching and the inv guard task
 pytest-xdist>=1.22,<2.0
 # Linting!
 flake8==2.4.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,11 +1,23 @@
+# Invocations for common project tasks
 invoke>=0.13,<2.0
-invocations>=0.13,<2.0
-sphinx>=1.1.3,<1.5
-alabaster>=0.7.5,<2.0
-releases>=1.1.0,<2.0
-semantic_version<3.0
+invocations>=1.0,<2.0
+# NOTE: pytest-relaxed currently only works with pytest >=3, <3.3
+pytest>=3.2,<3.3
+pytest-relaxed==1.1.2
+#pytest-xdist for test dir watching and the inv guard task
+pytest-xdist>=1.22,<2.0
+# Linting!
+flake8==2.4.0
+# Coverage!
+coverage==3.7.1
+codecov==1.6.3
+# Documentation tools
+sphinx>=1.4,<1.7
+alabaster>=0.7,<2.0
+releases>=1.5,<2.0
+# Release tools
+semantic_version>=2.4,<2.5
 wheel==0.24
-twine>=1.11.0
-flake8==2.6.2
-pytest==3.2.1
-pytest_relaxed==1.0.0
+twine==1.11.0
+
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ omit = paramiko/_winapi.py
 
 [flake8]
 exclude = sites,.git,build,dist,demos,tests
-ignore = E124,E125,E128,E261,E301,E302,E303,E402
+ignore = E124,E125,E128,E261,E301,E302,E303,E402,E721
 max-line-length = 79
 
 [tool:pytest]

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,3 +16,5 @@ max-line-length = 79
 # We use pytest-relaxed just for its utils at the moment, so disable it at the
 # plugin level until we adapt test organization to really use it.
 addopts = -p no:relaxed
+# Loop on failure
+looponfailroots = tests paramiko

--- a/tasks.py
+++ b/tasks.py
@@ -15,13 +15,14 @@ def test(
     ctx,
     verbose=True,
     color=True,
-    capture='sys',
+    capture="sys",
     module=None,
     k=None,
     x=False,
     opts="",
     coverage=False,
     include_slow=False,
+    loop_on_fail=False,
 ):
     """
     Run unit tests via pytest.
@@ -31,19 +32,21 @@ def test(
     well with explicit ``--opts="-m=xxx"`` - if ``-m`` is found in ``--opts``,
     ``--include-slow`` will be ignored!)
     """
-    if verbose and '--verbose' not in opts and '-v' not in opts:
+    if verbose and "--verbose" not in opts and "-v" not in opts:
         opts += " --verbose"
     # TODO: forget why invocations.pytest added this; is it to force color when
     # running headless? Probably?
     if color:
         opts += " --color=yes"
-    opts += ' --capture={0}'.format(capture)
-    if '-m' not in opts and not include_slow:
+    opts += " --capture={0}".format(capture)
+    if "-m" not in opts and not include_slow:
         opts += " -m 'not slow'"
-    if k is not None and not ('-k' in opts if opts else False):
-        opts += ' -k {}'.format(k)
-    if x and not ('-x' in opts if opts else False):
-        opts += ' -x'
+    if k is not None and not ("-k" in opts if opts else False):
+        opts += " -k {}".format(k)
+    if x and not ("-x" in opts if opts else False):
+        opts += " -x"
+    if loop_on_fail and not ("-f" in opts if opts else False):
+        opts += " -f"
     modstr = ""
     if module is not None:
         # NOTE: implicit test_ prefix as we're not on pytest-relaxed yet
@@ -62,8 +65,8 @@ def test(
     # way to handle the env stuff too, then we can remove these tasks entirely
     # in favor of just "run pytest"?
     env = dict(os.environ)
-    if 'SSH_AUTH_SOCK' in env:
-        del env['SSH_AUTH_SOCK']
+    if "SSH_AUTH_SOCK" in env:
+        del env["SSH_AUTH_SOCK"]
     cmd = "{} {} {}".format(runner, opts, modstr)
     # NOTE: we have a pytest.ini and tend to use that over PYTEST_ADDOPTS.
     ctx.run(cmd, pty=True, env=env, replace_env=True)
@@ -77,6 +80,15 @@ def coverage(ctx, opts=""):
     return test(ctx, coverage=True, include_slow=True, opts=opts)
 
 
+@task
+def guard(ctx, opts=""):
+    """
+    Execute all tests and then watch for changes, re-running.
+    """
+    # TODO if coverage was run via pytest-cov, we could add coverage here too
+    return test(ctx, include_slow=True, loop_on_fail=True, opts=opts)
+
+
 # Until we stop bundling docs w/ releases. Need to discover use cases first.
 # TODO: would be nice to tie this into our own version of build() too, but
 # still have publish() use that build()...really need to try out classes!
@@ -88,33 +100,38 @@ def release(ctx, sdist=True, wheel=True, sign=True, dry_run=False):
     # Build docs first. Use terribad workaround pending invoke #146
     ctx.run("inv docs", pty=True, hide=False)
     # Move the built docs into where Epydocs used to live
-    target = 'docs'
+    target = "docs"
     rmtree(target, ignore_errors=True)
     # TODO: make it easier to yank out this config val from the docs coll
-    copytree('sites/docs/_build', target)
+    copytree("sites/docs/_build", target)
     # Publish
     publish(ctx, sdist=sdist, wheel=wheel, sign=sign, dry_run=dry_run)
     # Remind
-    print("\n\nDon't forget to update RTD's versions page for new minor "
-          "releases!")
+    print(
+        "\n\nDon't forget to update RTD's versions page for new minor "
+        "releases!"
+    )
 
 
 # TODO: "replace one task with another" needs a better public API, this is
 # using unpublished internals & skips all the stuff add_task() does re:
 # aliasing, defaults etc.
-release_coll.tasks['publish'] = release
+release_coll.tasks["publish"] = release
 
-ns = Collection(test, coverage, release_coll, docs, www, sites, count_errors)
-ns.configure({
-    'packaging': {
-        # NOTE: many of these are also set in kwarg defaults above; but having
-        # them here too means once we get rid of our custom release(), the
-        # behavior stays.
-        'sign': True,
-        'wheel': True,
-        'changelog_file': join(
-            www.configuration()['sphinx']['source'],
-            'changelog.rst',
-        ),
-    },
-})
+ns = Collection(
+    test, coverage, guard, release_coll, docs, www, sites, count_errors
+)
+ns.configure(
+    {
+        "packaging": {
+            # NOTE: many of these are also set in kwarg defaults above; but
+            # having them here too means once we get rid of our custom
+            # release(), the behavior stays.
+            "sign": True,
+            "wheel": True,
+            "changelog_file": join(
+                www.configuration()["sphinx"]["source"], "changelog.rst"
+            ),
+        }
+    }
+)


### PR DESCRIPTION
* Update invocations min version
* Update pytest to be consistent with fabric
* Add pytest-xdist to enable `guard` task
* Other dependencies as found to be inconsistent with Fabric2
* add `inv guard` task