### PR TITLE
If the 'wrong' gssapi is present don't use it

### DIFF
--- a/paramiko/ssh_gss.py
+++ b/paramiko/ssh_gss.py
@@ -48,7 +48,10 @@ _API = "MIT"
 try:
     import gssapi
 
-    GSS_EXCEPTIONS = (gssapi.GSSException,)
+    try:
+        GSS_EXCEPTIONS = (gssapi.GSSException,)
+    except AttributeError:
+        raise ImportError("Incorrect gssapi module available")
 except (ImportError, OSError):
     try:
         import pywintypes


### PR DESCRIPTION
See #1068 for details of the issue. This ensures that having the 'wrong' module is treated the same as not having the module at all.

On Ubuntu 16.04 I have installed freeipa-client package which pulls in the [python-gssapi](https://packages.ubuntu.com/xenial/python-gssapi/) package. When I try to import paramiko on this system I get this error (same as the issue linked above):

```console
# python
Python 2.7.12 (default, Nov 12 2018, 14:36:49) 
[GCC 5.4.0 20160609] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import paramiko
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/dist-packages/paramiko/__init__.py", line 22, in <module>
    from paramiko.transport import SecurityOptions, Transport
  File "/usr/local/lib/python2.7/dist-packages/paramiko/transport.py", line 38, in <module>
    from paramiko.auth_handler import AuthHandler
  File "/usr/local/lib/python2.7/dist-packages/paramiko/auth_handler.py", line 72, in <module>
    from paramiko.ssh_gss import GSSAuth, GSS_EXCEPTIONS
  File "/usr/local/lib/python2.7/dist-packages/paramiko/ssh_gss.py", line 55, in <module>
    GSS_EXCEPTIONS = (gssapi.GSSException,)
AttributeError: 'module' object has no attribute 'GSSException'
```

I think the reason for this is because the package installs the ['gssapi' module](https://pypi.org/project/gssapi/) which is no longer maintained, while paramiko expects the ['python-gssapi' module](https://pypi.org/project/python-gssapi/) which is maintained. Because these modules both use the name 'gssapi' paramiko doesn't know which it is actually getting until it tries to access something which doesn't exist in the module I have.

The suggested workaround is to `pip uninstall gssapi` but as I mentioned I cannot do that because it is a system package which is required by other packages which I definitely need.

This PR just changes the behaviour so that if the imported 'gssapi' module does not have a GSSException member then it is treated the same as if the module was not found at all. This works as a solution for me because I do not ever need paramiko to do GSS authentication.