### PR TITLE
Prevent double close from __del__

### DIFF
--- a/paramiko/file.py
+++ b/paramiko/file.py
@@ -63,6 +63,8 @@ class BufferedFile(ClosingContextManager):
         self._size = 0
 
     def __del__(self):
+        if self._closed:
+            return
         self.close()
 
     def __iter__(self):


### PR DESCRIPTION
__del__ might be called after the channel is truly closed, causing the flush to fail.