### PR TITLE
Incorporate mkdir with heirarchical directory structure

### DIFF
--- a/paramiko/sftp_client.py
+++ b/paramiko/sftp_client.py
@@ -457,6 +457,10 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
         self._log(DEBUG, "mkdir({!r}, {!r})".format(path, mode))
         attr = SFTPAttributes()
         attr.st_mode = mode
+        # Take care of multi level directory creation
+        p_path = os.path.abspath(os.path.join(path, os.pardir))
+        if not self.exists(p_path):
+            self.mkdir(p_path)
         self._request(CMD_MKDIR, path, attr)
 
     def rmdir(self, path):


### PR DESCRIPTION
paramiko sftp_client doesn't support mkdir with directory with multiple levels.
This fix provided that feature. ( it is equivalent to `mkdir -p x/y/z` )