### PR TITLE
Replace pytest-relaxed with plain pytest.raises

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,7 +2,6 @@
 invoke==1.6.0
 invocations==2.6.0
 pytest==4.4.2
-pytest-relaxed==1.1.5
 # pytest-xdist for test dir watching and the inv guard task
 pytest-xdist==1.28.0
 mock==2.0.0

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,4 @@
 [pytest]
-# We use pytest-relaxed just for its utils at the moment, so disable it at the
-# plugin level until we adapt test organization to really use it.
-addopts = -p no:relaxed
 # Loop on failure
 looponfailroots = tests paramiko
 # Ignore some warnings we cannot easily handle.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -33,7 +33,7 @@ import warnings
 import weakref
 from tempfile import mkstemp
 
-from pytest_relaxed import raises
+import pytest
 from mock import patch, Mock
 
 import paramiko
@@ -733,11 +733,11 @@ class PasswordPassphraseTests(ClientTest):
 
     # TODO: more granular exception pending #387; should be signaling "no auth
     # methods available" because no key and no password
-    @raises(SSHException)
     @requires_sha1_signing
     def test_passphrase_kwarg_not_used_for_password_auth(self):
-        # Using the "right" password in the "wrong" field shouldn't work.
-        self._test_connection(passphrase="pygmalion")
+        with pytest.raises(SSHException):
+            # Using the "right" password in the "wrong" field shouldn't work.
+            self._test_connection(passphrase="pygmalion")
 
     @requires_sha1_signing
     def test_passphrase_kwarg_used_for_key_passphrase(self):
@@ -757,15 +757,15 @@ class PasswordPassphraseTests(ClientTest):
             password="television",
         )
 
-    @raises(AuthenticationException)  # TODO: more granular
     @requires_sha1_signing
     def test_password_kwarg_not_used_for_passphrase_when_passphrase_kwarg_given(  # noqa
         self
     ):
         # Sanity: if we're given both fields, the password field is NOT used as
         # a passphrase.
-        self._test_connection(
-            key_filename=_support("test_rsa_password.key"),
-            password="television",
-            passphrase="wat? lol no",
-        )
+        with pytest.raises(AuthenticationException):
+            self._test_connection(
+                key_filename=_support("test_rsa_password.key"),
+                password="television",
+                passphrase="wat? lol no",
+            )


### PR DESCRIPTION
There is really no technical reason to bring pytest-relaxed to call
@raises as a decorator while plain pytest works just fine.  Plus,
pytest.raises() is used in test_sftp already.

pytest-relaxed causes humongous breakage to other packages
on the system.  It has been banned from Gentoo for this reason.

This is alternative to #1543 that doesn't remove tests.