### PR TITLE
Move to cryptography 2.5 and stop using deprecated APIs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,9 @@ matrix:
   # to whatever the latest default is.
   include:
     - python: 2.7
-      env: "CRYPTO_BEFORE=1.6"
+      env: "CRYPTO_BEFORE=2.5"
     - python: 3.6
-      env: "CRYPTO_BEFORE=1.6"
+      env: "CRYPTO_BEFORE=2.5"
 install:
   # Ensure modern pip/etc to avoid some issues w/ older worker environs
   - pip install pip==9.0.1 setuptools==36.6.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,9 @@ matrix:
   # to whatever the latest default is.
   include:
     - python: 2.7
-      env: "CRYPTO_BEFORE=2.5"
+      env: "CRYPTO_BEFORE=2.6"
     - python: 3.6
-      env: "CRYPTO_BEFORE=2.5"
+      env: "CRYPTO_BEFORE=2.6"
 install:
   # Ensure modern pip/etc to avoid some issues w/ older worker environs
   - pip install pip==9.0.1 setuptools==36.6.0

--- a/paramiko/ecdsakey.py
+++ b/paramiko/ecdsakey.py
@@ -160,12 +160,11 @@ class ECDSAKey(PKey):
 
             pointinfo = msg.get_binary()
             try:
-                numbers = ec.EllipticCurvePublicKey.from_encoded_point(
+                self.verifying_key = ec.EllipticCurvePublicKey.from_encoded_point(
                     self.ecdsa_curve.curve_class(), pointinfo
-                ).public_numbers()
+                )
             except ValueError:
                 raise SSHException("Invalid public key")
-            self.verifying_key = numbers.public_key(backend=default_backend())
 
     @classmethod
     def supported_key_format_identifiers(cls):

--- a/paramiko/ecdsakey.py
+++ b/paramiko/ecdsakey.py
@@ -160,9 +160,9 @@ class ECDSAKey(PKey):
 
             pointinfo = msg.get_binary()
             try:
-                numbers = ec.EllipticCurvePublicNumbers.from_encoded_point(
+                numbers = ec.EllipticCurvePublicKey.from_encoded_point(
                     self.ecdsa_curve.curve_class(), pointinfo
-                )
+                ).public_numbers()
             except ValueError:
                 raise SSHException("Invalid public key")
             self.verifying_key = numbers.public_key(backend=default_backend())

--- a/paramiko/ecdsakey.py
+++ b/paramiko/ecdsakey.py
@@ -160,9 +160,10 @@ class ECDSAKey(PKey):
 
             pointinfo = msg.get_binary()
             try:
-                self.verifying_key = ec.EllipticCurvePublicKey.from_encoded_point(
+                key = ec.EllipticCurvePublicKey.from_encoded_point(
                     self.ecdsa_curve.curve_class(), pointinfo
                 )
+                self.verifying_key = key
             except ValueError:
                 raise SSHException("Invalid public key")
 

--- a/paramiko/kex_ecdh_nist.py
+++ b/paramiko/kex_ecdh_nist.py
@@ -66,9 +66,9 @@ class KexNistp256:
         Q_C_bytes = m.get_string()
         self.Q_C = ec.EllipticCurvePublicKey.from_encoded_point(
             self.curve, Q_C_bytes
-        ).public_numbers()
+        )
         K_S = self.transport.get_server_key().asbytes()
-        K = self.P.exchange(ec.ECDH(), self.Q_C.public_key(default_backend()))
+        K = self.P.exchange(ec.ECDH(), self.Q_C)
         K = long(hexlify(K), 16)
         # compute exchange hash
         hm = Message()
@@ -110,9 +110,9 @@ class KexNistp256:
         Q_S_bytes = m.get_string()
         self.Q_S = ec.EllipticCurvePublicKey.from_encoded_point(
             self.curve, Q_S_bytes
-        ).public_numbers()
+        )
         sig = m.get_binary()
-        K = self.P.exchange(ec.ECDH(), self.Q_S.public_key(default_backend()))
+        K = self.P.exchange(ec.ECDH(), self.Q_S)
         K = long(hexlify(K), 16)
         # compute exchange hash and verify signature
         hm = Message()

--- a/paramiko/kex_ecdh_nist.py
+++ b/paramiko/kex_ecdh_nist.py
@@ -9,6 +9,7 @@ from paramiko.py3compat import byte_chr, long
 from paramiko.ssh_exception import SSHException
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives import serialization
 from binascii import hexlify
 
 _MSG_KEXECDH_INIT, _MSG_KEXECDH_REPLY = range(30, 32)
@@ -36,7 +37,12 @@ class KexNistp256:
         m = Message()
         m.add_byte(c_MSG_KEXECDH_INIT)
         # SEC1: V2.0  2.3.3 Elliptic-Curve-Point-to-Octet-String Conversion
-        m.add_string(self.Q_C.public_numbers().encode_point())
+        m.add_string(
+            self.Q_C.public_bytes(
+                serialization.Encoding.X962,
+                serialization.PublicFormat.UncompressedPoint,
+            )
+        )
         self.transport._send_message(m)
         self.transport._expect_packet(_MSG_KEXECDH_REPLY)
 
@@ -58,9 +64,9 @@ class KexNistp256:
 
     def _parse_kexecdh_init(self, m):
         Q_C_bytes = m.get_string()
-        self.Q_C = ec.EllipticCurvePublicNumbers.from_encoded_point(
+        self.Q_C = ec.EllipticCurvePublicKey.from_encoded_point(
             self.curve, Q_C_bytes
-        )
+        ).public_numbers()
         K_S = self.transport.get_server_key().asbytes()
         K = self.P.exchange(ec.ECDH(), self.Q_C.public_key(default_backend()))
         K = long(hexlify(K), 16)
@@ -75,7 +81,12 @@ class KexNistp256:
         hm.add_string(K_S)
         hm.add_string(Q_C_bytes)
         # SEC1: V2.0  2.3.3 Elliptic-Curve-Point-to-Octet-String Conversion
-        hm.add_string(self.Q_S.public_numbers().encode_point())
+        hm.add_string(
+            self.Q_S.public_bytes(
+                serialization.Encoding.X962,
+                serialization.PublicFormat.UncompressedPoint,
+            )
+        )
         hm.add_mpint(long(K))
         H = self.hash_algo(hm.asbytes()).digest()
         self.transport._set_K_H(K, H)
@@ -84,7 +95,12 @@ class KexNistp256:
         m = Message()
         m.add_byte(c_MSG_KEXECDH_REPLY)
         m.add_string(K_S)
-        m.add_string(self.Q_S.public_numbers().encode_point())
+        m.add_string(
+            self.Q_S.public_bytes(
+                serialization.Encoding.X962,
+                serialization.PublicFormat.UncompressedPoint,
+            )
+        )
         m.add_string(sig)
         self.transport._send_message(m)
         self.transport._activate_outbound()
@@ -92,9 +108,9 @@ class KexNistp256:
     def _parse_kexecdh_reply(self, m):
         K_S = m.get_string()
         Q_S_bytes = m.get_string()
-        self.Q_S = ec.EllipticCurvePublicNumbers.from_encoded_point(
+        self.Q_S = ec.EllipticCurvePublicKey.from_encoded_point(
             self.curve, Q_S_bytes
-        )
+        ).public_numbers()
         sig = m.get_binary()
         K = self.P.exchange(ec.ECDH(), self.Q_S.public_key(default_backend()))
         K = long(hexlify(K), 16)
@@ -108,7 +124,12 @@ class KexNistp256:
         )
         hm.add_string(K_S)
         # SEC1: V2.0  2.3.3 Elliptic-Curve-Point-to-Octet-String Conversion
-        hm.add_string(self.Q_C.public_numbers().encode_point())
+        hm.add_string(
+            self.Q_C.public_bytes(
+                serialization.Encoding.X962,
+                serialization.PublicFormat.UncompressedPoint,
+            )
+        )
         hm.add_string(Q_S_bytes)
         hm.add_mpint(K)
         self.transport._set_K_H(K, self.hash_algo(hm.asbytes()).digest())

--- a/setup.py
+++ b/setup.py
@@ -71,5 +71,5 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
     ],
-    install_requires=["bcrypt>=3.1.3", "cryptography>=1.5", "pynacl>=1.0.1"],
+    install_requires=["bcrypt>=3.1.3", "cryptography>=2.5", "pynacl>=1.0.1"],
 )

--- a/tests/test_kex.py
+++ b/tests/test_kex.py
@@ -42,20 +42,20 @@ def dummy_urandom(n):
 def dummy_generate_key_pair(obj):
     private_key_value = 94761803665136558137557783047955027733968423115106677159790289642479432803037
     public_key_numbers = "042bdab212fa8ba1b7c843301682a4db424d307246c7e1e6083c41d9ca7b098bf30b3d63e2ec6278488c135360456cc054b3444ecc45998c08894cbc1370f5f989"
-    public_key_numbers_obj = ec.EllipticCurvePublicNumbers.from_encoded_point(
+    public_key_numbers_obj = ec.EllipticCurvePublicKey.from_encoded_point(
         ec.SECP256R1(), unhexlify(public_key_numbers)
-    )
+    ).public_numbers()
     obj.P = ec.EllipticCurvePrivateNumbers(
         private_value=private_key_value, public_numbers=public_key_numbers_obj
     ).private_key(default_backend())
     if obj.transport.server_mode:
-        obj.Q_S = ec.EllipticCurvePublicNumbers.from_encoded_point(
+        obj.Q_S = ec.EllipticCurvePublicKey.from_encoded_point(
             ec.SECP256R1(), unhexlify(public_key_numbers)
-        ).public_key(default_backend())
+        )
         return
-    obj.Q_C = ec.EllipticCurvePublicNumbers.from_encoded_point(
+    obj.Q_C = ec.EllipticCurvePublicKey.from_encoded_point(
         ec.SECP256R1(), unhexlify(public_key_numbers)
-    ).public_key(default_backend())
+    )
 
 
 class FakeKey(object):


### PR DESCRIPTION
Fixes #1369