### PR TITLE
fix for list index out of range, breaking vorta

### DIFF
--- a/paramiko/pkey.py
+++ b/paramiko/pkey.py
@@ -310,7 +310,9 @@ class PKey(object):
 
     def _read_private_key(self, tag, f, password=None):
         lines = f.readlines()
-
+        if not lines:
+            raise SSHException("no lines in {} private key file".format(tag))
+            
         # find the BEGIN tag
         start = 0
         m = self.BEGIN_TAG.match(lines[start])

--- a/paramiko/pkey.py
+++ b/paramiko/pkey.py
@@ -312,7 +312,7 @@ class PKey(object):
         lines = f.readlines()
         if not lines:
             raise SSHException("no lines in {} private key file".format(tag))
-            
+
         # find the BEGIN tag
         start = 0
         m = self.BEGIN_TAG.match(lines[start])


### PR DESCRIPTION
to recreate bug:
````
pip install vorta
rm ~/.ssh/.known_hosts.lock
touch ~/.ssh/.known_hosts.lock
vorta -f

Traceback (most recent call last):
  File "/opt/anaconda/anaconda3/bin/vorta", line 10, in <module>
    sys.exit(main())
  File "/opt/anaconda/anaconda3/lib/python3.6/site-packages/vorta/__main__.py", line 40, in main
    app = VortaApp(sys.argv, single_app=True)
  File "/opt/anaconda/anaconda3/lib/python3.6/site-packages/vorta/application.py", line 59, in __init__
    self.open_main_window_action()
  File "/opt/anaconda/anaconda3/lib/python3.6/site-packages/vorta/application.py", line 80, in open_main_window_action
    self.main_window = MainWindow(self)
  File "/opt/anaconda/anaconda3/lib/python3.6/site-packages/vorta/views/main_window.py", line 37, in __init__
    self.repoTab = RepoTab(self.repoTabSlot)
  File "/opt/anaconda/anaconda3/lib/python3.6/site-packages/vorta/views/repo_tab.py", line 55, in __init__
    self.init_ssh()
  File "/opt/anaconda/anaconda3/lib/python3.6/site-packages/vorta/views/repo_tab.py", line 88, in init_ssh
    keys = get_private_keys()
  File "/opt/anaconda/anaconda3/lib/python3.6/site-packages/vorta/utils.py", line 74, in get_private_keys
    parsed_key = key_format.from_private_key_file(key_file)
  File "/opt/anaconda/anaconda3/lib/python3.6/site-packages/paramiko/pkey.py", line 235, in from_private_key_file
    key = cls(filename=filename, password=password)
  File "/opt/anaconda/anaconda3/lib/python3.6/site-packages/paramiko/rsakey.py", line 55, in __init__
    self._from_private_key_file(filename, password)
  File "/opt/anaconda/anaconda3/lib/python3.6/site-packages/paramiko/rsakey.py", line 175, in _from_private_key_file
    data = self._read_private_key_file("RSA", filename, password)
  File "/opt/anaconda/anaconda3/lib/python3.6/site-packages/paramiko/pkey.py", line 308, in _read_private_key_file
    data = self._read_private_key(tag, f, password)
  File "/opt/anaconda/anaconda3/lib/python3.6/site-packages/paramiko/pkey.py", line 320, in _read_private_key
    m = self.BEGIN_TAG.match(lines[start])
IndexError: list index out of range
Segmentation fault (core dumped)
````

resolves #1637 