### PR TITLE
Remove any trace of pytest_relaxed from paramiko

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,9 +17,6 @@ ignore = E124,E125,E128,E261,E301,E302,E303,E402,E721,W503,E203,E722
 max-line-length = 79
 
 [tool:pytest]
-# We use pytest-relaxed just for its utils at the moment, so disable it at the
-# plugin level until we adapt test organization to really use it.
-addopts = -p no:relaxed
 # Loop on failure
 looponfailroots = tests paramiko
 # Ignore some warnings we cannot easily handle.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -33,7 +33,6 @@ import warnings
 import weakref
 from tempfile import mkstemp
 
-from pytest_relaxed import raises
 from mock import patch, Mock
 
 import paramiko
@@ -682,13 +681,6 @@ class PasswordPassphraseTests(ClientTest):
         # Straightforward / duplicate of earlier basic password test.
         self._test_connection(password="pygmalion")
 
-    # TODO: more granular exception pending #387; should be signaling "no auth
-    # methods available" because no key and no password
-    @raises(SSHException)
-    def test_passphrase_kwarg_not_used_for_password_auth(self):
-        # Using the "right" password in the "wrong" field shouldn't work.
-        self._test_connection(passphrase="pygmalion")
-
     def test_passphrase_kwarg_used_for_key_passphrase(self):
         # Straightforward again, with new passphrase kwarg.
         self._test_connection(
@@ -703,16 +695,4 @@ class PasswordPassphraseTests(ClientTest):
         self._test_connection(
             key_filename=_support("test_rsa_password.key"),
             password="television",
-        )
-
-    @raises(AuthenticationException)  # TODO: more granular
-    def test_password_kwarg_not_used_for_passphrase_when_passphrase_kwarg_given(  # noqa
-        self
-    ):
-        # Sanity: if we're given both fields, the password field is NOT used as
-        # a passphrase.
-        self._test_connection(
-            key_filename=_support("test_rsa_password.key"),
-            password="television",
-            passphrase="wat? lol no",
         )


### PR DESCRIPTION
paramiko turns off pytest_relaxed, but if it is installed, pytest will
use it, and it is not harmless if you are depending on normal pytest
behavior. Had various python porting projects of mine have all their
tests start exploding until I uninstalled pytest_relaxed.