### PR TITLE
handling of terminated proxy commands

### DIFF
--- a/paramiko/proxy.py
+++ b/paramiko/proxy.py
@@ -87,6 +87,10 @@ class ProxyCommand(ClosingContextManager):
             buffer = b""
             start = time.time()
             while len(buffer) < size:
+                if self.closed:
+                    if buffer:
+                        return buffer
+                    raise EOFError()
                 select_timeout = None
                 if self.timeout is not None:
                     elapsed = time.time() - start
@@ -113,7 +117,7 @@ class ProxyCommand(ClosingContextManager):
 
     @property
     def closed(self):
-        return self.process.returncode is not None
+        return self.process.poll() is not None
 
     @property
     def _closed(self):


### PR DESCRIPTION
The existing code will not robustly detect if the proxy command has terminated;

In `recv`, since we are usually just polling and not performing any operation on the pipe, no operation on the pipe is performed for it to detect/raise an error condition.  `send` is OK, this should raise a BrokenPipeError, but I believe we should poll the subprocess to check it's still alive within the `recv` loop.

Also, the `closed` property currently checks returncode, which would never be set without polling the subprocess anyway.