### PR TITLE
Updated dependencies for ed25519 key support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,5 +71,5 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
     ],
-    install_requires=["bcrypt>=3.1.3", "cryptography>=1.5", "pynacl>=1.0.1"],
+    install_requires=["bcrypt>=3.1.3", "cryptography>=2.2.2", "pynacl>=1.2.1"],
 )


### PR DESCRIPTION
After upgrade to paramiko version 2.4.1 one of my apps has stopped working and throw following exception:

> BadHostKeyException: (u'xx.xx.xx.xx', <paramiko.ed25519key.Ed25519Key object at 0x7f9d0dbbb150>, <paramiko.ed25519key.Ed25519Key object at 0x7f9d0dbf4f10>)

This issue occurs with these versions of dependencies:
cryptography==2.1.1
pynacl==1.0.1

The problem has been fixed by upgrade to the next versions:
cryptography==2.2.2
pynacl==1.2.1

To enable support of ed25519 type keys (#325) I've updated the minimum required versions specified in installation prerequisites.