### PR TITLE
client.py: Enable password-only multi-factor

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -748,7 +748,7 @@ class SSHClient(ClosingContextManager):
 
         if password is not None:
             try:
-                two_factor = set (
+                two_factor = set(
                     self._transport.auth_password(username, password)
                 )
                 if not two_factor:

--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -748,11 +748,15 @@ class SSHClient(ClosingContextManager):
 
         if password is not None:
             try:
-                self._transport.auth_password(username, password)
-                return
+                two_factor = set (
+                    self._transport.auth_password(username, password)
+                )
+                if not two_factor:
+                    return
             except SSHException as e:
                 saved_exception = e
-        elif two_factor:
+
+        if two_factor:
             try:
                 self._transport.auth_interactive_dumb(username)
                 return

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -28,6 +28,7 @@ import sys
 import threading
 import time
 import weakref
+from getpass import getpass
 from hashlib import md5, sha1, sha256, sha512
 
 from cryptography.hazmat.backends import default_backend
@@ -1649,8 +1650,11 @@ class Transport(threading.Thread, ClosingContextManager):
                 if instructions:
                     print(instructions.strip())
                 for prompt, show_input in prompt_list:
-                    print(prompt.strip(), end=" ")
-                    answers.append(input())
+                    if show_input:
+                        print(prompt.strip(), end=" ")
+                        answers.append(input())
+                    else:
+                        answers.append(getpass(prompt))
                 return answers
 
         return self.auth_interactive(username, handler, submethods)


### PR DESCRIPTION
- Enable password-based multi-factor auth in
SSHClient._auth

- Make default handler in transport.auth_interactive_dumb
slightly less dumb

Tested against two types of OTP infrastructure.