### PR TITLE
Close socket on failure

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -350,6 +350,9 @@ class SSHClient(ClosingContextManager):
                     # Break out of the loop on success
                     break
                 except socket.error as e:
+                    # As mentioned in socket docs - it is better to close sockets explicitly
+                    if sock:
+                        sock.close()
                     # Raise anything that isn't a straight up connection error
                     # (such as a resolution error)
                     if e.errno not in (ECONNREFUSED, EHOSTUNREACH):

--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -350,7 +350,8 @@ class SSHClient(ClosingContextManager):
                     # Break out of the loop on success
                     break
                 except socket.error as e:
-                    # As mentioned in socket docs - it is better to close sockets explicitly
+                    # As mentioned in socket docs it is better
+                    # to close sockets explicitly
                     if sock:
                         sock.close()
                     # Raise anything that isn't a straight up connection error


### PR DESCRIPTION
As mentioned in socket docs:
"Sockets are automatically closed when they are garbage-collected, but it is recommended to close() them explicitly, or to use a with statement around them."

Resolve #1126