### PR TITLE
ProxyCommand: run the command verbatim, via the shell

### DIFF
--- a/paramiko/proxy.py
+++ b/paramiko/proxy.py
@@ -18,7 +18,6 @@
 
 
 import os
-from shlex import split as shlsplit
 import signal
 from select import select
 import socket
@@ -50,9 +49,9 @@ class ProxyCommand(ClosingContextManager):
         # NOTE: subprocess import done lazily so platforms without it (e.g.
         # GAE) can still import us during overall Paramiko load.
         from subprocess import Popen, PIPE
-        self.cmd = shlsplit(command_line)
+        self.cmd = command_line
         self.process = Popen(self.cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE,
-                             bufsize=0)
+                             bufsize=0, shell=True)
         self.timeout = None
 
     def send(self, content):
@@ -69,7 +68,7 @@ class ProxyCommand(ClosingContextManager):
             # died and we can't proceed. The best option here is to
             # raise an exception informing the user that the informed
             # ProxyCommand is not working.
-            raise ProxyCommandFailure(' '.join(self.cmd), e.strerror)
+            raise ProxyCommandFailure(self.cmd, e.strerror)
         return len(content)
 
     def recv(self, size):
@@ -103,7 +102,7 @@ class ProxyCommand(ClosingContextManager):
                 return buffer
             raise  # socket.timeout is a subclass of IOError
         except IOError as e:
-            raise ProxyCommandFailure(' '.join(self.cmd), e.strerror)
+            raise ProxyCommandFailure(self.cmd, e.strerror)
 
     def close(self):
         os.kill(self.process.pid, signal.SIGTERM)


### PR DESCRIPTION
I have fairly complicated ssh setup for AWS in my ~/.ssh/config. It
looks something like this:

    Host bastion
    ProxyCommand nc $(aws ec2 describe-instances --filters "[{\"Name\":\"tag:aws:cloudformation:stack-name\", \"Values\":[\"Bastion\"]}, {\"Name\": \"tag:role\", \"Values\": [\"bastion\"]}]" --query="Reservations[*].Instances[0].PublicIpAddress" | grep -oP '(\d+\.){3}\d+' | head -1) 22

    Host prod
    ProxyCommand ssh -W $(aws ec2 describe-instances --filters "[{\"Name\":\"tag:aws:cloudformation:stack-name\", \"Values\":[\"PROD\"]}, {\"Name\": \"tag:role\", \"Values\": [\"web\"]}]" --query="Reservations[*].Instances[0].PrivateIpAddress" | grep -oP '(\d+\.){3}\d+' | head -1):22 bastion

In this way, I can do `ssh prod` and hop via a bastion server into the
prod server.

The point is that there are two complicated commands in there with
some mildly sophisticated shell syntax that really needs to be
interpreted by the shell.

OpenSSH handles this okay. It runs the actual shell. That's what I
want it to do. However, paramiko does not and my proxy commands don't
work.

I don't think there is a security risk here of shell injection. These
proxy commands are shell commands that the user put into their
.ssh/config file and if they're good enough for OpenSSH to run
verbatim via a shell, then paramiko can do that too.