### PR TITLE
Use Popen methods for closing proxy object

### DIFF
--- a/paramiko/proxy.py
+++ b/paramiko/proxy.py
@@ -109,11 +109,15 @@ class ProxyCommand(ClosingContextManager):
             raise ProxyCommandFailure(" ".join(self.cmd), e.strerror)
 
     def close(self):
-        os.kill(self.process.pid, signal.SIGTERM)
+        if self.process.poll() is None:
+            try:
+                self.process.terminate()
+            except OSError:
+                pass
 
     @property
     def closed(self):
-        return self.process.returncode is not None
+        return self.process.poll() is not None
 
     @property
     def _closed(self):


### PR DESCRIPTION
Using process.poll() in closed reaps up any dead child processes.

The unconditional os.kill can raise exception in case the the proxy died for some reason.
The process.terminate() call in close needs to be wrapped up in a try/catch as there may be a race condition, between the issue of process.poll() and process.terminate().