### PR TITLE
PKCS11 smartcard support

### DIFF
--- a/demos/demo_multithreading_pkcs11.py
+++ b/demos/demo_multithreading_pkcs11.py
@@ -1,0 +1,49 @@
+import paramiko
+from multiprocessing import Queue
+from threading import Thread
+import sys
+import getpass
+
+# get hostname
+username = ""
+port = 22
+if len(sys.argv) > 1:
+    hostname = sys.argv[1]
+    if hostname.find("@") >= 0:
+        username, hostname = hostname.split("@")
+else:
+    hostname = input("Hostname: ")
+if len(hostname) == 0:
+    print("*** Hostname required.")
+    sys.exit(1)
+
+if hostname.find(":") >= 0:
+    hostname, portstr = hostname.split(":")
+    port = int(portstr)
+
+# get username
+if username == "":
+    default_username = getpass.getuser()
+    username = input("Username [%s]: " % default_username)
+    if len(username) == 0:
+        username = default_username
+
+pkcs11provider = "/usr/local/lib/opensc-pkcs11.so"
+smartcard_pin = getpass.getpass("smartcard pin: ")
+
+def do_it(q):
+    session = q.get()
+    ssh = paramiko.SSHClient()
+    ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    ssh.connect(hostname, port, username, pkcs11_session=session)
+    stdin, stdout, stderr = ssh.exec_command("uname -a")
+    for line in stdout:
+        print(line)
+
+q = Queue()
+session = paramiko.pkcs11.open_session(pkcs11provider, smartcard_pin)
+mythread = Thread(target=do_it, args=(q,))
+q.put(session)
+mythread.start()
+mythread.join()
+paramiko.pkcs11.close_session(session)

--- a/demos/demo_pkcs11.py
+++ b/demos/demo_pkcs11.py
@@ -1,0 +1,39 @@
+import paramiko
+import sys
+import getpass
+
+# get hostname
+username = ""
+port = 22
+if len(sys.argv) > 1:
+    hostname = sys.argv[1]
+    if hostname.find("@") >= 0:
+        username, hostname = hostname.split("@")
+else:
+    hostname = input("Hostname: ")
+if len(hostname) == 0:
+    print("*** Hostname required.")
+    sys.exit(1)
+
+if hostname.find(":") >= 0:
+    hostname, portstr = hostname.split(":")
+    port = int(portstr)
+
+# get username
+if username == "":
+    default_username = getpass.getuser()
+    username = input("Username [%s]: " % default_username)
+    if len(username) == 0:
+        username = default_username
+
+pkcs11provider = "/usr/local/lib/opensc-pkcs11.so"
+smartcard_pin = getpass.getpass("smartcard pin: ")
+
+ssh = paramiko.SSHClient()
+ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+session = paramiko.pkcs11.open_session(pkcs11provider, smartcard_pin)
+ssh.connect(hostname, port, username, pkcs11_session=session)
+paramiko.pkcs11.close_session(session)
+stdin, stdout, stderr = ssh.exec_command("uname -a")
+for line in stdout:
+    print(line)

--- a/paramiko/auth_handler.py
+++ b/paramiko/auth_handler.py
@@ -149,7 +149,7 @@ class AuthHandler(object):
         self.transport.lock.acquire()
         try:
             self.auth_event = event
-            self.auth_method = 'publickey'
+            self.auth_method = "publickey"
             self.username = username
             self.pkcs11_session = pkcs11_session
             self._request_auth()

--- a/paramiko/pkcs11.py
+++ b/paramiko/pkcs11.py
@@ -1,0 +1,183 @@
+"""
+Support for PKCS#11-hosted private RSA keys & operations using them.
+Smart devices (such as smartcards and YubiKeys) can hold private key data & its
+corresponding public key data (in the form of a certificate) as well as perform
+signature operations using the private key - all without actually exposing the
+private key to the user, and typically protected by a secret PIN as well.
+Traditionally, Paramiko expects access to private key material, so the PKCS#11
+style of approach requires extra code - in this case, using the `ctypes` stdlib
+module to access a PKCS#11 "provider", a ``.so`` or ``.dll`` file such as those
+distributed by `OpenSC <https://github.com/OpenSC/OpenSC/wiki>`_.
+The typical case involves generating a PKCS "session" (via `.open_session`,
+giving it the provider file path and the PIN) and handing the result to
+`.client.SSHClient.connect` as its ``pkcs11_session`` argument. The same
+session may be used across multiple clients and/or threads; in any case,
+it must be explicitly closed via `.close_session`.
+.. note::
+    This module is based on the following reference material:
+    - `OpenSSH's own PKCS#11 support
+      <https://github.com/openssh/openssh-portable/blob/master/ssh-pkcs11.c>`_
+    - `The official PKCS#11 specification
+      <http://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/os/pkcs11-base-v2.40-os.html>`_
+"""
+
+from ctypes import (
+    c_void_p, c_ulong, c_int, c_char_p, cast, addressof, sizeof, byref, cdll,
+    Structure,
+)
+import subprocess
+import os
+import errno
+from paramiko.ssh_exception import AuthenticationException, SSHException
+
+
+class PKCS11Exception(SSHException):
+    """
+    Exception raised by failures in the PKCS11 API or related logic errors.
+    """
+    pass
+
+
+class PKCS11AuthenticationException(AuthenticationException):
+    """
+    Exception raised when pkcs11 authentication failed for some reason.
+    """
+    pass
+
+
+def get_public_key(keyid="01"):
+    """
+    Get the public key from a smart device
+    :param str pkcs11keyid: The keyid to use for the pkcs11 session.
+    """
+    public_key = None
+    try:
+        p = subprocess.Popen(["pkcs15-tool", "--read-ssh-key", keyid],
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE,
+                             stdin=subprocess.PIPE)
+        out, err = p.communicate()
+        if out is not None:
+            public_key = out
+    except OSError as error:
+        if error.errno == errno.ENOENT:
+            raise PKCS11Exception("Cannot find pkcs15-tool in PATH.")
+        else:
+            raise
+
+    if public_key is None or len(public_key) < 1:
+        raise PKCS11Exception("Invalid ssh public key returned by pkcs15-tool")
+
+    return public_key.decode('utf-8')
+
+
+def open_session(provider, pin, keyid="01", slot=0, publickey=None):
+    """
+    Open a pkcs11 session on a smart device.
+    :param str provider: If using PKCS11, this will be the provider
+    for the PKCS11 interface. Example: /usr/local/lib/opensc-pkcs11.so.
+    :param str pin: If using PKCS11, this will be the pin of your
+    token or smartcard.
+    :param str keyid: The keyid to use for the pkcs11 session.
+    :param int slot: The slot id used for establishing the session.
+    :param str publickey: If left the default (None), the public key
+    will be detected using OpenSC pkcs15-tool. Alternatively you can
+    provide it manually using this argument.
+    """
+    session = None
+
+    # Get Public SSH Key
+    if publickey is None:
+        publickey = get_public_key(keyid)
+
+    class ck_c_initialize_args(Structure):
+        _fields_ = [('CreateMutex', c_void_p), ('DestroyMutex', c_void_p),
+                    ('LockMutex', c_void_p), ('UnlockMutex', c_void_p),
+                    ('flags', c_ulong), ('pReserved', c_void_p)]
+
+    # Init Args
+    init_args = ck_c_initialize_args()
+    init_args.CreateMutex = c_void_p(0)
+    init_args.DestroyMutex = c_void_p(0)
+    init_args.LockMutex = c_void_p(0)
+    init_args.UnlockMutex = c_void_p(0)
+    init_args.pReserved = c_void_p(0)
+    init_args.flags = c_ulong(2)  # OS Locking for Multithreading Support
+
+    # Init
+    if not os.path.isfile(provider):
+        raise PKCS11Exception("provider path is not valid: {}".format(provider)) # noqa
+    lib = cdll.LoadLibrary(provider)
+    res = lib.C_Initialize(byref(init_args))
+    if res != 0:
+        raise PKCS11Exception("PKCS11 Failed to Initialize")
+
+    # Session
+    cstr_slot = c_ulong(slot)  # slot number
+    session = c_ulong()
+    flags = c_int(6)  # CKF_SERIAL_SESSION (100b), CKF_RW_SESSION(10b)
+    res = lib.C_OpenSession(cstr_slot, flags, 0, 0, byref(session))
+    if res != 0:
+        raise PKCS11Exception("PKCS11 Failed to Open Session")
+
+    # Login
+    login_type = c_int(1)  # 1=USER PIN
+    str_pin = pin.encode('utf-8')
+    cstr_pin = c_char_p(str_pin)
+    res = lib.C_Login(session, login_type, cstr_pin, len(str_pin))
+    if res != 0:
+        raise PKCS11AuthenticationException("PKCS11 Login Failed")
+
+    # Get object for key
+    class ck_attribute(Structure):
+        _fields_ = [('type', c_ulong), ('value', c_void_p),
+                    ('value_len', c_ulong)]
+
+    attrs = (ck_attribute * 3)()
+    count = c_ulong()
+
+    # Hard coded, two defined below
+    # (attrs is len 2 if using id, if not its len 1)
+    nattrs = c_ulong(1)
+
+    keyret = c_ulong()
+    cls = c_ulong(3)  # CKO_PRIVATE_KEY
+    objid_str = keyid.encode('utf-8')
+    objid = c_char_p(objid_str)
+    objid_len = c_ulong(len(objid_str))
+    attrs[0].type = c_ulong(0)  # CKA_CLASS
+    attrs[0].value = cast(addressof(cls), c_void_p)
+    attrs[0].value_len = c_ulong(sizeof(cls))
+    attrs[1].type = c_ulong(258)  # CKA_ID
+    attrs[1].value = cast(objid, c_void_p)
+    attrs[1].value_len = objid_len
+    res = lib.C_FindObjectsInit(session, attrs, nattrs)
+    if res != 0:
+        raise PKCS11Exception("PKCS11 Failed to Find Init")
+    res = lib.C_FindObjects(session, byref(keyret), 1, byref(count))
+    if res != 0:
+        raise PKCS11Exception("PKCS11 Failed to Find Objects")
+    res = lib.C_FindObjectsFinal(session)
+    if res != 0:
+        raise PKCS11Exception("PKCS11 Failed to Find Objects Final")
+
+    return {"session": session, "public_key": publickey,
+            "keyret": keyret, "provider": provider}
+
+
+def close_session(session):
+    """
+    Close a pkcs11 session on a smart device.
+    :param str session: pkcs11 session obtained
+    by calling pkcs11_open_session
+    """
+    if "provider" not in session:
+        raise PKCS11Exception("pkcs11 session is missing the provider, the session is not valid") # noqa
+    provider = session["provider"]
+    if not os.path.isfile(provider):
+        raise PKCS11Exception("provider path is not valid: {}".format(provider)) # noqa
+    lib = cdll.LoadLibrary(provider)
+    # Wrap things up
+    res = lib.C_Finalize(c_int(0))
+    if res != 0:
+        raise PKCS11Exception("PKCS11 Failed to Finalize")

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -1579,6 +1579,35 @@ class Transport(threading.Thread, ClosingContextManager):
             return []
         return self.auth_handler.wait_for_response(my_event)
 
+    def auth_pkcs11(self, username, pkcs11_session, event=None):
+        """
+        :param str username: the username to authenticate as
+        :param str pkcs11_session: session obtained from pkcs11_open_session
+        :param .threading.Event event:
+            an event to trigger when the authentication attempt is complete
+            (whether it was successful or not)
+        :return:
+            `list` of auth types permissible for the next stage of
+            authentication (normally empty)
+        :raises:
+            `.AuthenticationException` -- if the authentication failed (and no
+            event was passed in)
+        :raises: `.SSHException` -- if there was a network error
+        """
+        if (not self.active) or (not self.initial_kex_done):
+            # we should never try to authenticate unless we're on a secure link
+            raise SSHException('No existing session')
+        if event is None:
+            my_event = threading.Event()
+        else:
+            my_event = event
+        self.auth_handler = AuthHandler(self)
+        self.auth_handler.auth_pkcs11(username, pkcs11_session, my_event)
+        if event is not None:
+            # caller wants to wait for event themselves
+            return []
+        return self.auth_handler.wait_for_response(my_event)
+
     def auth_interactive(self, username, handler, submethods=""):
         """
         Authenticate to the server interactively.  A handler is used to answer

--- a/sites/docs/api/pkcs11.rst
+++ b/sites/docs/api/pkcs11.rst
@@ -1,0 +1,5 @@
+Pkcs11
+======
+
+.. automodule:: paramiko.pkcs11
+    :member-order: bysource

--- a/sites/docs/index.rst
+++ b/sites/docs/index.rst
@@ -72,3 +72,4 @@ Miscellany
     api/file
     api/pipe
     api/ssh_exception
+    api/pkcs11

--- a/tests/test_pkcs11.py
+++ b/tests/test_pkcs11.py
@@ -1,0 +1,161 @@
+# This file is part of paramiko.
+#
+# Paramiko is free software; you can redistribute it and/or modify it under the
+# terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# Paramiko is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Paramiko; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+
+"""
+Test the used APIs for pkcs11
+"""
+
+import unittest
+import mock
+from paramiko import pkcs11
+from paramiko.pkcs11 import PKCS11Exception 
+from paramiko.auth_handler import AuthHandler
+from paramiko.transport import Transport
+from tests.loop import LoopSocket
+
+
+test_rsa_public_key = b"ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAIEA049W6geFpmsljTwfvI1UmKWWJPNFI74+vNKTk4dmzkQY2yAMs6FhlvhlI8ysU4oj71ZsRYMecHbBbxdN79+JRFVYTKaLqjwGENeTd+yv4q+V2PvZv3fLnzApI3l7EJCqhWwJUHJ1jAkZzqDx0tyOL4uoZpww3nmE0kb3y21tH4c=" # noqa
+
+
+class MockPKCS11Lib(object):
+    def __init__(self):
+        pass
+
+    def C_Finalize(val):
+        return 0
+
+    def C_Initialize(val1, val2):
+        return 0
+
+    def C_OpenSession(val1, val2, val3, val4, val5, val6):
+        return 0
+
+    def C_Login(val1, val2, val3, val4, val5):
+        return 0
+
+    def C_FindObjectsInit(val1, val2, val3, val4):
+        return 0
+
+    def C_FindObjects(val1, val2, val3, val4, val5):
+        return 0
+
+    def C_FindObjectsFinal(val1, val2):
+        return 0
+
+    def C_Sign(val1, val2, val3, val4, val5, val6):
+        return 0
+
+    def C_SignInit(val1, val2, val3, val4):
+        return 0
+
+
+class MockPopen_pkcs15tool_rsakey(object):
+    def __init__(self, stdout, stderr):
+        self.stdout = stdout
+        self.stderr = stderr
+        self.stdout = test_rsa_public_key
+
+    def communicate(self):
+        return (self.stdout, self.stderr)
+
+    def wait(self):
+        pass
+
+    def kill(self):
+        pass
+
+
+class Pkcs11Test(unittest.TestCase):
+    def setUp(self):
+        self.sockc = LoopSocket()
+
+    def tearDown(self):
+        pass
+
+    @mock.patch('subprocess.Popen',
+                return_value=MockPopen_pkcs15tool_rsakey([], []))
+    def test_1_pkcs11_get_public_key(self, mock_popen):
+        """
+        Test Getting Public Key
+        """
+        public_key = pkcs11.get_public_key()
+        self.assertEqual(public_key, test_rsa_public_key.decode("utf-8"))
+
+    @mock.patch('os.path.isfile', return_value=True)
+    @mock.patch('paramiko.pkcs11.cdll.LoadLibrary',
+                return_value=MockPKCS11Lib())
+    def test_2_pkcs11_close_session_success(self,
+                                            mock_isfile,
+                                            mock_loadlibrary):
+        pkcs11_session = {"pkcs11provider": "/test/path/example"}
+        threw_exception = True
+        try:
+            pkcs11.close_session(pkcs11_session)
+        except Exception:
+            threw_exception = False
+        self.assertTrue(not threw_exception)
+
+    @mock.patch('os.path.isfile', return_value=False)
+    @mock.patch('paramiko.pkcs11.cdll.LoadLibrary',
+                return_value=MockPKCS11Lib())
+    def test_3_pkcs11_close_session_fail_nofile(self, mock_isfile,
+                                                mock_loadlibrary):
+        pkcs11_session = {"pkcs11provider": "/test/path/example"}
+        threw_exception = False
+        try:
+            pkcs11.close_session(pkcs11_session)
+        except PKCS11Exception:
+            threw_exception = True
+        self.assertTrue(threw_exception)
+
+    @mock.patch('subprocess.Popen',
+                return_value=MockPopen_pkcs15tool_rsakey([], []))
+    @mock.patch('os.path.isfile', return_value=True)
+    @mock.patch('paramiko.pkcs11.cdll.LoadLibrary',
+                return_value=MockPKCS11Lib())
+    def test_4_pkcs11_open_session(self,
+                                   mock_popen,
+                                   mock_isfile,
+                                   mock_loadlibrary):
+        session = pkcs11.open_session("/test/provider/example", "1234")
+        self.assertEqual(0, session["session"].value)
+        self.assertEqual(test_rsa_public_key.decode("utf-8"), session["public_key"])
+        self.assertEqual(0, session["keyret"].value)
+        self.assertEqual("/test/provider/example", session["provider"])
+
+    @mock.patch('paramiko.auth_handler.AuthHandler._request_auth',
+                return_value=True)
+    def test_5_pkcs11_authhandler_auth_pkcs11_basic(self, mock_requestauth):
+        # Mock _request_auth just to test the setup
+        # Just test the setup
+        tc = Transport(self.sockc)
+        session = {"session": None}
+        testauth = AuthHandler(tc)
+        testauth.auth_pkcs11("testuser", session, None)
+        self.assertEqual(testauth.auth_event, None)
+        self.assertEqual(testauth.auth_method, 'publickey')
+        self.assertEqual(testauth.username, "testuser")
+        self.assertEqual(testauth.pkcs11_session, session)
+
+    @mock.patch('paramiko.auth_handler.AuthHandler._request_auth',
+                return_value=True)
+    def test_6_pkcs11_authhandler_pkcs11_get_public_key(self, mock_requestauth):
+        tc = Transport(self.sockc)
+        session = {"public_key": test_rsa_public_key}
+        testauth = AuthHandler(tc)
+        testauth.auth_pkcs11("testuser", session, None)
+        public_key = testauth._pkcs11_get_public_key()
+        self.assertEqual(public_key, test_rsa_public_key)


### PR DESCRIPTION
This adds pkcs11 support to enable using paramiko with smartcards.  This requires OpenSC to be installed on the host for the pkcs11provider: https://github.com/OpenSC/OpenSC.

# Multithreading Example:

``` python
import paramiko
from multiprocessing import Queue
from threading import Thread

pkcs11provider="/usr/local/lib/opensc-pkcs11.so"
smartcard_pin="123456"

def do_it(q):
    session = q.get()
    ssh = paramiko.SSHClient()
    ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
    ssh.connect("HOSTNAME", username="USERNAME", pkcs11_session=session)
    stdin, stdout, stderr = ssh.exec_command("uname -a")
    for line in stdout:
        print(line)

q = Queue()
session = paramiko.pkcs11.open_session(pkcs11provider, smartcard_pin)
mythread = Thread(target=do_it, args=(q,))
q.put(session)
mythread.start()
mythread.join()
paramiko.pkcs11.close_session(session)
```
# Basic Example:

``` python
import paramiko

pkcs11provider="/usr/local/lib/opensc-pkcs11.so"
smartcard_pin="123456"

ssh = paramiko.SSHClient()
ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
session = paramiko.pkcs11.open_session(pkcs11provider, smartcard_pin)
ssh.connect("HOSTNAME", username="USERNAME", pkcs11_session=session)
paramiko.pkcs11.close_session(session)
stdin, stdout, stderr = ssh.exec_command("uname -a")
for line in stdout:
    print(line)
```

- David