### PR TITLE
pkey: check new openssh format key type

### DIFF
--- a/paramiko/dsskey.py
+++ b/paramiko/dsskey.py
@@ -221,11 +221,13 @@ class DSSKey(PKey):
     # ...internals...
 
     def _from_private_key_file(self, filename, password):
-        data = self._read_private_key_file("DSA", filename, password)
+        data = self._read_private_key_file(
+            "DSA", "ssh-dss", filename, password
+        )
         self._decode_key(data)
 
     def _from_private_key(self, file_obj, password):
-        data = self._read_private_key("DSA", file_obj, password)
+        data = self._read_private_key("DSA", "ssh-dss", file_obj, password)
         self._decode_key(data)
 
     def _decode_key(self, data):

--- a/paramiko/ecdsakey.py
+++ b/paramiko/ecdsakey.py
@@ -275,11 +275,13 @@ class ECDSAKey(PKey):
     # ...internals...
 
     def _from_private_key_file(self, filename, password):
-        data = self._read_private_key_file("EC", filename, password)
+        data = self._read_private_key_file(
+            "EC", "ecdsa-sha2-", filename, password
+        )
         self._decode_key(data)
 
     def _from_private_key(self, file_obj, password):
-        data = self._read_private_key("EC", file_obj, password)
+        data = self._read_private_key("EC", "ecdsa-sha2-", file_obj, password)
         self._decode_key(data)
 
     def _decode_key(self, data):

--- a/paramiko/ed25519key.py
+++ b/paramiko/ed25519key.py
@@ -55,9 +55,9 @@ class Ed25519Key(PKey):
             verifying_key = nacl.signing.VerifyKey(msg.get_binary())
         elif filename is not None:
             with open(filename, "r") as f:
-                pkformat, data = self._read_private_key("OPENSSH", f)
+                pkformat, data = self._read_private_key("OPENSSH", "-", f)
         elif file_obj is not None:
-            pkformat, data = self._read_private_key("OPENSSH", file_obj)
+            pkformat, data = self._read_private_key("OPENSSH", "-", file_obj)
 
         if filename or file_obj:
             signing_key = self._parse_signing_key_data(data, password)

--- a/paramiko/rsakey.py
+++ b/paramiko/rsakey.py
@@ -172,11 +172,13 @@ class RSAKey(PKey):
     # ...internals...
 
     def _from_private_key_file(self, filename, password):
-        data = self._read_private_key_file("RSA", filename, password)
+        data = self._read_private_key_file(
+            "RSA", "ssh-rsa", filename, password
+        )
         self._decode_key(data)
 
     def _from_private_key(self, file_obj, password):
-        data = self._read_private_key("RSA", file_obj, password)
+        data = self._read_private_key("RSA", "ssh-rsa", file_obj, password)
         self._decode_key(data)
 
     def _decode_key(self, data):

--- a/tests/test_pkey.py
+++ b/tests/test_pkey.py
@@ -27,6 +27,7 @@ from binascii import hexlify
 from hashlib import md5
 
 from paramiko import RSAKey, DSSKey, ECDSAKey, Ed25519Key, Message, util
+from paramiko import SSHException
 from paramiko.py3compat import StringIO, byte_chr, b, bytes, PY2
 
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateNumbers
@@ -517,6 +518,15 @@ class KeyTest(unittest.TestCase):
     def test_load_openssh_format_RSA_nopad(self):
         # check just not exploding with 'Invalid key'
         RSAKey.from_private_key_file(_support("test_rsa_openssh_nopad.key"))
+
+    def test_load_openssh_wrong_type(self):
+        # SSHClient.auth() attempts every key type for key_filenames
+        # needs loading to fail "correctly" for wrong type
+        self.assertRaises(
+            SSHException,
+            DSSKey.from_private_key_file,
+            _support("test_rsa_openssh_nopad.key"),
+        )
 
     def test_stringification(self):
         key = RSAKey.from_private_key_file(_support("test_rsa.key"))


### PR DESCRIPTION
needs to raise SSHException for wrong type
for SSHClient._auth() to detect type class for key_filenames

fixes #1590