### PR TITLE
Import MutableMapping from collections.abc instead of collections

### DIFF
--- a/paramiko/hostkeys.py
+++ b/paramiko/hostkeys.py
@@ -19,8 +19,12 @@
 
 import binascii
 import os
+import sys
 
-from collections import MutableMapping
+if sys.version_info[:2] >= (3, 3):
+    from collections.abc import MutableMapping
+else:
+    from collections import MutableMapping
 from hashlib import sha1
 from hmac import HMAC
 


### PR DESCRIPTION
Importing the collections ABCs from `collections` is deprecated and will not work in Python 3.8. From the [docs](https://docs.python.org/3/library/collections.html#module-collections):

> Changed in version 3.3: Moved Collections Abstract Base Classes to the `collections.abc` module. For backwards compatibility, they continue to be visible in this module through Python 3.7. Subsequently, they will be removed entirely.

This PR checks for the Python version being >=3.3 and imports `MutableMapping` from `collections.abc` instead of `collections` if it is.

(Fixed version of PR #1377, apologies)