### PR TITLE
OrPipe: add proper locking

### DIFF
--- a/paramiko/pipe.py
+++ b/paramiko/pipe.py
@@ -28,6 +28,7 @@ will trigger as readable in `select <select.select>`.
 import sys
 import os
 import socket
+import threading
 
 
 def make_pipe():
@@ -127,14 +128,18 @@ class OrPipe(object):
         self._pipe = pipe
 
     def set(self):
+        self._pipe._lock.acquire()
         self._set = True
         if not self._partner._set:
             self._pipe.set()
+        self._pipe._lock.release()
 
     def clear(self):
+        self._pipe._lock.acquire()
         self._set = False
         if not self._partner._set:
             self._pipe.clear()
+        self._pipe._lock.release()
 
 
 def make_or_pipe(pipe):
@@ -143,6 +148,7 @@ def make_or_pipe(pipe):
     affect the real pipe. if either returned pipe is set, the wrapped pipe
     is set. when both are cleared, the wrapped pipe is cleared.
     """
+    pipe._lock = threading.Lock()
     p1 = OrPipe(pipe)
     p2 = OrPipe(pipe)
     p1._partner = p2


### PR DESCRIPTION
In the context of fileno(), a Channel's .in_buffer and .in_stderr_buffer
operate on a pair of of OrPipes obtained from make_or_pipe(). These two
cooperate and share the same underlying PosixPipe resp. WindowsPipe.

Due to the lack of any synchronization in the OrPipe's .set() method, it
is possible (and has actually been observed) to have both OrPipes'
._set = True while the underlying pipe remains unset.

Fix that by adding proper locking to the OrPipe implementation.