### PR TITLE
Channel._request_success: Correct typo in log message

### DIFF
--- a/paramiko/channel.py
+++ b/paramiko/channel.py
@@ -1023,7 +1023,7 @@ class Channel(ClosingContextManager):
         )
 
     def _request_success(self, m):
-        self._log(DEBUG, "Sesch channel {} request ok".format(self.chanid))
+        self._log(DEBUG, "Secsh channel {} request ok".format(self.chanid))
         self.event_ready = True
         self.event.set()
         return


### PR DESCRIPTION
I noticed a typo in a log message. Please advise if I need to add anything to the changelog or do any other admin.