### PR TITLE
Remove redundant ed25519 extras_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ extras_require = {
         'gssapi>=1.4.1;platform_system!="Windows"',
         'pywin32>=2.1.8;platform_system=="Windows"',
     ],
-    "ed25519": ["pynacl>=1.0.1", "bcrypt>=3.1.3"],
     "invoke": ["invoke>=1.3"],
 }
 everything = []


### PR DESCRIPTION
Both of the libs are already listed as install_requires so there is no need to write them in extras_require again.