### PR TITLE
pkey: fix loading original format with leading whitespace/comments

### DIFF
--- a/paramiko/pkey.py
+++ b/paramiko/pkey.py
@@ -331,7 +331,7 @@ class PKey(object):
             m = self.END_TAG.match(lines[end])
 
         if keytype == tag:
-            data = self._read_private_key_pem(lines, end, password)
+            data = self._read_private_key_pem(lines[start:end], password)
             pkformat = self._PRIVATE_KEY_FORMAT_ORIGINAL
         elif keytype == "OPENSSH":
             data = self._read_private_key_openssh(lines[start:end], password)
@@ -347,11 +347,10 @@ class PKey(object):
         err = "{}._read_private_key() spat out an unknown key format id '{}'"
         raise SSHException(err.format(self.__class__.__name__, id_))
 
-    def _read_private_key_pem(self, lines, end, password):
-        start = 0
+    def _read_private_key_pem(self, lines, password):
         # parse any headers first
+        start = 0
         headers = {}
-        start += 1
         while start < len(lines):
             line = lines[start].split(": ")
             if len(line) == 1:
@@ -360,7 +359,7 @@ class PKey(object):
             start += 1
         # if we trudged to the end of the file, just try to cope.
         try:
-            data = decodebytes(b("".join(lines[start:end])))
+            data = decodebytes(b("".join(lines[start:])))
         except base64.binascii.Error as e:
             raise SSHException("base64 decoding error: {}".format(e))
         if "proc-type" not in headers:

--- a/tests/test_pkey.py
+++ b/tests/test_pkey.py
@@ -476,6 +476,17 @@ class KeyTest(unittest.TestCase):
         my_fp = hexlify(key.get_fingerprint())
         self.assertEqual(exp_fp, my_fp)
 
+    def test_leading_stuff(self):
+        orig = RSAKey.from_private_key(StringIO(RSA_PRIVATE_OUT))
+        skey = RSAKey.from_private_key(
+            StringIO("\n\n" + RSA_PRIVATE_OUT + "\n\n")
+        )
+        self.assertEqual(orig.get_fingerprint(), skey.get_fingerprint())
+
+        comment = "Bag Attributes\n    localKeyID: 32 CB FA 64 B9 D8 C5 D3 BC 4B 20 04 3D EC 38 6B 32 2D C4 9A \nKey Attributes: <No Attributes>\n"  # noqa: E501
+        ckey = RSAKey.from_private_key(StringIO(comment + RSA_PRIVATE_OUT))
+        self.assertEqual(orig.get_fingerprint(), ckey.get_fingerprint())
+
     def test_salt_size(self):
         # Read an existing encrypted private key
         file_ = _support("test_rsa_password.key")


### PR DESCRIPTION
accidentally broken when adding new openssh format private key support

fixes #1601 
fixes #1580 