### PR TITLE
Help users ignore unimportant errors

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -830,7 +830,7 @@ class WarningPolicy(MissingHostKeyPolicy):
         )
 
 
-class IgnorePolicy(paramiko.MissingHostKeyPolicy):
+class IgnorePolicy(MissingHostKeyPolicy):
     """
     Policy for ignoring missing host key.
     """

--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -828,3 +828,12 @@ class WarningPolicy(MissingHostKeyPolicy):
                 key.get_name(), hostname, hexlify(key.get_fingerprint())
             )
         )
+
+
+class IgnorePolicy(paramiko.MissingHostKeyPolicy):
+    """
+    Policy for ignoring missing host key.
+    """
+
+    def missing_host_key(self, client, hostname, key):
+        pass


### PR DESCRIPTION
Offer an SSH key policy for users who want to ignore unregistered key errors