### PR TITLE
Add tests/configs directory to sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include LICENSE setup_helper.py
 recursive-include docs *
 recursive-include tests *.py *.key *.pub
+recursive-include tests/configs *
 recursive-include demos *.py *.key user_rsa_key user_rsa_key.pub


### PR DESCRIPTION
Makes `python setup.py sdist --format=gztar` include `tests/configs` in the resulting archive, so that the tests work properly. See #1726.

Looks like it was never included. The directory first appeared in 4c4de253.