### PR TITLE
Mux transport for client

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -334,7 +334,8 @@ class SSHClient(ClosingContextManager):
         if controlpath:
             try:
                 t = self._transport = Transport(
-                    (hostname, port), controlpath=controlpath)
+                    (hostname, port), controlpath=controlpath
+                )
                 # If this connection succeeds, most (but not all) of the
                 # SSHClient connect steps can be bypassed
                 if self._log_channel is not None:

--- a/paramiko/common.py
+++ b/paramiko/common.py
@@ -174,6 +174,15 @@ CONNECTION_FAILED_CODE = {
     DISCONNECT_NO_MORE_AUTH_METHODS_AVAILABLE,
 ) = (7, 13, 14)
 
+(
+    MUX_MSG_HELLO,
+    MUX_C_PROXY,
+    MUX_S_PROXY,
+    MUX_C_ALIVE_CHECK,
+    MUX_S_ALIVE,
+    MUX_S_OK,
+) = (1, 0x1000000F, 0x8000000F, 0x10000004, 0x80000005, 0x80000001)
+
 zero_byte = byte_chr(0)
 one_byte = byte_chr(1)
 four_byte = byte_chr(4)

--- a/paramiko/packet.py
+++ b/paramiko/packet.py
@@ -443,7 +443,8 @@ class Packetizer(object):
             if self.__dump_packets:
                 self._log(
                     DEBUG,
-                    "Write mux packet <{}>, length {}".format(mux_packet_type, len(data)),
+                    "Write mux packet <{}>, length {}".format(
+                        mux_packet_type, len(data)),
                 )
                 self._log(DEBUG, util.format_binary(out, "OUT: "))
             self.write_all(out)
@@ -470,7 +471,8 @@ class Packetizer(object):
         # leftover contains decrypted bytes from the first block (after the
         # length field)
         leftover = header[4:]
-        if self.__block_size_in and (packet_size - len(leftover)) % self.__block_size_in != 0:
+        if (self.__block_size_in and
+                (packet_size - len(leftover)) % self.__block_size_in != 0):
             raise SSHException("Invalid packet blocking")
         buf = self.read_all(packet_size + self.__mac_size_in - len(leftover))
         packet = buf[: packet_size - len(leftover)]
@@ -567,7 +569,8 @@ class Packetizer(object):
         if self.__dump_packets:
             self._log(
                 DEBUG,
-                "Read mux packet <{}>, length {}".format(mux_packet_type, len(data)),
+                "Read mux packet <{}>, length {}".format(
+                    mux_packet_type, len(data)),
             )
             self._log(DEBUG, util.format_binary(len_prefix + data, "IN: "))
         return mux_packet_type, msg

--- a/paramiko/packet.py
+++ b/paramiko/packet.py
@@ -444,7 +444,8 @@ class Packetizer(object):
                 self._log(
                     DEBUG,
                     "Write mux packet <{}>, length {}".format(
-                        mux_packet_type, len(data)),
+                        mux_packet_type, len(data)
+                    ),
                 )
                 self._log(DEBUG, util.format_binary(out, "OUT: "))
             self.write_all(out)
@@ -471,8 +472,10 @@ class Packetizer(object):
         # leftover contains decrypted bytes from the first block (after the
         # length field)
         leftover = header[4:]
-        if (self.__block_size_in and
-                (packet_size - len(leftover)) % self.__block_size_in != 0):
+        if (
+            self.__block_size_in
+            and (packet_size - len(leftover)) % self.__block_size_in != 0
+        ):
             raise SSHException("Invalid packet blocking")
         buf = self.read_all(packet_size + self.__mac_size_in - len(leftover))
         packet = buf[: packet_size - len(leftover)]
@@ -570,7 +573,8 @@ class Packetizer(object):
             self._log(
                 DEBUG,
                 "Read mux packet <{}>, length {}".format(
-                    mux_packet_type, len(data)),
+                    mux_packet_type, len(data)
+                ),
             )
             self._log(DEBUG, util.format_binary(len_prefix + data, "IN: "))
         return mux_packet_type, msg

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -386,7 +386,8 @@ class Transport(threading.Thread, ClosingContextManager):
                 raise SSHException(
                     "Unable to connect to ControlPath '{}' - {}".format(
                         controlpath, e
-                    ))
+                    )
+                )
 
         if type(sock) is tuple:
             # connect to the given (host, port)
@@ -498,7 +499,6 @@ class Transport(threading.Thread, ClosingContextManager):
             self.auth_handler = AuthHandler(self)
             self.auth_handler.authenticated = True
             self.clear_to_send.set()
-
 
     def __repr__(self):
         """
@@ -2031,16 +2031,17 @@ class Transport(threading.Thread, ClosingContextManager):
                     self._log(
                         DEBUG,
                         "Local version/idstring: {}".format(
-                            self.local_version),
+                            self.local_version
+                        ),
                     )  # noqa
                     self._check_banner()
-                    # The above is actually very much part of the handshake, but
-                    # sometimes the banner can be read but the machine is not
-                    # responding, for example when the remote ssh daemon is loaded
-                    # in to memory but we can not read from the disk/spawn a new
-                    # shell.
-                    # Make sure we can specify a timeout for the initial handshake.
-                    # Re-use the banner timeout for now.
+                    # The above is actually very much part of the handshake,
+                    # but sometimes the banner can be read but the machine is
+                    # not responding, for example when the remote ssh daemon is
+                    # loaded in to memory but we can not read from the
+                    # dick/spawn a new shell.
+                    # Make sure we can specify a timeout for the initial
+                    # handshake. Re-use the banner timeout for now.
                     self.packetizer.start_handshake(self.handshake_timeout)
                     self._send_kex_init()
                     self._expect_packet(MSG_KEXINIT)
@@ -2865,12 +2866,15 @@ class Transport(threading.Thread, ClosingContextManager):
         resp, msg = self.packetizer.read_mux_message()
         if resp != MUX_MSG_HELLO:
             raise SSHException(
-                "Expected MUX_MSG_HELLO response, got 0x{:x}".format(resp))
+                "Expected MUX_MSG_HELLO response, got 0x{:x}".format(resp)
+            )
         remote_version = msg.get_int()
         if remote_version != version:
             raise SSHException(
                 "Expected Mux protocol version {:d}, got {:d}".format(
-                    version, remote_version))
+                    version, remote_version
+                )
+            )
         # Send MUX_C_ALIVE_CHECK as final confirmation
         m = paramiko.Message()
         m.add_int(MUX_C_ALIVE_CHECK)
@@ -2882,7 +2886,8 @@ class Transport(threading.Thread, ClosingContextManager):
         request_id = msg.get_int()
         if request_id != 1:
             raise SSHException(
-                "Mux reply - expected request id 1, got {}", request_id)
+                "Mux reply - expected request id 1, got {}", request_id
+            )
         pid = msg.get_int()
         self._log(DEBUG, "Connected to SSH ControlMaster (PID {})".format(pid))
         # Everything looks good, one last request to enter proxy mode

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -84,6 +84,11 @@ from paramiko.common import (
     HIGHEST_USERAUTH_MESSAGE_ID,
     MSG_UNIMPLEMENTED,
     MSG_NAMES,
+    MUX_MSG_HELLO,
+    MUX_C_PROXY,
+    MUX_S_PROXY,
+    MUX_C_ALIVE_CHECK,
+    MUX_S_ALIVE,
 )
 from paramiko.compress import ZlibCompressor, ZlibDecompressor
 from paramiko.dsskey import DSSKey
@@ -292,6 +297,7 @@ class Transport(threading.Thread, ClosingContextManager):
         default_max_packet_size=DEFAULT_MAX_PACKET_SIZE,
         gss_kex=False,
         gss_deleg_creds=True,
+        mux_path = None,
     ):
         """
         Create a new SSH session over an existing socket, or socket-like
@@ -339,6 +345,8 @@ class Transport(threading.Thread, ClosingContextManager):
         """
         self.active = False
         self.hostname = None
+        self.log_name = "paramiko.transport"
+        self.logger = util.get_logger(self.log_name)
 
         if isinstance(sock, string_types):
             # convert "host:port" into (host, port)
@@ -348,6 +356,28 @@ class Transport(threading.Thread, ClosingContextManager):
                 sock = (hl[0], 22)
             else:
                 sock = (hl[0], int(hl[1]))
+        # If mux_path is set, try connecting to it, fallback to non-mux
+        self.mux_path = None
+        if mux_path:
+            try:
+                self._log(INFO, "Trying ControlPath '%s'", mux_path)
+                mux_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                mux_sock.connect(mux_path)
+                self._log(DEBUG, "Connected to ControlPath '%s'", mux_path)
+                # Send/recv the HELLO message to Mux server
+                self.packetizer = Packetizer(mux_sock)
+                self.packetizer.set_log(self.logger)
+                # Mux connection requires no cipher, no compression, no padding
+                self.packetizer.set_outbound_cipher(None, 0, None, 0, None)
+                self.packetizer.set_inbound_cipher(None, 0, None, 0, None)
+                #
+                self._start_mux_session()
+                self.mux_path = mux_path
+                sock = mux_sock
+            except Exception as e:
+                self._log(INFO, "Multiplex connection failed: %r", e)
+                self._log(INFO, "Falling back to socket connection")
+
         if type(sock) is tuple:
             # connect to the given (host, port)
             hostname, port = sock
@@ -380,7 +410,8 @@ class Transport(threading.Thread, ClosingContextManager):
         self.sock.settimeout(self._active_check_timeout)
 
         # negotiated crypto parameters
-        self.packetizer = Packetizer(sock)
+        if not self.mux_path:
+            self.packetizer = Packetizer(sock)
         self.local_version = "SSH-" + self._PROTO_ID + "-" + self._CLIENT_ID
         self.remote_version = ""
         self.local_cipher = self.remote_cipher = ""
@@ -428,8 +459,6 @@ class Transport(threading.Thread, ClosingContextManager):
         self.clear_to_send = threading.Event()
         self.clear_to_send_lock = threading.Lock()
         self.clear_to_send_timeout = 30.0
-        self.log_name = "paramiko.transport"
-        self.logger = util.get_logger(self.log_name)
         self.packetizer.set_log(self.logger)
         self.auth_handler = None
         # response Message from an arbitrary global request
@@ -452,6 +481,15 @@ class Transport(threading.Thread, ClosingContextManager):
         self.server_accept_cv = threading.Condition(self.lock)
         self.subsystem_table = {}
 
+        # Express connect state when using ControlMaster
+        if self.mux_path:
+            self.initial_kex_done = True
+            self.authenticated = True
+            self.auth_handler = AuthHandler(self)
+            self.auth_handler.authenticated = True
+            self.clear_to_send.set()
+
+
     def __repr__(self):
         """
         Returns a string representation of this object, for debugging.
@@ -460,6 +498,8 @@ class Transport(threading.Thread, ClosingContextManager):
         out = "<paramiko.Transport at {}".format(id_)
         if not self.active:
             out += " (unconnected)"
+        elif self.mux_path:
+            out += " (Mux/ControlPath {})".format(self.mux_path)
         else:
             if self.local_cipher != "":
                 out += " (cipher {}, {:d} bits)".format(
@@ -1216,6 +1256,10 @@ class Transport(threading.Thread, ClosingContextManager):
         )
 
         self.start_client()
+        if self.mux_path:
+            # If ControlMaster connection has been established, then there
+            # is no need to check host keys or do any user authentication
+            return
 
         # check host key if we were given one
         # If GSS-API Key Exchange was performed, we are not required to check
@@ -1956,24 +2000,30 @@ class Transport(threading.Thread, ClosingContextManager):
             self._log(DEBUG, "starting thread (server mode): {}".format(tid))
         else:
             self._log(DEBUG, "starting thread (client mode): {}".format(tid))
+            if self.mux_path:
+                # No initial protocol chatter (banner, Kex) takes
+                # place when using ControlMaster mux connection. Force
+                # the completion event to allow start_client to return.
+                self.completion_event.set()
         try:
             try:
-                self.packetizer.write_all(b(self.local_version + "\r\n"))
-                self._log(
-                    DEBUG,
-                    "Local version/idstring: {}".format(self.local_version),
-                )  # noqa
-                self._check_banner()
-                # The above is actually very much part of the handshake, but
-                # sometimes the banner can be read but the machine is not
-                # responding, for example when the remote ssh daemon is loaded
-                # in to memory but we can not read from the disk/spawn a new
-                # shell.
-                # Make sure we can specify a timeout for the initial handshake.
-                # Re-use the banner timeout for now.
-                self.packetizer.start_handshake(self.handshake_timeout)
-                self._send_kex_init()
-                self._expect_packet(MSG_KEXINIT)
+                if not self.mux_path:
+                    self.packetizer.write_all(b(self.local_version + "\r\n"))
+                    self._log(
+                        DEBUG,
+                        "Local version/idstring: {}".format(self.local_version),
+                    )  # noqa
+                    self._check_banner()
+                    # The above is actually very much part of the handshake, but
+                    # sometimes the banner can be read but the machine is not
+                    # responding, for example when the remote ssh daemon is loaded
+                    # in to memory but we can not read from the disk/spawn a new
+                    # shell.
+                    # Make sure we can specify a timeout for the initial handshake.
+                    # Re-use the banner timeout for now.
+                    self.packetizer.start_handshake(self.handshake_timeout)
+                    self._send_kex_init()
+                    self._expect_packet(MSG_KEXINIT)
 
                 while self.active:
                     if self.packetizer.need_rekey() and not self.in_kex:
@@ -2778,6 +2828,46 @@ class Transport(threading.Thread, ClosingContextManager):
             return self.subsystem_table[name]
         finally:
             self.lock.release()
+
+    def _start_mux_session(self, version=4):
+        """
+        Check the SSH ControlMaster connection, and ensure that the
+        server side responds appropriately to MUX_MSG_HELLO, MUX_C_ALIVE_CHECK,
+        and MUX_C_PROXY messages. Once entering proxy mode, the client
+        SSH protocol messages can be sent to the ControlMaster as
+        unencrypted, unpadded Transport messages.
+        """
+        m = paramiko.Message()
+        m.add_int(MUX_MSG_HELLO)
+        m.add_int(version)
+        self.packetizer.send_mux_message(m.asbytes())
+        resp, msg = self.packetizer.read_mux_message()
+        if resp != MUX_MSG_HELLO:
+            raise SSHException("Expected MUX_MSG_HELLO response, got 0x{:x}".format(resp))
+        remote_version = msg.get_int()
+        if remote_version != version:
+            raise SSHException("Expected Mux protocol version {:d}, got {:d}".format(version, remote_version))
+        # Send MUX_C_ALIVE_CHECK as final confirmation
+        m = paramiko.Message()
+        m.add_int(MUX_C_ALIVE_CHECK)
+        m.add_int(1)
+        self.packetizer.send_mux_message(m.asbytes())
+        resp, msg = self.packetizer.read_mux_message()
+        if resp != MUX_S_ALIVE:
+            raise SSHException("Mux Alive - Invalid reply 0x{:x}".format(resp))
+        request_id = msg.get_int()
+        if request_id != 1:
+            raise SSHException("Mux reply - expected request id 1, got {}", request_id)
+        pid = msg.get_int()
+        self._log(DEBUG, "Connected to SSH ControlMaster (PID {})".format(pid))
+        # Everything looks good, one last request to enter proxy mode
+        m = paramiko.Message()
+        m.add_int(MUX_C_PROXY)
+        m.add_int(2)
+        self.packetizer.send_mux_message(m.asbytes())
+        resp, msg = self.packetizer.read_mux_message()
+        if resp != MUX_S_PROXY or msg.get_int() != 2:
+            raise SSHException('Mux proxy request - got unexpected reply: 0x{:x} {!r}'.format(resp, msg))
 
     _handler_table = {
         MSG_NEWKEYS: _parse_newkeys,

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -2039,7 +2039,7 @@ class Transport(threading.Thread, ClosingContextManager):
                     # but sometimes the banner can be read but the machine is
                     # not responding, for example when the remote ssh daemon is
                     # loaded in to memory but we can not read from the
-                    # dick/spawn a new shell.
+                    # disk/spawn a new shell.
                     # Make sure we can specify a timeout for the initial
                     # handshake. Re-use the banner timeout for now.
                     self.packetizer.start_handshake(self.handshake_timeout)
@@ -2898,7 +2898,8 @@ class Transport(threading.Thread, ClosingContextManager):
         resp, msg = self.packetizer.read_mux_message()
         if resp != MUX_S_PROXY or msg.get_int() != 2:
             raise SSHException(
-                "Mux proxy request - got unexpected reply: 0x{:x} {!r}".format(
+                "Mux proxy request rejected (Requires OpenSSH 7.4 or greater)"
+                " - got unexpected reply: 0x{:x} {!r}".format(
                     resp, msg
                 )
             )

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -338,9 +338,9 @@ class Transport(threading.Thread, ClosingContextManager):
         :param int default_max_packet_size:
             sets the default max packet size on the transport. (defaults to
             32768)
-        :param boolean gss_kex:
+        :param bool gss_kex:
             Use GSSAPI key exchange
-        :param boolean gss_deleg_creds:
+        :param bool gss_deleg_creds:
             Opt to delegate GSSAPI credentials
         :param string controlpath:
             Connect to a multiplexing ControlMaster instead of standard

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -2899,7 +2899,9 @@ class Transport(threading.Thread, ClosingContextManager):
         if resp != MUX_S_PROXY or msg.get_int() != 2:
             raise SSHException(
                 "Mux proxy request - got unexpected reply: 0x{:x} {!r}".format(
-                    resp, msg))
+                    resp, msg
+                )
+            )
 
     _handler_table = {
         MSG_NEWKEYS: _parse_newkeys,


### PR DESCRIPTION
Draft implementation for #852 

Seems to work fine for normal open_session management, some quirks with port forwarding and global request/response handling, and catastrophic behavior if renegotiate_keys is called when in proxy mode :)

Some guesswork needed, as the OpenSSH client uses "passenger mode" instead of "proxy mode", but proxy mode seems a much better fit for paramiko, since the SSH protocol messages are already implemented, and the proxy mode only required a small set of changes to the packetizing (zero padding failed to work due to modulo calculation)

Supply a (new) controlpath parameter to `Transport()` or `SSHClient()`, and domain socket connection is attempted. If successful, it confirms that is is talking to a ControlMaster server, and switches the ControlMaster session into Proxy mode. The Transport then behaves as an authenticated transport, skipping the initial hostkey validation, key exchange, and user auth.