### PR TITLE
Change SFTP Server to check if attributes is instance of SFTPAttributes

### DIFF
--- a/paramiko/sftp_server.py
+++ b/paramiko/sftp_server.py
@@ -234,7 +234,7 @@ class SFTPServer(BaseSFTP, SubsystemHandler):
                 msg.add_int(item)
             elif isinstance(item, (string_types, bytes_types)):
                 msg.add_string(item)
-            elif type(item) is SFTPAttributes:
+            elif isinstance(item, SFTPAttributes):
                 item._pack(msg)
             else:
                 raise Exception(


### PR DESCRIPTION
I needed to extend SFTPAttributes to handle a custom hash function, but the `_process` checks if the type equals to `SFTPAttributes`, so I changed the check to `isinstance` instead of `type()`