### PR TITLE
Highlight python syntax in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,9 @@ Demo
 ----
 
 Several demo scripts come with Paramiko to demonstrate how to use it.
-Probably the simplest demo is this::
+Probably the simplest demo is this
+
+.. code-block:: python
 
     import base64
     import paramiko


### PR DESCRIPTION
So we go from this:

![screenshot_2018-10-12 ocaballeror paramiko 1](https://user-images.githubusercontent.com/20464046/46870200-3c487880-ce2e-11e8-90f8-25ab224e1c79.png)

to this:

![screenshot_2018-10-12 ocaballeror paramiko](https://user-images.githubusercontent.com/20464046/46870244-5e41fb00-ce2e-11e8-9d81-502178c40dbb.png)

