### PR TITLE
issue #1141: avoid quadratic buffer management on Python 3.x

### DIFF
--- a/paramiko/file.py
+++ b/paramiko/file.py
@@ -192,9 +192,9 @@ class BufferedFile(ClosingContextManager):
             raise IOError("File is not open for reading")
         if (size is None) or (size < 0):
             # go for broke
-            result = self._rbuffer
+            result = [self._rbuffer]
+            self._pos += len(self._rbuffer)
             self._rbuffer = bytes()
-            self._pos += len(result)
             while True:
                 try:
                     new_data = self._read(self._DEFAULT_BUFSIZE)
@@ -202,10 +202,10 @@ class BufferedFile(ClosingContextManager):
                     new_data = None
                 if (new_data is None) or (len(new_data) == 0):
                     break
-                result += new_data
+                result.append(new_data)
                 self._realpos += len(new_data)
                 self._pos += len(new_data)
-            return result
+            return bytes().join(result)
         if size <= len(self._rbuffer):
             result = self._rbuffer[:size]
             self._rbuffer = self._rbuffer[size:]


### PR DESCRIPTION
When size is negative or None, it is possible for the result of the read to grow without bound. Since result is managed through repeat string concatenation, runtime is quadratic in the number of successful calls to
_read().

In Python 2 this had reasonable runtime because Python/ceval.c [contained a special case for appending to a string that could be safely mutated](https://github.com/python/cpython/blob/v2.7.11/Python/ceval.c#L5109-L5188), as the only reference to it existed on the stack, however during the great Python 3.x transition this special case was [rewritten to only support Unicode](https://github.com/python/cpython/blob/v3.5.1/Python/ceval.c#L5211-L5259), causing a huge amount of heap churn and memory copies on 3.x.

This was diagnosed using a combination of `/usr/bin/time`, Linux `perf` and `py-spy` run against the reproduction from #1141 to isolate the offending function.

Perf output showing 87% CPU spent in `memcpy()` and soft faults:

![Screenshot from 2019-07-18 11-16-38](https://user-images.githubusercontent.com/2315/61450667-7b70a080-a94f-11e9-80f8-fbd11cd73e36.png)

`/usr/bin/time` output confirming many soft faults due to repeatedly allocated heap having no backing pages on each loop iteration:

````
	Command being timed: "perf record -o perf.3 -g python3 ssh.py ssh 127.0.0.1 dd if=/dev/zero bs=20M count=1 22"
	User time (seconds): 4.68
	System time (seconds): 7.04
	Percent of CPU this job got: 96%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:12.14
	Maximum resident set size (kbytes): 68800
	Minor (reclaiming a frame) page faults: 6569001
````

`/usr/bin/time` with fix applied:

````
	Command being timed: "perf record -o perf.3 -g python3 ssh.py ssh 127.0.0.1 dd if=/dev/zero bs=20M count=1 22"
	User time (seconds): 0.49
	System time (seconds): 0.29
	Percent of CPU this job got: 65%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:01.20
	Maximum resident set size (kbytes): 69272
	Minor (reclaiming a frame) page faults: 21368
	Voluntary context switches: 5391
````