### PR TITLE
kex: support curve25519-sha256@libssh.org

### DIFF
--- a/paramiko/kex_curve25519.py
+++ b/paramiko/kex_curve25519.py
@@ -93,7 +93,7 @@ class KexCurve25519(object):
         if x25519 is None:
             return False  # cryptography < 2.0
 
-        if not hasattr(Encoding, 'Raw'):
+        if not hasattr(Encoding, "Raw"):
             return False  # cryptography < 2.5
 
         try:

--- a/paramiko/kex_curve25519.py
+++ b/paramiko/kex_curve25519.py
@@ -28,11 +28,16 @@ from hashlib import sha256
 from paramiko.message import Message
 from paramiko.py3compat import byte_chr, long
 from paramiko.ssh_exception import SSHException
-from cryptography.hazmat.primitives.asymmetric import x25519
 from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 from cryptography.exceptions import UnsupportedAlgorithm
 from binascii import hexlify
 
+# x25519 was added in cryptography 2.5, but we support as low as 1.5. Trap any
+# import failure and just don't load x25519 support.
+try:
+    from cryptography.hazmat.primitives.asymmetric import x25519
+except ImportError:
+    x25519 = None
 
 _MSG_KEXC25519_INIT, _MSG_KEXC25519_REPLY = range(30, 32)
 c_MSG_KEXC25519_INIT, c_MSG_KEXC25519_REPLY = [
@@ -83,10 +88,21 @@ class KexCurve25519(object):
     def is_supported():
         """
         Check if the openssl version pyca-cryptography is linked against
-        supports curve25519 key agreement.
+        supports curve25519 key agreement, and if cryptography itself is of a
+        sufficient version for x25519 support.
 
-        Returns True if OpenSSL supports x25519 keys, and False otherwise.
+        Returns True if cryptography and OpenSSL both support x25519 keys, and
+        False otherwise.
         """
+        if x25519 is None:
+            return False
+
+        if not hasattr(Encoding, 'Raw'):
+            return False
+
+        if not hasattr(PublicFormat, 'Raw'):
+            return False
+
         try:
             x25519.X25519PublicKey.from_public_bytes(b"\x00" * 32)
         except UnsupportedAlgorithm:

--- a/paramiko/kex_curve25519.py
+++ b/paramiko/kex_curve25519.py
@@ -1,5 +1,3 @@
-# Copyright (C) 2003-2007  Robey Pointer <robeypointer@gmail.com>
-#
 # This file is part of paramiko.
 #
 # Paramiko is free software; you can redistribute it and/or modify it under the
@@ -17,8 +15,7 @@
 # 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
 
 """
-Key exchange using DJB's Curve25519. Originally introduced in OpenSSH 6.5, and
-the only kex currently (August 2018) recommended by arthepsy's ssh-audit.
+Key exchange using DJB's Curve25519. Originally introduced in OpenSSH 6.5
 """
 
 # Author: Dan Fuhry <dan@fuhry.com>
@@ -32,8 +29,7 @@ from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 from cryptography.exceptions import UnsupportedAlgorithm
 from binascii import hexlify
 
-# x25519 was added in cryptography 2.5, but we support as low as 1.5. Trap any
-# import failure and just don't load x25519 support.
+# x25519 was added in cryptography 2.0, but we support down to cryptography 1.5
 try:
     from cryptography.hazmat.primitives.asymmetric import x25519
 except ImportError:
@@ -95,18 +91,15 @@ class KexCurve25519(object):
         False otherwise.
         """
         if x25519 is None:
-            return False
+            return False  # cryptography < 2.0
 
         if not hasattr(Encoding, 'Raw'):
-            return False
-
-        if not hasattr(PublicFormat, 'Raw'):
-            return False
+            return False  # cryptography < 2.5
 
         try:
             x25519.X25519PublicKey.from_public_bytes(b"\x00" * 32)
         except UnsupportedAlgorithm:
-            return False
+            return False  # openssl < 1.1.0
 
         return True
 

--- a/paramiko/kex_curve25519.py
+++ b/paramiko/kex_curve25519.py
@@ -1,0 +1,180 @@
+# Copyright (C) 2003-2007  Robey Pointer <robeypointer@gmail.com>
+#
+# This file is part of paramiko.
+#
+# Paramiko is free software; you can redistribute it and/or modify it under the
+# terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# Paramiko is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Paramiko; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+
+"""
+Key exchange using DJB's Curve25519. Originally introduced in OpenSSH 6.5, and
+the only kex currently (August 2018) recommended by arthepsy's ssh-audit.
+"""
+
+# Author: Dan Fuhry <dan@fuhry.com>
+
+from hashlib import sha256
+
+from paramiko.message import Message
+from paramiko.py3compat import byte_chr, long
+from paramiko.ssh_exception import SSHException
+from cryptography.hazmat.primitives.asymmetric import x25519
+from cryptography.exceptions import UnsupportedAlgorithm
+from binascii import hexlify
+
+
+_MSG_KEXC25519_INIT, _MSG_KEXC25519_REPLY = range(30, 32)
+c_MSG_KEXC25519_INIT, c_MSG_KEXC25519_REPLY = [
+    byte_chr(c) for c in range(30, 32)
+]
+
+
+class KexCurve25519(object):
+    name = "curve25519-sha256@libssh.org"
+    hash_algo = sha256
+    K = None
+
+    def __init__(self, transport):
+        self.transport = transport
+
+        self.P = long(0)
+        # Client public key
+        self.Q_C = None
+        # Server public key
+        self.Q_S = None
+
+    def start_kex(self):
+        self._generate_key_pair()
+        if self.transport.server_mode:
+            self.transport._expect_packet(_MSG_KEXC25519_INIT)
+            return
+        m = Message()
+        m.add_byte(c_MSG_KEXC25519_INIT)
+        Q_C_bytes = self.Q_C.public_bytes()
+        m.add_string(Q_C_bytes)
+        self.transport._send_message(m)
+        self.transport._expect_packet(_MSG_KEXC25519_REPLY)
+
+    def parse_next(self, ptype, m):
+        if self.transport.server_mode and (ptype == _MSG_KEXC25519_INIT):
+            return self._parse_kexc25519_init(m)
+        elif not self.transport.server_mode and (
+            ptype == _MSG_KEXC25519_REPLY
+        ):
+
+            return self._parse_kexc25519_reply(m)
+        msg = "KexCurve25519 asked to handle packet type {:d}"
+        raise SSHException(msg.format(ptype))
+
+    @staticmethod
+    def is_supported():
+        """
+        Check if the openssl version pyca-cryptography is linked against
+        supports curve25519 key agreement.
+
+        Returns True if OpenSSL supports x25519 keys, and False otherwise.
+        """
+        try:
+            x25519.X25519PublicKey.from_public_bytes(b"\x00" * 32)
+        except UnsupportedAlgorithm:
+            return False
+
+        return True
+
+    # ...internals...
+
+    def _generate_key_pair(self):
+        while True:
+            self.P = x25519.X25519PrivateKey.generate()
+            if len(self.P.public_key().public_bytes()) != 32:
+                continue
+
+            if self.transport.server_mode:
+                self.Q_S = self.P.public_key()
+            else:
+                self.Q_C = self.P.public_key()
+            break
+
+    def _parse_kexc25519_reply(self, m):
+        # client mode
+
+        # 3 fields in response:
+        #   - KEX host key
+        #   - Ephemeral (Curve25519) key
+        #   - Signature
+        K_S = m.get_string()
+        self.Q_S = x25519.X25519PublicKey.from_public_bytes(m.get_string())
+        sig = m.get_binary()
+
+        # Compute shared secret
+        K = self.P.exchange(self.Q_S)
+        K = long(hexlify(K), 16)
+
+        hm = Message()
+        hm.add(
+            self.transport.local_version,
+            self.transport.remote_version,
+            self.transport.local_kex_init,
+            self.transport.remote_kex_init,
+        )
+
+        # "hm" is used as the initial transport key
+        hm.add_string(K_S)
+        hm.add_string(self.Q_C.public_bytes())
+        hm.add_string(self.Q_S.public_bytes())
+        hm.add_mpint(K)
+        self.transport._set_K_H(K, self.hash_algo(hm.asbytes()).digest())
+        # Verify that server signed kex message with its own pubkey
+        self.transport._verify_key(K_S, sig)
+        self.transport._activate_outbound()
+
+    def _parse_kexc25519_init(self, m):
+        # server mode
+
+        # Only one field in the client's message, which is their public key
+        Q_C_bytes = m.get_string()
+        self.Q_C = x25519.X25519PublicKey.from_public_bytes(Q_C_bytes)
+
+        # Compute shared secret
+        K = self.P.exchange(self.Q_C)
+        K = long(hexlify(K), 16)
+
+        # Prepare hostkey
+        K_S = self.transport.get_server_key().asbytes()
+
+        # Compute initial transport key
+        hm = Message()
+        hm.add(
+            self.transport.remote_version,
+            self.transport.local_version,
+            self.transport.remote_kex_init,
+            self.transport.local_kex_init,
+        )
+
+        hm.add_string(K_S)
+        hm.add_string(Q_C_bytes)
+        hm.add_string(self.Q_S.public_bytes())
+        hm.add_mpint(K)
+        H = self.hash_algo(hm.asbytes()).digest()
+        self.transport._set_K_H(K, H)
+
+        # Compute signature
+        sig = self.transport.get_server_key().sign_ssh_data(H)
+        # construct reply
+        m = Message()
+        m.add_byte(c_MSG_KEXC25519_REPLY)
+        m.add_string(K_S)
+        m.add_string(self.Q_S.public_bytes())
+        m.add_string(sig)
+        self.transport._send_message(m)
+        self.transport._activate_outbound()

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -90,6 +90,7 @@ from paramiko.kex_gex import KexGex, KexGexSHA256
 from paramiko.kex_group1 import KexGroup1
 from paramiko.kex_group14 import KexGroup14
 from paramiko.kex_ecdh_nist import KexNistp256, KexNistp384, KexNistp521
+from paramiko.kex_curve25519 import KexCurve25519
 from paramiko.kex_gss import KexGSSGex, KexGSSGroup1, KexGSSGroup14
 from paramiko.message import Message
 from paramiko.packet import Packetizer, NeedRekeyException
@@ -175,6 +176,7 @@ class Transport(threading.Thread, ClosingContextManager):
         "diffie-hellman-group14-sha1",
         "diffie-hellman-group1-sha1",
     )
+    _preferred_c25519kex = ("curve25519-sha256@libssh.org",)
     _preferred_gsskex = (
         "gss-gex-sha1-toWM5Slw5Ew8Mqkay+al2g==",
         "gss-group14-sha1-toWM5Slw5Ew8Mqkay+al2g==",
@@ -268,6 +270,7 @@ class Transport(threading.Thread, ClosingContextManager):
         "ecdh-sha2-nistp256": KexNistp256,
         "ecdh-sha2-nistp384": KexNistp384,
         "ecdh-sha2-nistp521": KexNistp521,
+        "curve25519-sha256@libssh.org": KexCurve25519,
     }
 
     _compression_info = {
@@ -387,6 +390,12 @@ class Transport(threading.Thread, ClosingContextManager):
         self.session_id = None
         self.host_key_type = None
         self.host_key = None
+        self.use_c25519_kex = False
+
+        if self._kex_info["curve25519-sha256@libssh.org"].is_supported():
+            self._preferred_kex = (
+                self._preferred_c25519kex + self._preferred_kex
+            )
 
         # GSS-API / SSPI Key Exchange
         self.use_gss_kex = gss_kex

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -176,7 +176,9 @@ class Transport(threading.Thread, ClosingContextManager):
         "diffie-hellman-group14-sha1",
         "diffie-hellman-group1-sha1",
     )
-    _preferred_c25519kex = ("curve25519-sha256@libssh.org",)
+    if KexCurve25519.is_supported():
+        _preferred_kex = ('curve25519-sha256@libssh.org',) + _preferred_kex
+
     _preferred_gsskex = (
         "gss-gex-sha1-toWM5Slw5Ew8Mqkay+al2g==",
         "gss-group14-sha1-toWM5Slw5Ew8Mqkay+al2g==",
@@ -391,11 +393,6 @@ class Transport(threading.Thread, ClosingContextManager):
         self.host_key_type = None
         self.host_key = None
         self.use_c25519_kex = False
-
-        if self._kex_info["curve25519-sha256@libssh.org"].is_supported():
-            self._preferred_kex = (
-                self._preferred_c25519kex + self._preferred_kex
-            )
 
         # GSS-API / SSPI Key Exchange
         self.use_gss_kex = gss_kex

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -177,7 +177,7 @@ class Transport(threading.Thread, ClosingContextManager):
         "diffie-hellman-group1-sha1",
     )
     if KexCurve25519.is_supported():
-        _preferred_kex = ('curve25519-sha256@libssh.org',) + _preferred_kex
+        _preferred_kex = ("curve25519-sha256@libssh.org",) + _preferred_kex
 
     _preferred_gsskex = (
         "gss-gex-sha1-toWM5Slw5Ew8Mqkay+al2g==",

--- a/setup.py
+++ b/setup.py
@@ -71,5 +71,5 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
     ],
-    install_requires=["bcrypt>=3.1.3", "cryptography>=2.5", "pynacl>=1.0.1"],
+    install_requires=["bcrypt>=3.1.3", "cryptography>=1.5", "pynacl>=1.0.1"],
 )

--- a/setup.py
+++ b/setup.py
@@ -71,5 +71,5 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
     ],
-    install_requires=["bcrypt>=3.1.3", "cryptography>=1.5", "pynacl>=1.0.1"],
+    install_requires=["bcrypt>=3.1.3", "cryptography>=2.5", "pynacl>=1.0.1"],
 )

--- a/tests/test_kex.py
+++ b/tests/test_kex.py
@@ -69,7 +69,7 @@ def dummy_generate_key_curve25519(obj):
     private_key_value = unhexlify(
         b"2184abc7eb3e656d2349d2470ee695b570c227340c2b2863b6c9ff427af1f040"
     )
-    obj.P = x25519.X25519PrivateKey._from_private_bytes(private_key_value)
+    obj.P = x25519.X25519PrivateKey.from_private_bytes(private_key_value)
     if obj.transport.server_mode:
         obj.Q_S = obj.P.public_key()
     else:
@@ -567,9 +567,7 @@ class KexTest(unittest.TestCase):
                 "openssl used by cryptography does not support x25519"
             )
 
-        K = (
-            71294722834835117201316639182051104803802881348227506835068888449366462300724
-        )
+        K = 71294722834835117201316639182051104803802881348227506835068888449366462300724
         transport = FakeTransport()
         transport.server_mode = False
         kex = KexCurve25519(transport)
@@ -601,9 +599,7 @@ class KexTest(unittest.TestCase):
                 "openssl used by cryptography does not support x25519"
             )
 
-        K = (
-            71294722834835117201316639182051104803802881348227506835068888449366462300724
-        )
+        K = 71294722834835117201316639182051104803802881348227506835068888449366462300724
         transport = FakeTransport()
         transport.server_mode = True
         kex = KexCurve25519(transport)

--- a/tests/test_kex.py
+++ b/tests/test_kex.py
@@ -28,6 +28,7 @@ import pytest
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import ec
+
 try:
     from cryptography.hazmat.primitives.asymmetric import x25519
 except ImportError:


### PR DESCRIPTION
This commit introduces support for the `curve25519-sha256@libssh.org` key exchange method, which is the currently (August 2018) recommended method for all modern SSH servers and clients.

Client mode, server mode and unit tests are included and have been tested with the OpenSSH client and server.

Closes #532