### PR TITLE
Fix up typo: non-desctructive -> non-destructive.

### DIFF
--- a/paramiko/sftp_si.py
+++ b/paramiko/sftp_si.py
@@ -193,7 +193,7 @@ class SFTPServerInterface(object):
 
         .. note:: You should return an error if a file with the same name as
             ``newpath`` already exists.  (The rename operation should be
-            non-desctructive.)
+            non-destructive.)
 
         .. note::
             This method implements 'standard' SFTP ``RENAME`` behavior; those


### PR DESCRIPTION
Fixes #1531 