### PR TITLE
Fix datatype of timeout parameter (int -> float).

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -483,7 +483,7 @@ class SSHClient(ClosingContextManager):
         :param int bufsize:
             interpreted the same way as by the built-in ``file()`` function in
             Python
-        :param int timeout:
+        :param float timeout:
             set command's channel timeout. See `.Channel.settimeout`
         :param bool get_pty:
             Request a pseudo-terminal from the server (default ``False``).


### PR DESCRIPTION
This pull request covers a wrong parameter documentation.

The parameter `timeout` of the `SSHClient.exec_command()` method should be of type `float` instead of `int`, because at the two places where it is used (`chan = self._transport.open_session(timeout=timeout)` and `chan.settimeout(timeout)`) a `float` parameter is expected.

Thank you.
