### PR TITLE
Correct processing of "match" types in config

### DIFF
--- a/paramiko/config.py
+++ b/paramiko/config.py
@@ -510,7 +510,7 @@ class SSHConfig(object):
         tokens = shlex.split(match)
         while tokens:
             match = {"type": None, "param": None, "negate": False}
-            type_ = tokens.pop(0)
+            type_ = tokens.pop(0).lower()
             # Handle per-keyword negation
             if type_.startswith("!"):
                 match["negate"] = True


### PR DESCRIPTION
Without lower-casing the match type, we miss detecting the special-case
match types of "canonical" and "all".

This same change also addresses another bug in config processing, where
an unkonwn match type will always be evaluated to be matching.