### PR TITLE
Fix bug in port forwarding demos causing lost bytes when send buffer/window fills up

### DIFF
--- a/demos/forward.py
+++ b/demos/forward.py
@@ -88,12 +88,12 @@ class Handler(SocketServer.BaseRequestHandler):
                 data = self.request.recv(1024)
                 if len(data) == 0:
                     break
-                chan.send(data)
+                chan.sendall(data)
             if chan in r:
                 data = chan.recv(1024)
                 if len(data) == 0:
                     break
-                self.request.send(data)
+                self.request.sendall(data)
 
         peername = self.request.getpeername()
         chan.close()

--- a/demos/rforward.py
+++ b/demos/rforward.py
@@ -60,12 +60,12 @@ def handler(chan, host, port):
             data = sock.recv(1024)
             if len(data) == 0:
                 break
-            chan.send(data)
+            chan.sendall(data)
         if chan in r:
             data = chan.recv(1024)
             if len(data) == 0:
                 break
-            sock.send(data)
+            sock.sendall(data)
     chan.close()
     sock.close()
     verbose("Tunnel closed from %r" % (chan.origin_addr,))


### PR DESCRIPTION
This fix is not ideal. Since sendall() blocks until all data is sent, there may be a risk of a deadlock if there is data congestion in both directions simultaneously, depending on the behavior of the processes at both ends of the tunnel.  However, the likelihood is significantly lower than the likelihood of hitting the current bug where bytes are lost in the tunnel.  A better fix would be to select the channel and request for sending and send data in chunks within the same loop.  However, Paramiko channels currently do not support select for sending, which makes this approach more difficult.