### PR TITLE
Raise minimum cryptography version to 3.3.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,10 @@ setup(
     ],
     # TODO 3.0: remove bcrypt, pynacl and update installation docs noting that
     # use of the extras_require(s) is now required for those
-    install_requires=["bcrypt>=3.1.3", "cryptography>=3.3.2,<3.4", "pynacl>=1.0.1"],
+    install_requires=[
+        "bcrypt>=3.1.3",
+        "cryptography>=3.3.2,<3.4",
+        "pynacl>=1.0.1",
+    ],
     extras_require=extras_require,
 )

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,6 @@ setup(
     ],
     # TODO 3.0: remove bcrypt, pynacl and update installation docs noting that
     # use of the extras_require(s) is now required for those
-    install_requires=["bcrypt>=3.1.3", "cryptography>=2.5", "pynacl>=1.0.1"],
+    install_requires=["bcrypt>=3.1.3", "cryptography>=3.3.2", "pynacl>=1.0.1"],
     extras_require=extras_require,
 )


### PR DESCRIPTION
There's a security issue: https://github.com/pyca/cryptography/blob/master/CHANGELOG.rst#332---2021-02-07