### PR TITLE
Force zero-copy slicing with memoryview

### DIFF
--- a/paramiko/file.py
+++ b/paramiko/file.py
@@ -518,6 +518,7 @@ class BufferedFile(ClosingContextManager):
     def _write_all(self, data):
         # the underlying stream may be something that does partial writes (like
         # a socket).
+        data = memoryview(data)
         while len(data) > 0:
             count = self._write(data)
             data = data[count:]


### PR DESCRIPTION
Fixes #892 for uploading large strings/buffers, like hundreds of MiB.

There's a tremendous improvement of `SFTPFile.write(...)` with a byte string of 500 MiB, for example.