### PR TITLE
Recognize AttributeError for gssapi 'missing'

### DIFF
--- a/paramiko/ssh_gss.py
+++ b/paramiko/ssh_gss.py
@@ -49,7 +49,7 @@ try:
     import gssapi
 
     GSS_EXCEPTIONS = (gssapi.GSSException,)
-except (ImportError, OSError):
+except (ImportError, OSError, AttributeError):
     try:
         import pywintypes
         import sspicon


### PR DESCRIPTION
RedHat includes an older python-gssapi as part of its IPA
stack.  This results in an AttributeError when it tries
to get the exceptions.