### PR TITLE
Mux transport for client (rebased)

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -340,7 +340,8 @@ class SSHClient(ClosingContextManager):
         if controlpath:
             try:
                 t = self._transport = Transport(
-                    (hostname, port), controlpath=controlpath)
+                    (hostname, port), controlpath=controlpath
+                )
                 # If this connection succeeds, most (but not all) of the
                 # SSHClient connect steps can be bypassed
                 if self._log_channel is not None:

--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -348,7 +348,7 @@ class SSHClient(ClosingContextManager):
                     t.set_log_channel(self._log_channel)
                 t.start_client(timeout=timeout)
                 return
-            except SSHException as e:
+            except SSHException:
                 # Quietly fallback to traditional connection steps
                 pass
         if not sock:

--- a/paramiko/common.py
+++ b/paramiko/common.py
@@ -174,6 +174,15 @@ CONNECTION_FAILED_CODE = {
     DISCONNECT_NO_MORE_AUTH_METHODS_AVAILABLE,
 ) = (7, 13, 14)
 
+(
+    MUX_MSG_HELLO,
+    MUX_C_PROXY,
+    MUX_S_PROXY,
+    MUX_C_ALIVE_CHECK,
+    MUX_S_ALIVE,
+    MUX_S_OK,
+) = (1, 0x1000000F, 0x8000000F, 0x10000004, 0x80000005, 0x80000001)
+
 zero_byte = byte_chr(0)
 one_byte = byte_chr(1)
 four_byte = byte_chr(4)

--- a/paramiko/packet.py
+++ b/paramiko/packet.py
@@ -461,7 +461,8 @@ class Packetizer(object):
             if self.__dump_packets:
                 self._log(
                     DEBUG,
-                    "Write mux packet <{}>, length {}".format(mux_packet_type, len(data)),
+                    "Write mux packet <{}>, length {}".format(
+                        mux_packet_type, len(data)),
                 )
                 self._log(DEBUG, util.format_binary(out, "OUT: "))
             self.write_all(out)
@@ -512,7 +513,8 @@ class Packetizer(object):
             # leftover contains decrypted bytes from the first block (after the
             # length field)
             leftover = header[4:]
-            if self.__block_size_in and (packet_size - len(leftover)) % self.__block_size_in != 0:
+            if (self.__block_size_in and
+                    (packet_size - len(leftover)) % self.__block_size_in != 0):
                 raise SSHException("Invalid packet blocking")
             buf = self.read_all(
                 packet_size + self.__mac_size_in - len(leftover)
@@ -613,7 +615,8 @@ class Packetizer(object):
         if self.__dump_packets:
             self._log(
                 DEBUG,
-                "Read mux packet <{}>, length {}".format(mux_packet_type, len(data)),
+                "Read mux packet <{}>, length {}".format(
+                    mux_packet_type, len(data)),
             )
             self._log(DEBUG, util.format_binary(len_prefix + data, "IN: "))
         return mux_packet_type, msg

--- a/paramiko/packet.py
+++ b/paramiko/packet.py
@@ -462,7 +462,8 @@ class Packetizer(object):
                 self._log(
                     DEBUG,
                     "Write mux packet <{}>, length {}".format(
-                        mux_packet_type, len(data)),
+                        mux_packet_type, len(data)
+                    ),
                 )
                 self._log(DEBUG, util.format_binary(out, "OUT: "))
             self.write_all(out)
@@ -513,8 +514,10 @@ class Packetizer(object):
             # leftover contains decrypted bytes from the first block (after the
             # length field)
             leftover = header[4:]
-            if (self.__block_size_in and
-                    (packet_size - len(leftover)) % self.__block_size_in != 0):
+            if (
+                    self.__block_size_in
+                    and (packet_size - len(leftover)) % self.__block_size_in != 0
+            ):
                 raise SSHException("Invalid packet blocking")
             buf = self.read_all(
                 packet_size + self.__mac_size_in - len(leftover)
@@ -616,7 +619,8 @@ class Packetizer(object):
             self._log(
                 DEBUG,
                 "Read mux packet <{}>, length {}".format(
-                    mux_packet_type, len(data)),
+                    mux_packet_type, len(data)
+                ),
             )
             self._log(DEBUG, util.format_binary(len_prefix + data, "IN: "))
         return mux_packet_type, msg

--- a/paramiko/packet.py
+++ b/paramiko/packet.py
@@ -515,8 +515,8 @@ class Packetizer(object):
             # length field)
             leftover = header[4:]
             if (
-                    self.__block_size_in
-                    and (packet_size - len(leftover)) % self.__block_size_in != 0
+                self.__block_size_in
+                and (packet_size - len(leftover)) % self.__block_size_in != 0
             ):
                 raise SSHException("Invalid packet blocking")
             buf = self.read_all(
@@ -675,8 +675,8 @@ class Packetizer(object):
         # pad up at least 4 bytes, to nearest block-size (usually 8)
         bsize = self.__block_size_out
         if bsize:
-            # do not include payload length in computations for padding in EtM mode
-            # (payload length won't be encrypted)
+            # do not include payload length in computations for padding in EtM
+            # mode (payload length won't be encrypted)
             addlen = 4 if self.__etm_out else 8
             padding = 3 + bsize - ((len(payload) + addlen) % bsize)
         else:

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -315,7 +315,7 @@ class Transport(threading.Thread, ClosingContextManager):
         gss_kex=False,
         gss_deleg_creds=True,
         disabled_algorithms=None,
-        mux_path = None,
+        mux_path=None,
     ):
         """
         Create a new SSH session over an existing socket, or socket-like
@@ -1094,10 +1094,11 @@ class Transport(threading.Thread, ClosingContextManager):
         response = self.global_request(
             "tcpip-forward", (address, port), wait=True
         )
-        if response is None:
-            raise SSHException("TCP forwarding request denied")
-        if port == 0:
-            port = response.get_int()
+        if not self.mux_path:
+            if response is None:
+                raise SSHException("TCP forwarding request denied")
+            if port == 0:
+                port = response.get_int()
         if handler is None:
 
             def default_handler(channel, src_addr, dest_addr_port):
@@ -1166,6 +1167,10 @@ class Transport(threading.Thread, ClosingContextManager):
             `.SSHException` -- if the key renegotiation failed (which causes
             the session to end)
         """
+        if self.mux_path:
+            # Disallow this when in mux proxy mode
+            self._log(DEBUG, "Ignoring renegotiate_keys() in mux proxy mode")
+            return
         self.completion_event = threading.Event()
         self._send_kex_init()
         while True:
@@ -1224,6 +1229,10 @@ class Transport(threading.Thread, ClosingContextManager):
         self._log(DEBUG, 'Sending global request "{}"'.format(kind))
         self._send_user_message(m)
         if not wait:
+            return None
+        if self.mux_path:
+            # Mux master does not forward the global_response reply
+            self._log(DEBUG, "Skipping global_response wait from mux proxy")
             return None
         while True:
             self.completion_event.wait(0.1)
@@ -2083,7 +2092,8 @@ class Transport(threading.Thread, ClosingContextManager):
                     self.packetizer.write_all(b(self.local_version + "\r\n"))
                     self._log(
                         DEBUG,
-                        "Local version/idstring: {}".format(self.local_version),
+                        "Local version/idstring: {}".format(
+                            self.local_version),
                     )  # noqa
                     self._check_banner()
                     # The above is actually very much part of the handshake, but
@@ -2677,6 +2687,7 @@ class Transport(threading.Thread, ClosingContextManager):
                 DEBUG,
                 'Rejecting "{}" global request from server.'.format(kind),
             )
+            self._log(DEBUG, "want_reply {}".format(want_reply))
             ok = False
         elif kind == "tcpip-forward":
             address = m.get_text()
@@ -2917,10 +2928,13 @@ class Transport(threading.Thread, ClosingContextManager):
         self.packetizer.send_mux_message(m.asbytes())
         resp, msg = self.packetizer.read_mux_message()
         if resp != MUX_MSG_HELLO:
-            raise SSHException("Expected MUX_MSG_HELLO response, got 0x{:x}".format(resp))
+            raise SSHException(
+                "Expected MUX_MSG_HELLO response, got 0x{:x}".format(resp))
         remote_version = msg.get_int()
         if remote_version != version:
-            raise SSHException("Expected Mux protocol version {:d}, got {:d}".format(version, remote_version))
+            raise SSHException(
+                "Expected Mux protocol version {:d}, got {:d}".format(
+                    version, remote_version))
         # Send MUX_C_ALIVE_CHECK as final confirmation
         m = paramiko.Message()
         m.add_int(MUX_C_ALIVE_CHECK)
@@ -2931,7 +2945,8 @@ class Transport(threading.Thread, ClosingContextManager):
             raise SSHException("Mux Alive - Invalid reply 0x{:x}".format(resp))
         request_id = msg.get_int()
         if request_id != 1:
-            raise SSHException("Mux reply - expected request id 1, got {}", request_id)
+            raise SSHException(
+                "Mux reply - expected request id 1, got {}", request_id)
         pid = msg.get_int()
         self._log(DEBUG, "Connected to SSH ControlMaster (PID {})".format(pid))
         # Everything looks good, one last request to enter proxy mode
@@ -2941,7 +2956,9 @@ class Transport(threading.Thread, ClosingContextManager):
         self.packetizer.send_mux_message(m.asbytes())
         resp, msg = self.packetizer.read_mux_message()
         if resp != MUX_S_PROXY or msg.get_int() != 2:
-            raise SSHException('Mux proxy request - got unexpected reply: 0x{:x} {!r}'.format(resp, msg))
+            raise SSHException(
+                "Mux proxy request - got unexpected reply: 0x{:x} {!r}".format(
+                    resp, msg))
 
     _handler_table = {
         MSG_NEWKEYS: _parse_newkeys,

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -2108,7 +2108,7 @@ class Transport(threading.Thread, ClosingContextManager):
                     # but sometimes the banner can be read but the machine is
                     # not responding, for example when the remote ssh daemon is
                     # loaded in to memory but we can not read from the
-                    # dick/spawn a new shell.
+                    # disk/spawn a new shell.
                     # Make sure we can specify a timeout for the initial
                     # handshake. Re-use the banner timeout for now.
                     self.packetizer.start_handshake(self.handshake_timeout)
@@ -2969,7 +2969,8 @@ class Transport(threading.Thread, ClosingContextManager):
         resp, msg = self.packetizer.read_mux_message()
         if resp != MUX_S_PROXY or msg.get_int() != 2:
             raise SSHException(
-                "Mux proxy request - got unexpected reply: 0x{:x} {!r}".format(
+                "Mux proxy request rejected (Requires OpenSSH 7.4 or greater)"
+                " - got unexpected reply: 0x{:x} {!r}".format(
                     resp, msg
                 )
             )

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -84,6 +84,11 @@ from paramiko.common import (
     HIGHEST_USERAUTH_MESSAGE_ID,
     MSG_UNIMPLEMENTED,
     MSG_NAMES,
+    MUX_MSG_HELLO,
+    MUX_C_PROXY,
+    MUX_S_PROXY,
+    MUX_C_ALIVE_CHECK,
+    MUX_S_ALIVE,
 )
 from paramiko.compress import ZlibCompressor, ZlibDecompressor
 from paramiko.dsskey import DSSKey
@@ -310,6 +315,7 @@ class Transport(threading.Thread, ClosingContextManager):
         gss_kex=False,
         gss_deleg_creds=True,
         disabled_algorithms=None,
+        mux_path = None,
     ):
         """
         Create a new SSH session over an existing socket, or socket-like
@@ -383,6 +389,8 @@ class Transport(threading.Thread, ClosingContextManager):
         """
         self.active = False
         self.hostname = None
+        self.log_name = "paramiko.transport"
+        self.logger = util.get_logger(self.log_name)
 
         if isinstance(sock, string_types):
             # convert "host:port" into (host, port)
@@ -392,6 +400,28 @@ class Transport(threading.Thread, ClosingContextManager):
                 sock = (hl[0], 22)
             else:
                 sock = (hl[0], int(hl[1]))
+        # If mux_path is set, try connecting to it, fallback to non-mux
+        self.mux_path = None
+        if mux_path:
+            try:
+                self._log(INFO, "Trying ControlPath '%s'", mux_path)
+                mux_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                mux_sock.connect(mux_path)
+                self._log(DEBUG, "Connected to ControlPath '%s'", mux_path)
+                # Send/recv the HELLO message to Mux server
+                self.packetizer = Packetizer(mux_sock)
+                self.packetizer.set_log(self.logger)
+                # Mux connection requires no cipher, no compression, no padding
+                self.packetizer.set_outbound_cipher(None, 0, None, 0, None)
+                self.packetizer.set_inbound_cipher(None, 0, None, 0, None)
+                #
+                self._start_mux_session()
+                self.mux_path = mux_path
+                sock = mux_sock
+            except Exception as e:
+                self._log(INFO, "Multiplex connection failed: %r", e)
+                self._log(INFO, "Falling back to socket connection")
+
         if type(sock) is tuple:
             # connect to the given (host, port)
             hostname, port = sock
@@ -424,7 +454,8 @@ class Transport(threading.Thread, ClosingContextManager):
         self.sock.settimeout(self._active_check_timeout)
 
         # negotiated crypto parameters
-        self.packetizer = Packetizer(sock)
+        if not self.mux_path:
+            self.packetizer = Packetizer(sock)
         self.local_version = "SSH-" + self._PROTO_ID + "-" + self._CLIENT_ID
         self.remote_version = ""
         self.local_cipher = self.remote_cipher = ""
@@ -472,8 +503,6 @@ class Transport(threading.Thread, ClosingContextManager):
         self.clear_to_send = threading.Event()
         self.clear_to_send_lock = threading.Lock()
         self.clear_to_send_timeout = 30.0
-        self.log_name = "paramiko.transport"
-        self.logger = util.get_logger(self.log_name)
         self.packetizer.set_log(self.logger)
         self.auth_handler = None
         # response Message from an arbitrary global request
@@ -496,6 +525,14 @@ class Transport(threading.Thread, ClosingContextManager):
         self.server_accepts = []
         self.server_accept_cv = threading.Condition(self.lock)
         self.subsystem_table = {}
+
+        # Express connect state when using ControlMaster
+        if self.mux_path:
+            self.initial_kex_done = True
+            self.authenticated = True
+            self.auth_handler = AuthHandler(self)
+            self.auth_handler.authenticated = True
+            self.clear_to_send.set()
 
     def _filter_algorithm(self, type_):
         default = getattr(self, "_preferred_{}".format(type_))
@@ -533,6 +570,8 @@ class Transport(threading.Thread, ClosingContextManager):
         out = "<paramiko.Transport at {}".format(id_)
         if not self.active:
             out += " (unconnected)"
+        elif self.mux_path:
+            out += " (Mux/ControlPath {})".format(self.mux_path)
         else:
             if self.local_cipher != "":
                 out += " (cipher {}, {:d} bits)".format(
@@ -1289,6 +1328,10 @@ class Transport(threading.Thread, ClosingContextManager):
         )
 
         self.start_client()
+        if self.mux_path:
+            # If ControlMaster connection has been established, then there
+            # is no need to check host keys or do any user authentication
+            return
 
         # check host key if we were given one
         # If GSS-API Key Exchange was performed, we are not required to check
@@ -2029,24 +2072,30 @@ class Transport(threading.Thread, ClosingContextManager):
             self._log(DEBUG, "starting thread (server mode): {}".format(tid))
         else:
             self._log(DEBUG, "starting thread (client mode): {}".format(tid))
+            if self.mux_path:
+                # No initial protocol chatter (banner, Kex) takes
+                # place when using ControlMaster mux connection. Force
+                # the completion event to allow start_client to return.
+                self.completion_event.set()
         try:
             try:
-                self.packetizer.write_all(b(self.local_version + "\r\n"))
-                self._log(
-                    DEBUG,
-                    "Local version/idstring: {}".format(self.local_version),
-                )  # noqa
-                self._check_banner()
-                # The above is actually very much part of the handshake, but
-                # sometimes the banner can be read but the machine is not
-                # responding, for example when the remote ssh daemon is loaded
-                # in to memory but we can not read from the disk/spawn a new
-                # shell.
-                # Make sure we can specify a timeout for the initial handshake.
-                # Re-use the banner timeout for now.
-                self.packetizer.start_handshake(self.handshake_timeout)
-                self._send_kex_init()
-                self._expect_packet(MSG_KEXINIT)
+                if not self.mux_path:
+                    self.packetizer.write_all(b(self.local_version + "\r\n"))
+                    self._log(
+                        DEBUG,
+                        "Local version/idstring: {}".format(self.local_version),
+                    )  # noqa
+                    self._check_banner()
+                    # The above is actually very much part of the handshake, but
+                    # sometimes the banner can be read but the machine is not
+                    # responding, for example when the remote ssh daemon is loaded
+                    # in to memory but we can not read from the disk/spawn a new
+                    # shell.
+                    # Make sure we can specify a timeout for the initial handshake.
+                    # Re-use the banner timeout for now.
+                    self.packetizer.start_handshake(self.handshake_timeout)
+                    self._send_kex_init()
+                    self._expect_packet(MSG_KEXINIT)
 
                 while self.active:
                     if self.packetizer.need_rekey() and not self.in_kex:
@@ -2853,6 +2902,46 @@ class Transport(threading.Thread, ClosingContextManager):
             return self.subsystem_table[name]
         finally:
             self.lock.release()
+
+    def _start_mux_session(self, version=4):
+        """
+        Check the SSH ControlMaster connection, and ensure that the
+        server side responds appropriately to MUX_MSG_HELLO, MUX_C_ALIVE_CHECK,
+        and MUX_C_PROXY messages. Once entering proxy mode, the client
+        SSH protocol messages can be sent to the ControlMaster as
+        unencrypted, unpadded Transport messages.
+        """
+        m = paramiko.Message()
+        m.add_int(MUX_MSG_HELLO)
+        m.add_int(version)
+        self.packetizer.send_mux_message(m.asbytes())
+        resp, msg = self.packetizer.read_mux_message()
+        if resp != MUX_MSG_HELLO:
+            raise SSHException("Expected MUX_MSG_HELLO response, got 0x{:x}".format(resp))
+        remote_version = msg.get_int()
+        if remote_version != version:
+            raise SSHException("Expected Mux protocol version {:d}, got {:d}".format(version, remote_version))
+        # Send MUX_C_ALIVE_CHECK as final confirmation
+        m = paramiko.Message()
+        m.add_int(MUX_C_ALIVE_CHECK)
+        m.add_int(1)
+        self.packetizer.send_mux_message(m.asbytes())
+        resp, msg = self.packetizer.read_mux_message()
+        if resp != MUX_S_ALIVE:
+            raise SSHException("Mux Alive - Invalid reply 0x{:x}".format(resp))
+        request_id = msg.get_int()
+        if request_id != 1:
+            raise SSHException("Mux reply - expected request id 1, got {}", request_id)
+        pid = msg.get_int()
+        self._log(DEBUG, "Connected to SSH ControlMaster (PID {})".format(pid))
+        # Everything looks good, one last request to enter proxy mode
+        m = paramiko.Message()
+        m.add_int(MUX_C_PROXY)
+        m.add_int(2)
+        self.packetizer.send_mux_message(m.asbytes())
+        resp, msg = self.packetizer.read_mux_message()
+        if resp != MUX_S_PROXY or msg.get_int() != 2:
+            raise SSHException('Mux proxy request - got unexpected reply: 0x{:x} {!r}'.format(resp, msg))
 
     _handler_table = {
         MSG_NEWKEYS: _parse_newkeys,

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -426,7 +426,8 @@ class Transport(threading.Thread, ClosingContextManager):
                 raise SSHException(
                     "Unable to connect to ControlPath '{}' - {}".format(
                         controlpath, e
-                    ))
+                    )
+                )
 
         if type(sock) is tuple:
             # connect to the given (host, port)
@@ -2099,16 +2100,17 @@ class Transport(threading.Thread, ClosingContextManager):
                     self._log(
                         DEBUG,
                         "Local version/idstring: {}".format(
-                            self.local_version),
+                            self.local_version
+                        ),
                     )  # noqa
                     self._check_banner()
-                    # The above is actually very much part of the handshake, but
-                    # sometimes the banner can be read but the machine is not
-                    # responding, for example when the remote ssh daemon is loaded
-                    # in to memory but we can not read from the disk/spawn a new
-                    # shell.
-                    # Make sure we can specify a timeout for the initial handshake.
-                    # Re-use the banner timeout for now.
+                    # The above is actually very much part of the handshake,
+                    # but sometimes the banner can be read but the machine is
+                    # not responding, for example when the remote ssh daemon is
+                    # loaded in to memory but we can not read from the
+                    # dick/spawn a new shell.
+                    # Make sure we can specify a timeout for the initial
+                    # handshake. Re-use the banner timeout for now.
                     self.packetizer.start_handshake(self.handshake_timeout)
                     self._send_kex_init()
                     self._expect_packet(MSG_KEXINIT)
@@ -2935,12 +2937,15 @@ class Transport(threading.Thread, ClosingContextManager):
         resp, msg = self.packetizer.read_mux_message()
         if resp != MUX_MSG_HELLO:
             raise SSHException(
-                "Expected MUX_MSG_HELLO response, got 0x{:x}".format(resp))
+                "Expected MUX_MSG_HELLO response, got 0x{:x}".format(resp)
+            )
         remote_version = msg.get_int()
         if remote_version != version:
             raise SSHException(
                 "Expected Mux protocol version {:d}, got {:d}".format(
-                    version, remote_version))
+                    version, remote_version
+                )
+            )
         # Send MUX_C_ALIVE_CHECK as final confirmation
         m = paramiko.Message()
         m.add_int(MUX_C_ALIVE_CHECK)
@@ -2952,7 +2957,8 @@ class Transport(threading.Thread, ClosingContextManager):
         request_id = msg.get_int()
         if request_id != 1:
             raise SSHException(
-                "Mux reply - expected request id 1, got {}", request_id)
+                "Mux reply - expected request id 1, got {}", request_id
+            )
         pid = msg.get_int()
         self._log(DEBUG, "Connected to SSH ControlMaster (PID {})".format(pid))
         # Everything looks good, one last request to enter proxy mode

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -2970,7 +2970,9 @@ class Transport(threading.Thread, ClosingContextManager):
         if resp != MUX_S_PROXY or msg.get_int() != 2:
             raise SSHException(
                 "Mux proxy request - got unexpected reply: 0x{:x} {!r}".format(
-                    resp, msg))
+                    resp, msg
+                )
+            )
 
     _handler_table = {
         MSG_NEWKEYS: _parse_newkeys,

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -315,7 +315,7 @@ class Transport(threading.Thread, ClosingContextManager):
         gss_kex=False,
         gss_deleg_creds=True,
         disabled_algorithms=None,
-        mux_path=None,
+        controlpath=None,
     ):
         """
         Create a new SSH session over an existing socket, or socket-like
@@ -378,6 +378,10 @@ class Transport(threading.Thread, ClosingContextManager):
             your code talks to a server which implements it differently from
             Paramiko), specify ``disabled_algorithms={"kex":
             ["diffie-hellman-group16-sha512"]}``.
+        :param string controlpath:
+            Connect to a multiplexing ControlMaster instead of standard
+            TCP socket, allowing a shared connection to an already negotiated
+            and authenticated SSH Transport (via proxy)
 
         .. versionchanged:: 1.15
             Added the ``default_window_size`` and ``default_max_packet_size``
@@ -400,27 +404,29 @@ class Transport(threading.Thread, ClosingContextManager):
                 sock = (hl[0], 22)
             else:
                 sock = (hl[0], int(hl[1]))
-        # If mux_path is set, try connecting to it, fallback to non-mux
-        self.mux_path = None
-        if mux_path:
+        # If controlpath is set, try connecting to it
+        self.controlpath = None
+        if controlpath:
             try:
-                self._log(INFO, "Trying ControlPath '%s'", mux_path)
+                self._log(INFO, "Trying ControlPath '%s'", controlpath)
                 mux_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-                mux_sock.connect(mux_path)
-                self._log(DEBUG, "Connected to ControlPath '%s'", mux_path)
-                # Send/recv the HELLO message to Mux server
+                mux_sock.connect(controlpath)
+                self._log(DEBUG, "Connected to ControlPath '%s'", controlpath)
                 self.packetizer = Packetizer(mux_sock)
                 self.packetizer.set_log(self.logger)
                 # Mux connection requires no cipher, no compression, no padding
                 self.packetizer.set_outbound_cipher(None, 0, None, 0, None)
                 self.packetizer.set_inbound_cipher(None, 0, None, 0, None)
-                #
+                # Send/recv the HELLO message to Mux server
                 self._start_mux_session()
-                self.mux_path = mux_path
+                self.controlpath = controlpath
                 sock = mux_sock
             except Exception as e:
-                self._log(INFO, "Multiplex connection failed: %r", e)
-                self._log(INFO, "Falling back to socket connection")
+                self._log(INFO, "ControlPath connection failed: %r", e)
+                raise SSHException(
+                    "Unable to connect to ControlPath '{}' - {}".format(
+                        controlpath, e
+                    ))
 
         if type(sock) is tuple:
             # connect to the given (host, port)
@@ -454,7 +460,7 @@ class Transport(threading.Thread, ClosingContextManager):
         self.sock.settimeout(self._active_check_timeout)
 
         # negotiated crypto parameters
-        if not self.mux_path:
+        if not self.controlpath:
             self.packetizer = Packetizer(sock)
         self.local_version = "SSH-" + self._PROTO_ID + "-" + self._CLIENT_ID
         self.remote_version = ""
@@ -526,8 +532,8 @@ class Transport(threading.Thread, ClosingContextManager):
         self.server_accept_cv = threading.Condition(self.lock)
         self.subsystem_table = {}
 
-        # Express connect state when using ControlMaster
-        if self.mux_path:
+        # Express connect state when using controlpath
+        if self.controlpath:
             self.initial_kex_done = True
             self.authenticated = True
             self.auth_handler = AuthHandler(self)
@@ -570,8 +576,8 @@ class Transport(threading.Thread, ClosingContextManager):
         out = "<paramiko.Transport at {}".format(id_)
         if not self.active:
             out += " (unconnected)"
-        elif self.mux_path:
-            out += " (Mux/ControlPath {})".format(self.mux_path)
+        elif self.controlpath:
+            out += " (Mux/ControlPath {})".format(self.controlpath)
         else:
             if self.local_cipher != "":
                 out += " (cipher {}, {:d} bits)".format(
@@ -1094,7 +1100,7 @@ class Transport(threading.Thread, ClosingContextManager):
         response = self.global_request(
             "tcpip-forward", (address, port), wait=True
         )
-        if not self.mux_path:
+        if not self.controlpath:
             if response is None:
                 raise SSHException("TCP forwarding request denied")
             if port == 0:
@@ -1167,7 +1173,7 @@ class Transport(threading.Thread, ClosingContextManager):
             `.SSHException` -- if the key renegotiation failed (which causes
             the session to end)
         """
-        if self.mux_path:
+        if self.controlpath:
             # Disallow this when in mux proxy mode
             self._log(DEBUG, "Ignoring renegotiate_keys() in mux proxy mode")
             return
@@ -1230,7 +1236,7 @@ class Transport(threading.Thread, ClosingContextManager):
         self._send_user_message(m)
         if not wait:
             return None
-        if self.mux_path:
+        if self.controlpath:
             # Mux master does not forward the global_response reply
             self._log(DEBUG, "Skipping global_response wait from mux proxy")
             return None
@@ -1337,8 +1343,8 @@ class Transport(threading.Thread, ClosingContextManager):
         )
 
         self.start_client()
-        if self.mux_path:
-            # If ControlMaster connection has been established, then there
+        if self.controlpath:
+            # If ControlPath connection has been established, then there
             # is no need to check host keys or do any user authentication
             return
 
@@ -2081,14 +2087,14 @@ class Transport(threading.Thread, ClosingContextManager):
             self._log(DEBUG, "starting thread (server mode): {}".format(tid))
         else:
             self._log(DEBUG, "starting thread (client mode): {}".format(tid))
-            if self.mux_path:
+            if self.controlpath:
                 # No initial protocol chatter (banner, Kex) takes
-                # place when using ControlMaster mux connection. Force
+                # place when using ControlPath mux connection. Force
                 # the completion event to allow start_client to return.
                 self.completion_event.set()
         try:
             try:
-                if not self.mux_path:
+                if not self.controlpath:
                     self.packetizer.write_all(b(self.local_version + "\r\n"))
                     self._log(
                         DEBUG,
@@ -2916,10 +2922,10 @@ class Transport(threading.Thread, ClosingContextManager):
 
     def _start_mux_session(self, version=4):
         """
-        Check the SSH ControlMaster connection, and ensure that the
+        Check the SSH ControlPath connection, and ensure that the
         server side responds appropriately to MUX_MSG_HELLO, MUX_C_ALIVE_CHECK,
         and MUX_C_PROXY messages. Once entering proxy mode, the client
-        SSH protocol messages can be sent to the ControlMaster as
+        SSH protocol messages can be sent to the ControlPath as
         unencrypted, unpadded Transport messages.
         """
         m = paramiko.Message()


### PR DESCRIPTION
This is a straight rebase of #1341, which no longer merges cleanly. So far, I've not attempted to make any changes to it.

I wonder if it would be better, rather than adding another parameter to `Client.connect()` which causes it to take a completely different code path, to add a separate method, called something like `connect_multiplex()` or `connect_master()`, which just does this. Then it can be up to the caller whether to fall back to standard connection if using the multiplexing socket fails (whereas the current implementation silences errors and always tries to fall back).

(In principle, I'd also like to disentangle the code in Transport in a similar way, but it's less clear how to do that)