### PR TITLE
Update pypi.python.org URLs to pypi.org

### DIFF
--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -807,7 +807,7 @@ Changelog
 * :feature:`152` Add tentative support for ECDSA keys. **This adds the ecdsa
   module as a new dependency of Paramiko.** The module is available at
   `warner/python-ecdsa on Github <https://github.com/warner/python-ecdsa>`_ and
-  `ecdsa on PyPI <https://pypi.python.org/pypi/ecdsa>`_.
+  `ecdsa on PyPI <https://pypi.org/project/ecdsa/>`_.
 
     * Note that you might still run into problems with key negotiation --
       Paramiko picks the first key that the server offers, which might not be

--- a/sites/www/installing.rst
+++ b/sites/www/installing.rst
@@ -106,7 +106,7 @@ due to their infrequent utility & non-platform-agnostic requirements):
 
   .. note:: This library appears to only function on Python 2.7 and up.
 
-* **Windows** needs `pywin32 <https://pypi.python.org/pypi/pywin32>`_ ``2.1.8``
+* **Windows** needs `pywin32 <https://pypi.org/project/pywin32/>`_ ``2.1.8``
   or better.
 
 .. note::


### PR DESCRIPTION
For details on the new PyPI, see the blog post:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html