### PR TITLE
[RSA keys] Add support for rsa-sha2-256 and rsa-sha2-512

### DIFF
--- a/paramiko/rsakey.py
+++ b/paramiko/rsakey.py
@@ -123,7 +123,14 @@ class RSAKey(PKey):
         return m
 
     def verify_ssh_sig(self, data, msg):
-        if msg.get_text() != "ssh-rsa":
+        key_algorithm = msg.get_text()
+        if key_algorithm == "ssh-rsa":
+            algorithm = hashes.SHA1()
+        elif key_algorithm == "rsa-sha2-256":
+            algorithm = hashes.SHA256()
+        elif key_algorithm == "rsa-sha2-512":
+            algorithm = hashes.SHA512()
+        else:
             return False
         key = self.key
         if isinstance(key, rsa.RSAPrivateKey):

--- a/paramiko/rsakey.py
+++ b/paramiko/rsakey.py
@@ -138,7 +138,7 @@ class RSAKey(PKey):
 
         try:
             key.verify(
-                msg.get_binary(), data, padding.PKCS1v15(), hashes.SHA1()
+                msg.get_binary(), data, padding.PKCS1v15(), algorithm
             )
         except InvalidSignature:
             return False

--- a/paramiko/rsakey.py
+++ b/paramiko/rsakey.py
@@ -137,9 +137,7 @@ class RSAKey(PKey):
             key = key.public_key()
 
         try:
-            key.verify(
-                msg.get_binary(), data, padding.PKCS1v15(), algorithm
-            )
+            key.verify(msg.get_binary(), data, padding.PKCS1v15(), algorithm)
         except InvalidSignature:
             return False
         else:

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -260,6 +260,8 @@ class Transport(threading.Thread, ClosingContextManager):
 
     _key_info = {
         "ssh-rsa": RSAKey,
+        "rsa-sha2-256": RSAKey,
+        "rsa-sha2-512": RSAKey,
         "ssh-rsa-cert-v01@openssh.com": RSAKey,
         "ssh-dss": DSSKey,
         "ssh-dss-cert-v01@openssh.com": DSSKey,


### PR DESCRIPTION
RSA keys: Add support for rsa-sha2-256 and rsa-sha2-512

RFC: https://tools.ietf.org/rfc/rfc8332.txt

```
This memo updates RFCs 4252 and 4253 to define new public key
   algorithms for use of RSA keys with SHA-256 and SHA-512 for server
   and client authentication in SSH connections.

```

```
3.  New RSA Public Key Algorithms

   This memo adopts the style and conventions of [RFC4253] in specifying
   how use of a public key algorithm is indicated in SSH.

   The following new public key algorithms are defined:

     rsa-sha2-256        RECOMMENDED    sign    Raw RSA key
     rsa-sha2-512        OPTIONAL       sign    Raw RSA key

   These algorithms are suitable for use both in the SSH transport layer
   [RFC4253] for server authentication and in the authentication layer
   [RFC4252] for client authentication.

   Since RSA keys are not dependent on the choice of hash function, the
   new public key algorithms reuse the "ssh-rsa" public key format as
   defined in [RFC4253]:

   string    "ssh-rsa"
   mpint     e
   mpint     n

   All aspects of the "ssh-rsa" format are kept, including the encoded
   string "ssh-rsa".  This allows existing RSA keys to be used with the
   new public key algorithms, without requiring re-encoding or affecting
   already trusted key fingerprints.

   Signing and verifying using these algorithms is performed according
   to the RSASSA-PKCS1-v1_5 scheme in [RFC8017] using SHA-2 [SHS] as
   hash.

   For the algorithm "rsa-sha2-256", the hash used is SHA-256.
   For the algorithm "rsa-sha2-512", the hash used is SHA-512.
```