### PR TITLE
Stop excessive exceptions when connection is hung up before banner

### DIFF
--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -2211,6 +2211,8 @@ class Transport(threading.Thread, ClosingContextManager):
                 buf = self.packetizer.readline(timeout)
             except ProxyCommandFailure:
                 raise
+            except EOFError:
+                raise
             except Exception as e:
                 raise SSHException(
                     "Error reading SSH protocol banner" + str(e)

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -264,6 +264,17 @@ class TransportTest(unittest.TestCase):
         self.assertTrue(event.is_set())
         self.assertTrue(self.ts.is_active())
 
+    def test_clients_hangs_up_before_banner(self):
+        """
+        verify hanging up before banner
+        """
+        server = NullServer()
+        event = threading.Event()
+        self.ts.start_server(event=event, server=server)
+        self.sockc.close()
+        event.wait(1.0)
+        self.assertFalse(self.ts.is_active())
+
     def test_special(self):
         """
         verify that the client can demand odd handshake settings, and can


### PR DESCRIPTION
This is a solution to #1682 (Excessive exception on TCP-probe)
It solves the problem of exception logging if a connection is ended before a banner has been sent.
When deploying a sftp server behind a load balancer, e.g. NGINX, the server will be repeatedly probed by establishing, and then closing, a connection to port 22. 
A load balancer will do this to find out if the server is available or not.
Without this fix a stacktrace will be printed for each probe which will make logfiles hard to read.