### PR TITLE
Remove dead code

### DIFF
--- a/paramiko/sftp_client.py
+++ b/paramiko/sftp_client.py
@@ -164,8 +164,6 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
         chan = t.open_session(
             window_size=window_size, max_packet_size=max_packet_size
         )
-        if chan is None:
-            return None
         chan.invoke_subsystem("sftp")
         return cls(chan)
 


### PR DESCRIPTION
paramiko.Transport.open_session return value is guaranteed to be not None (raises an exception if it is), so remove the dead code.