### PR TITLE
Support reading binary file-like objects using from_private_key

### DIFF
--- a/paramiko/pkey.py
+++ b/paramiko/pkey.py
@@ -281,6 +281,11 @@ class PKey(object):
 
     def _read_private_key(self, tag, f, password=None):
         lines = f.readlines()
+
+        # Support binary file-like objects
+        if type(lines[0]) is bytes:
+            lines = [line.decode('ascii') for line in lines]
+
         start = 0
         beginning_of_key = "-----BEGIN " + tag + " PRIVATE KEY-----"
         while start < len(lines) and lines[start].strip() != beginning_of_key:


### PR DESCRIPTION
This PR fixes #1513 by automatically decoding bytes when a binary file-like object is passed to `from_private_key`.

Example code:

```python
from paramiko import RSAKey
import io

with open('id_rsa', 'rb') as f:
    ssh_key = f.read()
    file_obj = io.BytesIO(ssh_key)
    pkey = RSAKey.from_private_key(file_obj)
```