### PR TITLE
pass exc_info along when logging exs, dont split and log tb separately (version 2)

### DIFF
--- a/paramiko/server.py
+++ b/paramiko/server.py
@@ -21,7 +21,8 @@
 """
 
 import threading
-from paramiko import util
+import sys
+
 from paramiko.common import (
     DEBUG,
     ERROR,
@@ -685,10 +686,8 @@ class SubsystemHandler(threading.Thread):
             self.__transport._log(
                 ERROR,
                 'Exception in subsystem handler for "{}": {}'.format(
-                    self.__name, e
-                ),
+                    self.__name, e), exc_info=sys.exc_info()
             )
-            self.__transport._log(ERROR, util.tb_strings())
         try:
             self.finish_subsystem()
         except:

--- a/paramiko/sftp.py
+++ b/paramiko/sftp.py
@@ -154,8 +154,8 @@ class BaseSFTP(object):
         self._send_packet(CMD_VERSION, msg)
         return version
 
-    def _log(self, level, msg, *args):
-        self.logger.log(level, msg, *args)
+    def _log(self, level, msg, *args, **kwargs):
+        self.logger.log(level, msg, *args, **kwargs)
 
     def _write_all(self, out):
         while len(out) > 0:

--- a/paramiko/sftp_server.py
+++ b/paramiko/sftp_server.py
@@ -151,16 +151,14 @@ class SFTPServer(BaseSFTP, SubsystemHandler):
                 self._log(DEBUG, "EOF -- end of session")
                 return
             except Exception as e:
-                self._log(DEBUG, "Exception on channel: " + str(e))
-                self._log(DEBUG, util.tb_strings())
+                self._log(DEBUG, "Exception on channel: " + str(e), exc_info=sys.exc_info())
                 return
             msg = Message(data)
             request_number = msg.get_int()
             try:
                 self._process(t, request_number, msg)
             except Exception as e:
-                self._log(DEBUG, "Exception in server processing: " + str(e))
-                self._log(DEBUG, util.tb_strings())
+                self._log(DEBUG, "Exception in server processing: " + str(e), exc_info=sys.exc_info())
                 # send some kind of failure message, at least
                 try:
                     self._send_status(request_number, SFTP_FAILURE)

--- a/paramiko/sftp_server.py
+++ b/paramiko/sftp_server.py
@@ -125,7 +125,7 @@ class SFTPServer(BaseSFTP, SubsystemHandler):
         self.folder_table = {}
         self.server = sftp_si(server, *largs, **kwargs)
 
-    def _log(self, level, msg):
+    def _log(self, level, msg, *args, **kwargs):
         if issubclass(type(msg), list):
             for m in msg:
                 super(SFTPServer, self)._log(
@@ -133,7 +133,10 @@ class SFTPServer(BaseSFTP, SubsystemHandler):
                 )
         else:
             super(SFTPServer, self)._log(
-                level, "[chan " + self.sock.get_name() + "] " + msg
+                level,
+                "[chan " + self.sock.get_name() + "] " + msg,
+                *args,
+                **kwargs
             )
 
     def start_subsystem(self, name, transport, channel):

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -1811,12 +1811,12 @@ class Transport(threading.Thread, ClosingContextManager):
 
     # internals...
 
-    def _log(self, level, msg, *args):
+    def _log(self, level, msg, *args, **kwargs):
         if issubclass(type(msg), list):
             for m in msg:
                 self.logger.log(level, m)
         else:
-            self.logger.log(level, msg, *args)
+            self.logger.log(level, msg, *args, **kwargs)
 
     def _get_modulus_pack(self):
         """used by KexGex to find primes for group exchange"""

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -2126,8 +2126,7 @@ class Transport(threading.Thread, ClosingContextManager):
                             self._send_message(msg)
                     self.packetizer.complete_handshake()
             except SSHException as e:
-                self._log(ERROR, "Exception: " + str(e))
-                self._log(ERROR, util.tb_strings())
+                self._log(ERROR, 'Exception: ' + str(e), exc_info=sys.exc_info())
                 self.saved_exception = e
             except EOFError as e:
                 self._log(DEBUG, "EOF in transport thread")
@@ -2143,8 +2142,7 @@ class Transport(threading.Thread, ClosingContextManager):
                 self._log(ERROR, "Socket exception: " + emsg)
                 self.saved_exception = e
             except Exception as e:
-                self._log(ERROR, "Unknown exception: " + str(e))
-                self._log(ERROR, util.tb_strings())
+                self._log(ERROR, 'Exception: ' + str(e), exc_info=sys.exc_info())
                 self.saved_exception = e
             _active_threads.remove(self)
             for chan in list(self._channels.values()):

--- a/paramiko/util.py
+++ b/paramiko/util.py
@@ -23,9 +23,7 @@ Useful functions used by the rest of paramiko.
 from __future__ import generators
 
 import errno
-import sys
 import struct
-import traceback
 import threading
 import logging
 
@@ -133,10 +131,6 @@ def bit_length(n):
             hbyte <<= 1
             bitlen -= 1
         return bitlen
-
-
-def tb_strings():
-    return "".join(traceback.format_exception(*sys.exc_info())).split("\n")
 
 
 def generate_key_bytes(hash_alg, salt, key, nbytes):


### PR DESCRIPTION
Took the concepts in #406 and applied them to latest version of this project.

This PR uses exec_info instead of util.tb_strings to generate a single log message. closes #405