### PR TITLE
Use pytest.mark.xfail instead of broken pytest_relaxed

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,9 +1,7 @@
 # Invocations for common project tasks
 invoke>=1.0,<2.0
 invocations>=1.2.0,<2.0
-# NOTE: pytest-relaxed currently only works with pytest >=3, <3.3
-pytest>=3.2,<3.3
-pytest-relaxed==1.1.4
+pytest>=3.2
 # pytest-xdist for test dir watching and the inv guard task
 pytest-xdist>=1.22,<1.25.0
 mock==2.0.0

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -33,7 +33,7 @@ import warnings
 import weakref
 from tempfile import mkstemp
 
-from pytest_relaxed import raises
+import pytest
 
 import paramiko
 from paramiko.pkey import PublicBlob
@@ -662,7 +662,7 @@ class PasswordPassphraseTests(ClientTest):
 
     # TODO: more granular exception pending #387; should be signaling "no auth
     # methods available" because no key and no password
-    @raises(SSHException)
+    @pytest.mark.xfail(raises=SSHException)
     def test_passphrase_kwarg_not_used_for_password_auth(self):
         # Using the "right" password in the "wrong" field shouldn't work.
         self._test_connection(passphrase="pygmalion")
@@ -683,8 +683,8 @@ class PasswordPassphraseTests(ClientTest):
             password="television",
         )
 
-    @raises(AuthenticationException)  # TODO: more granular
-    def test_password_kwarg_not_used_for_passphrase_when_passphrase_kwarg_given(  # noqa
+    @pytest.mark.xfail(raises=AuthenticationException)  # TODO: more granular
+    def test_password_kwarg_not_used_for_passphrase_when_passphrase_kwarg_given( # noqa
         self
     ):
         # Sanity: if we're given both fields, the password field is NOT used as


### PR DESCRIPTION
pytest_relaxed is broken with newer versions on pytest. And pytest itself has needed funcionality