### PR TITLE
Add support for tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,17 +27,21 @@ matrix:
       env: "USE_K5TEST=yes"
 install:
   # Ensure modern pip/etc to avoid some issues w/ older worker environs
-  - pip install pip==9.0.1 setuptools==36.6.0
+  - pip install pip==9.0.2 setuptools==28.8.0 setuptools-rust==0.11.4 cffi==1.14.5
   # Grab a specific version of Cryptography if desired. Doing this before other
   # installations ensures we don't have to do any downgrading/overriding.
   - |
     if [[ -n "$OLDEST_CRYPTO" ]]; then
+      export CRYPTOGRAPHY_DONT_BUILD_RUST=1
       pip install "cryptography==${OLDEST_CRYPTO}"
     fi
   # Self-install for setup.py-driven deps (plus additional
   # safe-enough-for-all-matrix-cells optional deps)
   # TODO: additional matrices or test steps to test all the entrypoints
-  - pip install -e ".[ed25519,invoke]"
+  - |
+    export CRYPTOGRAPHY_DONT_BUILD_RUST=1
+    sudo apt-get install -y gcc
+    pip install -e ".[ed25519,invoke]"
   # Dev (doc/test running) requirements
   # TODO: use poetry + whatever contexty-type stuff it has, should be more than
   # just prod/dev split. Also apply to the above re: extras_require.

--- a/README.rst
+++ b/README.rst
@@ -143,3 +143,8 @@ use the package k5test to setup a Kerberos environment on the fly::
     $ pip install -r dev-requirements.txt
     $ pip install k5test gssapi pyasn1
     $ pytest
+
+Tests can be executed against different Python versions handled by
+`tox https://tox.readthedocs.io/en/latest/` with the command::
+
+   $ tox

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,6 +6,7 @@ pytest-relaxed==1.1.5
 # pytest-xdist for test dir watching and the inv guard task
 pytest-xdist==1.28.0
 mock==2.0.0
+tox>=2.3
 # Linting!
 flake8==3.8.3
 # Coverage!

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py27,py34,py35,py36
+
+[testenv]
+deps = -rdev-requirements.txt
+commands = pytest


### PR DESCRIPTION
@bitprophet 

This change add `tox.ini` file definitions in order run the [paramiko](/paramiko/paramiko) tests against different versions of python by using [tox](https://tox.readthedocs.io) project.

Contains only the minimum requirements in order to tests against the current supported versions defined into the [setup.py](/paramiko/paramiko/blob/master/setup.py#L66) classifiers. It's handy for testing pipeline!

It outputs a nice colored summary at the end of the tests sessions. The following command run for `py27` and `py35` environments only:

```
$ tox -e py27,py35
...
_________________________________________________ summary_________________________________________________
  py27: commands succeeded
  py35: commands succeeded
  congratulations :)
$ echo $?
0
```

TODO:

- [x] Update with `py37` when #1247 is merged