### PR TITLE
Add testing and document support for Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 sudo: false
 cache:
@@ -8,21 +9,18 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "3.7-dev"
-  - "pypy-5.6.0"
+  - "3.7"
+  - "pypy2.7-6.0"
+  - "pypy3.5-6.0"
 matrix:
-  allow_failures:
-    - python: "3.7-dev"
   # Explicitly test against our oldest supported cryptography.io, in addition
   # to whatever the latest default is.
   include:
     - python: 2.7
       env: "CRYPTO_BEFORE=1.6"
-    - python: 3.6
+    - python: 3.7
       env: "CRYPTO_BEFORE=1.6"
 install:
-  # Ensure modern pip/etc to avoid some issues w/ older worker environs
-  - pip install pip==9.0.1 setuptools==36.6.0
   # Grab a specific version of Cryptography if desired. Doing this before other
   # installations ensures we don't have to do any downgrading/overriding.
   - |

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
     install_requires=["bcrypt>=3.1.3", "cryptography>=1.5", "pynacl>=1.0.1"],
 )


### PR DESCRIPTION
Python 3.7 was released on June 27, 2018.

https://docs.python.org/3/whatsnew/3.7.html

Use 'dist: xenial' on Travis to use Python 3.7. Travis officially added
support for Xenial on 2018-11-08.

https://blog.travis-ci.com/2018-11-08-xenial-release

Using PyPy on xenial requires an explicit version, see:

https://travis-ci.community/t/pypy-2-7-on-xenial/889