### PR TITLE
EOFError Race condition when closing a transport thread

### DIFF
--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -2151,7 +2151,10 @@ class Transport(threading.Thread, ClosingContextManager):
                 chan._unlink()
             if self.active:
                 self.active = False
-                self.packetizer.close()
+                try:
+                    self.packetizer.close()
+                except EOFError:
+                    self._log(WARNING, "Connection closed early during packetizer closing.")
                 if self.completion_event is not None:
                     self.completion_event.set()
                 if self.auth_handler is not None:


### PR DESCRIPTION
Adding exception handling for packetizer race condition when the server ends the session before the client. This can occur when utilizing fabric2 2.5.0 and sends a high volume of commands through a Connection() object, then trying to close the object.

The EOFError is being raised when trying to write out the final bytes to close the socket, but the socket is already closed. This does not prevent the rest of the transport object shutdown properly, so a warning log is written out instead of raising the exception higher.