### PR TITLE
Fixes decoding issue with Python 3.5.2

### DIFF
--- a/demos/interactive.py
+++ b/demos/interactive.py
@@ -84,7 +84,7 @@ def windows_shell(chan):
                 sys.stdout.write("\r\n*** EOF ***\r\n\r\n")
                 sys.stdout.flush()
                 break
-            sys.stdout.write(data)
+            sys.stdout.write(data.decode("utf-8"))
             sys.stdout.flush()
 
     writer = threading.Thread(target=writeall, args=(chan,))


### PR DESCRIPTION
Addresses the following error I encountered while running demo.py:
```
Exception in thread Thread-3:
Traceback (most recent call last):
  File "D:\Program Files\Miniconda3\lib\threading.py", line 914, in _bootstrap_inner
    self.run()
  File "D:\Program Files\Miniconda3\lib\threading.py", line 862, in run
    self._target(*self._args, **self._kwargs)
  File "D:\OneDrive\Documents\birdie\paramiko-master\paramiko-master\demos\interactive.py", line 87, in writeall
    sys.stdout.write(data.decode)
TypeError: write() argument must be str, not builtin_function_or_method
```