### PR TITLE
Remove BytesWarnings in client.py by putting u() around every hexlify, other BytesWarnings fixes

### DIFF
--- a/demos/demo.py
+++ b/demos/demo.py
@@ -28,7 +28,7 @@ import socket
 import sys
 import time
 import traceback
-from paramiko.py3compat import input
+from paramiko.py3compat import u,input
 
 import paramiko
 
@@ -50,7 +50,7 @@ def agent_auth(transport, username):
         return
 
     for key in agent_keys:
-        print("Trying ssh-agent key %s" % hexlify(key.get_fingerprint()))
+        print("Trying ssh-agent key %s" % u(hexlify(key.get_fingerprint())))
         try:
             transport.auth_publickey(username, key)
             print("... success!")

--- a/paramiko/auth_handler.py
+++ b/paramiko/auth_handler.py
@@ -61,7 +61,7 @@ from paramiko.common import (
     cMSG_USERAUTH_BANNER,
 )
 from paramiko.message import Message
-from paramiko.py3compat import b
+from paramiko.py3compat import b,u
 from paramiko.ssh_exception import (
     SSHException,
     AuthenticationException,
@@ -653,7 +653,7 @@ Error Message: {}
     def _parse_userauth_banner(self, m):
         banner = m.get_string()
         self.banner = banner
-        self._log(INFO, "Auth banner: {}".format(banner))
+        self._log(INFO, "Auth banner: {}".format(u(banner)))
         # who cares.
 
     def _parse_userauth_info_request(self, m):

--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -35,7 +35,7 @@ from paramiko.dsskey import DSSKey
 from paramiko.ecdsakey import ECDSAKey
 from paramiko.ed25519key import Ed25519Key
 from paramiko.hostkeys import HostKeys
-from paramiko.py3compat import string_types
+from paramiko.py3compat import u,string_types
 from paramiko.rsakey import RSAKey
 from paramiko.ssh_exception import (
     SSHException,
@@ -588,7 +588,7 @@ class SSHClient(ClosingContextManager):
         # when #387 is released, since this is a critical log message users are
         # likely testing/filtering for (bah.)
         msg = "Trying discovered key {} in {}".format(
-            hexlify(key.get_fingerprint()), key_path
+            u(hexlify(key.get_fingerprint())), key_path
         )
         self._log(DEBUG, msg)
         # Attempt to load cert if it exists.
@@ -657,7 +657,7 @@ class SSHClient(ClosingContextManager):
                 self._log(
                     DEBUG,
                     "Trying SSH key {}".format(
-                        hexlify(pkey.get_fingerprint())
+                        u(hexlify(pkey.get_fingerprint()))
                     ),
                 )
                 allowed_types = set(
@@ -692,7 +692,7 @@ class SSHClient(ClosingContextManager):
 
             for key in self._agent.get_keys():
                 try:
-                    id_ = hexlify(key.get_fingerprint())
+                    id_ = u(hexlify(key.get_fingerprint()))
                     self._log(DEBUG, "Trying SSH agent key {}".format(id_))
                     # for 2-factor auth a successfully auth'd key password
                     # will return an allowed 2fac auth method
@@ -802,7 +802,7 @@ class AutoAddPolicy(MissingHostKeyPolicy):
         client._log(
             DEBUG,
             "Adding {} host key for {}: {}".format(
-                key.get_name(), hostname, hexlify(key.get_fingerprint())
+                key.get_name(), hostname, u(hexlify(key.get_fingerprint()))
             ),
         )
 
@@ -817,7 +817,7 @@ class RejectPolicy(MissingHostKeyPolicy):
         client._log(
             DEBUG,
             "Rejecting {} host key for {}: {}".format(
-                key.get_name(), hostname, hexlify(key.get_fingerprint())
+                key.get_name(), hostname, u(hexlify(key.get_fingerprint()))
             ),
         )
         raise SSHException(
@@ -834,6 +834,6 @@ class WarningPolicy(MissingHostKeyPolicy):
     def missing_host_key(self, client, hostname, key):
         warnings.warn(
             "Unknown {} host key for {}: {}".format(
-                key.get_name(), hostname, hexlify(key.get_fingerprint())
+                key.get_name(), hostname, u(hexlify(key.get_fingerprint()))
             )
         )

--- a/paramiko/sftp_file.py
+++ b/paramiko/sftp_file.py
@@ -294,7 +294,7 @@ class SFTPFile(BufferedFile):
         :param int mode: new permissions
         """
         self.sftp._log(
-            DEBUG, "chmod({}, {!r})".format(hexlify(self.handle), mode)
+            DEBUG, "chmod({}, {!r})".format(u(hexlify(self.handle)), mode)
         )
         attr = SFTPAttributes()
         attr.st_mode = mode
@@ -312,7 +312,7 @@ class SFTPFile(BufferedFile):
         """
         self.sftp._log(
             DEBUG,
-            "chown({}, {!r}, {!r})".format(hexlify(self.handle), uid, gid),
+            "chown({}, {!r}, {!r})".format(u(hexlify(self.handle)), uid, gid),
         )
         attr = SFTPAttributes()
         attr.st_uid, attr.st_gid = uid, gid
@@ -334,7 +334,7 @@ class SFTPFile(BufferedFile):
         if times is None:
             times = (time.time(), time.time())
         self.sftp._log(
-            DEBUG, "utime({}, {!r})".format(hexlify(self.handle), times)
+            DEBUG, "utime({}, {!r})".format(u(hexlify(self.handle)), times)
         )
         attr = SFTPAttributes()
         attr.st_atime, attr.st_mtime = times
@@ -349,7 +349,7 @@ class SFTPFile(BufferedFile):
         :param size: the new size of the file
         """
         self.sftp._log(
-            DEBUG, "truncate({}, {!r})".format(hexlify(self.handle), size)
+            DEBUG, "truncate({}, {!r})".format(u(hexlify(self.handle)), size)
         )
         attr = SFTPAttributes()
         attr.st_size = size
@@ -490,7 +490,7 @@ class SFTPFile(BufferedFile):
         .. versionadded:: 1.5.4
         """
         self.sftp._log(
-            DEBUG, "readv({}, {!r})".format(hexlify(self.handle), chunks)
+            DEBUG, "readv({}, {!r})".format(u(hexlify(self.handle)), chunks)
         )
 
         read_chunks = []


### PR DESCRIPTION
I run python in an environment where BytesWarnings are enabled and promoted to errors. This was really helpful during py2->3 transitioning, and still helps prevent misuse of bytes as strings.

I'd like to keep doing this while using Paramiko, but I hit BytesWarnings when doing so. I looked at related issues for paramiko, and they've previously been fixed by putting a u() around the offending bytes. This is appropriate for calls to hexlify that are then passed to format(), since hexlify returns the bytes for the ASCII-encoded hex rep of the input.

This is what was done for the same kind of issue previously: https://github.com/paramiko/paramiko/issues/1074

I also fixed the same kind of issue, in auth_client.py, reported at:
https://github.com/paramiko/paramiko/issues/1593 

This should also close the issue 728 linked below. The issue requested a string-ish hex-digest, which would be more dramatic and risky for a wholesale transition, since there could be clients that still need the bytes-ish one. But the u() around the hexlifys going to format safely resolves being able to run with -bb.:
https://github.com/paramiko/paramiko/issues/726

I went ahead and found the rest of the uses of hexlify that were exclusively passed to format/print, and fixed similarly. I left other uses of hexllify alone, as there are definitely still places, e.g. tests, that fully expect bytes back.
