### PR TITLE
Set timeout to prevent transport hanging during initialization

### DIFF
--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -406,6 +406,7 @@ class Transport(threading.Thread, ClosingContextManager):
                     # addr = sockaddr
                     sock = socket.socket(af, socket.SOCK_STREAM)
                     try:
+                        sock.settimeout(self._active_check_timeout)
                         retry_on_signal(lambda: sock.connect((hostname, port)))
                     except socket.error as e:
                         reason = str(e)


### PR DESCRIPTION
This is to address issue 1677 which I opened (Paramiko Transport hangs during initialization)