### PR TITLE
If a timeout is defined, use it in Channel._wait_for_event

### DIFF
--- a/paramiko/channel.py
+++ b/paramiko/channel.py
@@ -1198,7 +1198,8 @@ class Channel(ClosingContextManager):
         self.event_ready = False
 
     def _wait_for_event(self):
-        self.event.wait()
+        if not self.event.wait(timeout=self.timeout):
+            raise socket.timeout()
         assert self.event.is_set()
         if self.event_ready:
             return


### PR DESCRIPTION
At present after we have sent a command (e.g. a channel request), we wait on a
threading.Event object for a signal.
This signal will be delivered either once we get a response to the request, or
if there is a socket error, such as a timeout.

A badly behaved server can fail to respond to the request, but not cause a
socket error, resulting in a potentially infinite wait.

As such, if we have a timeout defined, use it in _wait_for_event and throw a
socket timeout exception if we hit it.