### PR TITLE
Make prefetching optional in get() and getfo()

### DIFF
--- a/tests/test_sftp.py
+++ b/tests/test_sftp.py
@@ -560,25 +560,27 @@ class TestSFTP(object):
         using a lager file.
         """
 
+        sftp_filename = sftp.FOLDER + "/dummy_file"
+        num_chars = 1024 * 1024 * 4
+
         fd, localname = mkstemp()
         os.close(fd)
 
         with open(localname, 'wb') as f:
-            num_chars = 1024 * 1024 * 4
             f.write(b'0' * num_chars)
 
-        sftp.put(localname, sftp.FOLDER + "/dummy_file")
+        sftp.put(localname, sftp_filename)
 
         os.unlink(localname)
         fd, localname = mkstemp()
         os.close(fd)
 
-        sftp.get(sftp.FOLDER + "/dummy_file", localname, prefetch=False)
+        sftp.get(sftp_filename, localname, prefetch=False)
 
-        assert os.stat(localname).st_size == 4194304
+        assert os.stat(localname).st_size == num_chars
 
         os.unlink(localname)
-        sftp.unlink(sftp.FOLDER + "/dummy_file")
+        sftp.unlink(sftp_filename)
 
     def test_check(self, sftp):
         """

--- a/tests/test_sftp.py
+++ b/tests/test_sftp.py
@@ -554,6 +554,32 @@ class TestSFTP(object):
         os.unlink(localname)
         sftp.unlink(sftp.FOLDER + "/bunny.txt")
 
+    def test_get_without_prefetch(self, sftp):
+        """
+        Create a 4MB file. Verify that pull works without prefetching
+        using a lager file.
+        """
+
+        fd, localname = mkstemp()
+        os.close(fd)
+
+        with open(localname, 'wb') as f:
+            num_chars = 1024 * 1024 * 4
+            f.write(b'0' * num_chars)
+
+        sftp.put(localname, sftp.FOLDER + "/dummy_file")
+
+        os.unlink(localname)
+        fd, localname = mkstemp()
+        os.close(fd)
+
+        sftp.get(sftp.FOLDER + "/dummy_file", localname, prefetch=False)
+
+        assert os.stat(localname).st_size == 4194304
+
+        os.unlink(localname)
+        sftp.unlink(sftp.FOLDER + "/dummy_file")
+
     def test_check(self, sftp):
         """
         verify that file.check() works against our own server.


### PR DESCRIPTION
In some cases prefetching can lead to problems when downloading larger files. The connection to the SFTP server is disconnected due to the query behavior. Proprietary implementations in particular tend to behave that way. Switching off prefetching is a slow but resilient solution to this problem.