### PR TITLE
Remove unnecessary compat shim bytes

### DIFF
--- a/paramiko/channel.py
+++ b/paramiko/channel.py
@@ -43,7 +43,6 @@ from paramiko.common import (
     cMSG_CHANNEL_CLOSE,
 )
 from paramiko.message import Message
-from paramiko.py3compat import bytes_types
 from paramiko.ssh_exception import SSHException
 from paramiko.file import BufferedFile
 from paramiko.buffered_pipe import BufferedPipe, PipeTimeout
@@ -1021,7 +1020,7 @@ class Channel(ClosingContextManager):
                 self.transport._send_user_message(m)
 
     def _feed(self, m):
-        if isinstance(m, bytes_types):
+        if isinstance(m, bytes):
             # passed from _feed_extended
             s = m
         else:

--- a/paramiko/file.py
+++ b/paramiko/file.py
@@ -22,7 +22,7 @@ from paramiko.common import (
     linefeed_byte,
     cr_byte_value,
 )
-from paramiko.py3compat import BytesIO, PY2, u, bytes_types, text_type
+from paramiko.py3compat import BytesIO, PY2, u, text_type
 
 from paramiko.util import ClosingContextManager
 
@@ -537,9 +537,7 @@ class BufferedFile(ClosingContextManager):
             return
         if self.newlines is None:
             self.newlines = newline
-        elif self.newlines != newline and isinstance(
-            self.newlines, bytes_types
-        ):
+        elif self.newlines != newline and isinstance(self.newlines, bytes):
             self.newlines = (self.newlines, newline)
         elif newline not in self.newlines:
             self.newlines += (newline,)

--- a/paramiko/py3compat.py
+++ b/paramiko/py3compat.py
@@ -12,8 +12,6 @@ __all__ = [
     "byte_chr",
     "byte_mask",
     "byte_ord",
-    "bytes",
-    "bytes_types",
     "decodebytes",
     "encodebytes",
     "input",
@@ -31,8 +29,6 @@ PY2 = sys.version_info[0] < 3
 if PY2:
     string_types = basestring  # NOQA
     text_type = unicode  # NOQA
-    bytes_types = str
-    bytes = str
     integer_types = (int, long)  # NOQA
     long = long  # NOQA
     input = raw_input  # NOQA
@@ -107,8 +103,6 @@ else:
 
     string_types = str
     text_type = str
-    bytes = bytes
-    bytes_types = bytes
     integer_types = int
 
     class long(int):

--- a/paramiko/sftp_server.py
+++ b/paramiko/sftp_server.py
@@ -36,7 +36,7 @@ from paramiko.sftp import (
 from paramiko.sftp_si import SFTPServerInterface
 from paramiko.sftp_attr import SFTPAttributes
 from paramiko.common import DEBUG
-from paramiko.py3compat import long, string_types, bytes_types, b
+from paramiko.py3compat import long, string_types, b
 from paramiko.server import SubsystemHandler
 
 
@@ -232,7 +232,7 @@ class SFTPServer(BaseSFTP, SubsystemHandler):
                 msg.add_int64(item)
             elif isinstance(item, int):
                 msg.add_int(item)
-            elif isinstance(item, (string_types, bytes_types)):
+            elif isinstance(item, (string_types, bytes)):
                 msg.add_string(item)
             elif type(item) is SFTPAttributes:
                 item._pack(msg)
@@ -340,7 +340,7 @@ class SFTPServer(BaseSFTP, SubsystemHandler):
             hash_obj = alg()
             while count < blocklen:
                 data = f.read(offset, chunklen)
-                if not isinstance(data, bytes_types):
+                if not isinstance(data, bytes):
                     self._send_status(
                         request_number, data, "Unable to hash file"
                     )
@@ -408,7 +408,7 @@ class SFTPServer(BaseSFTP, SubsystemHandler):
                 )
                 return
             data = self.file_table[handle].read(offset, length)
-            if isinstance(data, (bytes_types, string_types)):
+            if isinstance(data, (bytes, string_types)):
                 if len(data) == 0:
                     self._send_status(request_number, SFTP_EOF)
                 else:
@@ -500,7 +500,7 @@ class SFTPServer(BaseSFTP, SubsystemHandler):
         elif t == CMD_READLINK:
             path = msg.get_text()
             resp = self.server.readlink(path)
-            if isinstance(resp, (bytes_types, string_types)):
+            if isinstance(resp, (bytes, string_types)):
                 self._response(
                     request_number, CMD_NAME, 1, resp, "", SFTPAttributes()
                 )

--- a/tests/test_pkey.py
+++ b/tests/test_pkey.py
@@ -28,7 +28,7 @@ from hashlib import md5
 import base64
 
 from paramiko import RSAKey, DSSKey, ECDSAKey, Ed25519Key, Message, util
-from paramiko.py3compat import StringIO, byte_chr, b, bytes, PY2
+from paramiko.py3compat import StringIO, byte_chr, b, PY2
 
 from .util import _support
 

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -59,7 +59,7 @@ from paramiko.common import (
     MSG_UNIMPLEMENTED,
     MSG_USERAUTH_SUCCESS,
 )
-from paramiko.py3compat import bytes, byte_chr
+from paramiko.py3compat import byte_chr
 from paramiko.message import Message
 
 from .util import needs_builtin, _support, slow


### PR DESCRIPTION
The bytes type exists on both Python 2.7 and Python 3. On Python2.7, it
is an alias of str, same as was previously defined in py3compat.py.
Makes the code slightly more forward compatible with Python 3. Observe:

    $ python2
    >>> bytes
    <type 'str'>