### PR TITLE
Reduce the number of nacl imports

### DIFF
--- a/paramiko/ed25519key.py
+++ b/paramiko/ed25519key.py
@@ -35,7 +35,7 @@ def unpad(data):
     # really ought to be made constant time (possibly by upstreaming this logic
     # into pyca/cryptography).
     padding_length = six.indexbytes(data, -1)
-    if 0x20 <= padding_length < 0x7f:
+    if 0x20 <= padding_length < 0x7F:
         return data  # no padding, last byte part comment (printable ascii)
     if padding_length > 15:
         raise SSHException("Invalid key")
@@ -71,6 +71,7 @@ class Ed25519Key(PKey):
                 cert_type="ssh-ed25519-cert-v01@openssh.com",
             )
             import nacl.signing
+
             verifying_key = nacl.signing.VerifyKey(msg.get_binary())
         elif filename is not None:
             with open(filename, "r") as f:
@@ -112,9 +113,7 @@ class Ed25519Key(PKey):
                 raise SSHException("Invalid key")
         elif kdfname == "bcrypt":
             if not password:
-                raise PasswordRequiredException(
-                    "Private key file is encrypted"
-                )
+                raise PasswordRequiredException("Private key file is encrypted")
             kdf = Message(kdfoptions)
             bcrypt_salt = kdf.get_binary()
             bcrypt_rounds = kdf.get_int()
@@ -150,9 +149,7 @@ class Ed25519Key(PKey):
                 cipher["mode"](key[cipher["key-size"] :]),
                 backend=default_backend(),
             ).decryptor()
-            private_data = (
-                decryptor.update(private_ciphertext) + decryptor.finalize()
-            )
+            private_data = decryptor.update(private_ciphertext) + decryptor.finalize()
 
         message = Message(unpad(private_data))
         if message.get_int() != message.get_int():
@@ -222,6 +219,7 @@ class Ed25519Key(PKey):
             return False
 
         from nacl.exceptions import BadSignatureError
+
         try:
             self._verifying_key.verify(data, msg.get_binary())
         except BadSignatureError:

--- a/paramiko/ed25519key.py
+++ b/paramiko/ed25519key.py
@@ -19,8 +19,6 @@ import bcrypt
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.ciphers import Cipher
 
-import nacl.signing
-
 import six
 
 from paramiko.message import Message
@@ -72,6 +70,7 @@ class Ed25519Key(PKey):
                 key_type="ssh-ed25519",
                 cert_type="ssh-ed25519-cert-v01@openssh.com",
             )
+            import nacl.signing
             verifying_key = nacl.signing.VerifyKey(msg.get_binary())
         elif filename is not None:
             with open(filename, "r") as f:
@@ -168,6 +167,8 @@ class Ed25519Key(PKey):
             key_data = message.get_binary()
             # The second half of the key data is yet another copy of the public
             # key...
+            import nacl.signing
+
             signing_key = nacl.signing.SigningKey(key_data[:32])
             # Verify that all the public keys are the same...
             assert (
@@ -220,9 +221,10 @@ class Ed25519Key(PKey):
         if msg.get_text() != "ssh-ed25519":
             return False
 
+        from nacl.exceptions import BadSignatureError
         try:
             self._verifying_key.verify(data, msg.get_binary())
-        except nacl.exceptions.BadSignatureError:
+        except BadSignatureError:
             return False
         else:
             return True

--- a/paramiko/ed25519key.py
+++ b/paramiko/ed25519key.py
@@ -113,7 +113,9 @@ class Ed25519Key(PKey):
                 raise SSHException("Invalid key")
         elif kdfname == "bcrypt":
             if not password:
-                raise PasswordRequiredException("Private key file is encrypted")
+                raise PasswordRequiredException(
+                    "Private key file is encrypted"
+                )
             kdf = Message(kdfoptions)
             bcrypt_salt = kdf.get_binary()
             bcrypt_rounds = kdf.get_int()
@@ -149,7 +151,9 @@ class Ed25519Key(PKey):
                 cipher["mode"](key[cipher["key-size"] :]),
                 backend=default_backend(),
             ).decryptor()
-            private_data = decryptor.update(private_ciphertext) + decryptor.finalize()
+            private_data = (
+                decryptor.update(private_ciphertext) + decryptor.finalize()
+            )
 
         message = Message(unpad(private_data))
         if message.get_int() != message.get_int():


### PR DESCRIPTION
There are indications (i.e. https://github.com/paramiko/paramiko/issues/1368) that PyNaCl incurs significant performance penalties when imported. By moving the import statements I hope to reduce the number of paths that require PyNaCl and therefore make the average path faster.