### PR TITLE
Avoid exception which can not be handled

### DIFF
--- a/paramiko/auth_handler.py
+++ b/paramiko/auth_handler.py
@@ -672,9 +672,10 @@ Error Message: {}
 
         m = Message()
         m.add_byte(cMSG_USERAUTH_INFO_RESPONSE)
-        m.add_int(len(response_list))
-        for r in response_list:
-            m.add_string(r)
+        if (response_list is not None):
+            m.add_int(len(response_list))
+            for r in response_list:
+                m.add_string(r)
         self.transport._send_message(m)
 
     def _parse_userauth_info_response(self, m):


### PR DESCRIPTION
When we use auth_interactive and the SSH server has challenge-response authentication paramiko raise an exception which can not be handled.

To reproduce the bug (with the server OpenSSH):
Set the configuration to "ChallengeResponseAuthentication yes"

and run the following script:
```
#!/usr/bin/env python3

import paramiko
import sys
import socket

server = sys.argv[1]
port = int(sys.argv[2])
user = sys.argv[3]

def pass_handler(title, instruction, prompt_list):
    print(prompt_list)

sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
sock.connect((server, port))
transport = paramiko.Transport(sock)
transport.start_client()
try:
    list_auth_types = transport.auth_interactive(username=user, handler=pass_handler)                                                                     
except Exception:
    pass
```

Output:
```
$ ./test-paramiko.py 127.0.0.1 22 manu
[('Password: ', False)]
Unknown exception: object of type 'NoneType' has no len()
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/paramiko/transport.py", line 2109, in run                                                                  
    handler(self.auth_handler, m)
  File "/usr/local/lib/python3.7/dist-packages/paramiko/auth_handler.py", line 675, in _parse_userauth_info_request                                       
    m.add_int(len(response_list))
TypeError: object of type 'NoneType' has no len()
```

With this fix we avoid this exception.
```
$ ./test-paramiko.py 127.0.0.1 22 manu
[('Password: ', False)]
```
