### PR TITLE
made invoke_shell to utilize environment variable(s)

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -534,6 +534,8 @@ class SSHClient(ClosingContextManager):
         :raises: `.SSHException` -- if the server fails to invoke a shell
         """
         chan = self._transport.open_session()
+        if environment:
+            chan.update_environment(environment)
         chan.get_pty(term, width, height, width_pixels, height_pixels)
         chan.invoke_shell()
         return chan


### PR DESCRIPTION
invoke_shell is currently ignoring the environment dict that is passed by caller. 