### PR TITLE
Update get-function of sftp_client.py

### DIFF
--- a/paramiko/sftp_client.py
+++ b/paramiko/sftp_client.py
@@ -800,10 +800,10 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
         """
         with open(localpath, "wb") as fl:
             size = self.getfo(remotepath, fl, callback)
-        s = os.stat(localpath)
-        if s.st_size != size:
+            localsize = fl.tell()
+        if localsize != size:
             raise IOError(
-                "size mismatch in get!  {} != {}".format(s.st_size, size)
+                "size mismatch in get!  {} != {}".format(localsize, size)
             )
 
     # ...internals...


### PR DESCRIPTION
Replace file-path based file-size check using file-object based one.

Original file-size check using 'os.stat(localpath)' raises 'IOError' in case of multiple file transfer (i.e. using pysftp or custom-build wrapper) due to synchronicity issues between Python interpreter and local operating system to store files.

New file-size check is using file-object based '.tell()'-method during file-handling to avoid synchronicity issues.

Other methods depending on 'os.stat' are not considered but could potentially profit from using file-object based handling as well.