### PR TITLE
Remove pynacl dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,10 @@ extras_require = {
         'gssapi>=1.4.1;platform_system!="Windows"',
         'pywin32>=2.1.8;platform_system=="Windows"',
     ],
-    "ed25519": ["pynacl>=1.0.1", "bcrypt>=3.1.3"],
+    # TODO 3.0: Remove the ED extra requirement.
+    # This does nothing as ED2559 is supported via cryptography.
+    # Here for backward compatibility.
+    "ed25519": [],
     "invoke": ["invoke>=1.3"],
 }
 everything = []
@@ -86,8 +89,6 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
     ],
-    # TODO 3.0: remove bcrypt, pynacl and update installation docs noting that
-    # use of the extras_require(s) is now required for those
-    install_requires=["bcrypt>=3.1.3", "cryptography>=2.5", "pynacl>=1.0.1"],
+    install_requires=["bcrypt>=3.1.3", "cryptography>=2.6"],
     extras_require=extras_require,
 )

--- a/sites/www/installing.rst
+++ b/sites/www/installing.rst
@@ -26,27 +26,20 @@ Paramiko has only a few **direct dependencies**:
 
 - The big one, with its own sub-dependencies, is Cryptography; see :ref:`its
   specific note below <cryptography>` for more details;
-- `bcrypt <https://pypi.org/project/bcrypt/>`_, for Ed25519 key support;
-- `pynacl <https://pypi.org/project/PyNaCl/>`_, also for Ed25519 key support.
+- `bcrypt <https://pypi.org/project/bcrypt/>`_,
+   for encrypted OpenSSH v1 new key format support;
 
 There are also a number of **optional dependencies** you may install using
 `setuptools 'extras'
 <https://packaging.python.org/tutorials/installing-packages/#installing-setuptools-extras>`_:
 
 .. TODO 3.0: tweak the invoke line to mention proxycommand too
-.. TODO 3.0: tweak the ed25519 line to remove the caveat
 
 - If you want all optional dependencies at once, use ``paramiko[all]``.
 - For ``Match exec`` config support, use ``paramiko[invoke]`` (which installs
   `Invoke <https://www.pyinvoke.org>`_).
 - For GSS-API / SSPI support, use ``paramiko[gssapi]``, though also see
   :ref:`the below subsection on it <gssapi>` for details.
-- ``paramiko[ed25519]`` references the dependencies for Ed25519 key support.
-
-    - As of Paramiko 2.x this doesn't technically do anything, as those
-      dependencies are core installation requirements.
-    - However, you should use this for forwards compatibility; 3.0 will drop
-      those dependencies from core, leaving them purely optional.
 
 
 .. _release-lines:


### PR DESCRIPTION
Scope
=====

The pynacl is only used for ED keys.

cryptography starting with 2.6 supports ED signing.

I think that by removing the pynacl and libsodium deps, it will be much easier to deploy paramiko.
I saw a few issues about failing to use paramiko due to the pynacl deps.


Changes
=======

Update requirements from cryptography 2.5 to 2.6 for ED support.

I think that bcrypt will remain a main deps as it is used in the new OpenSSH v1 private key format.

I kept the ed25519 extra requirement for backward compatibility.

Use cryptography to sign and validate SSH data.

Update the automated tests to include a quick sign / verify test.

Update the www docs to remove `paramiko[ed25519]` or pynacl deps.
Update bcrypt to informa that it's used for OpenSSH v1 private key format.

How to test
========

In the dev environment install cryptography 2.6 and make sure pynacl is removed and run the tests

```
pip install -r dev-requirements.txt
pip install cryptography==2.6
pip uninstall pynacl
invoke test
flake8
```

Check extra requirement still works for backward compatibility:

```
pip install .[ed25519]
```