### PR TITLE
Debug get-function of sftp_client.py

### DIFF
--- a/paramiko/sftp_client.py
+++ b/paramiko/sftp_client.py
@@ -800,10 +800,10 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
         """
         with open(localpath, "wb") as fl:
             size = self.getfo(remotepath, fl, callback)
-        s = os.stat(localpath)
-        if s.st_size != size:
+            localsize = fl.tell()
+        if localsize != size:
             raise IOError(
-                "size mismatch in get!  {} != {}".format(s.st_size, size)
+                "size mismatch in get!  {} != {}".format(localsize, size)
             )
 
     # ...internals...


### PR DESCRIPTION
The get-function of the 'sftp_client.py' was being modified using file-object based approach in order to avoid size-mismatching in get-chains (for example using 'pysftp.get_d').

'IOError' was being thrown due to synchronicity issues between Python interpreter and operating-system using `os.stat(localpath)` to gather file-size of local file.

Commits tested in local OSX-Docker environment (macOS Catalina version 10.15.6 and Docker Engine version 19.03.13) using Python 3.9 image accessing remote SFTP-server to get files without any issue.