### PR TITLE
pin pytest-xdist to < 1.25.0

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,7 +5,7 @@ invocations>=1.2.0,<2.0
 pytest>=3.2,<3.3
 pytest-relaxed==1.1.4
 # pytest-xdist for test dir watching and the inv guard task
-pytest-xdist>=1.22,<2.0
+pytest-xdist>=1.22,<1.25.0
 mock==2.0.0
 # Linting!
 flake8==2.4.0


### PR DESCRIPTION
1.25.0 requires pytest >=3.6, but pytest-relaxed doesn't support pytest >3.2.x. This temporary pin can work around that issue. Without this the test suite is broken (although ultimately pytest-relaxed should be updated to support newer pytest).

This affects the cryptography downstream tests right now so we'd like to get it resolved ASAP.