### PR TITLE
Fix KeyError exception in SSHConfig.get_hostnames

### DIFF
--- a/paramiko/config.py
+++ b/paramiko/config.py
@@ -319,6 +319,8 @@ class SSHConfig(object):
         """
         hosts = set()
         for entry in self._config:
+            if "host" not in entry.keys():
+                continue
             hosts.update(entry["host"])
         return hosts
 


### PR DESCRIPTION
Just add a test to fix a KeyError exception in the SSHConfig.get_hostnames
In some cases, when using the Match command in ssh config file, ther is no "host" key. 
