### PR TITLE
paramiko/client.py: Fix invoke_shell to work with environment

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -544,6 +544,8 @@ class SSHClient(ClosingContextManager):
         """
         chan = self._transport.open_session()
         chan.get_pty(term, width, height, width_pixels, height_pixels)
+        if environment:
+            chan.update_environment(environment)
         chan.invoke_shell()
         return chan
 


### PR DESCRIPTION
When calling invoke_shell() with environment set to something
other than None it is not passed on to the ssh server.

The invoke_shell should pass the environment the same
manner as exec_command().

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>