### PR TITLE
fix RSA key loading: p and q were being swapped

### DIFF
--- a/paramiko/rsakey.py
+++ b/paramiko/rsakey.py
@@ -189,7 +189,7 @@ class RSAKey(PKey):
             except ValueError as e:
                 raise SSHException(str(e))
         elif pkformat == self._PRIVATE_KEY_FORMAT_OPENSSH:
-            n, e, d, iqmp, q, p = self._uint32_cstruct_unpack(data, "iiiiii")
+            n, e, d, iqmp, p, q = self._uint32_cstruct_unpack(data, "iiiiii")
             public_numbers = rsa.RSAPublicNumbers(e=e, n=n)
             key = rsa.RSAPrivateNumbers(
                 p=p,


### PR DESCRIPTION
This currently works, because OpenSSL simply re-computes iqmp when it doesn't match the p & q values. However a future pyca/cryptography patch enforces this.