### PR TITLE
Add SOCKS5 proxy functionality

### DIFF
--- a/demos/demo_socks_proxy.py
+++ b/demos/demo_socks_proxy.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python
+#
+# This file is part of paramiko.
+#
+# Paramiko is free software; you can redistribute it and/or modify it under the
+# terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# Paramiko is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Paramiko; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+
+"""
+Sample script to show how to use paramiko's SOCKS proxy server functionality.
+
+This script connects to a configured SSH server and opens a local
+SOCKS5 proxy which tunnels all traffic over the SSH connection (similar to
+`openssh -D`). It then configures a requests session to use this SOCKS5 proxy
+to fetch the configured URL tunneled through the SSH connection.
+
+Please note that you need to install requests with socks proxy support
+(`requests[socks]`) for this demo to work.
+"""
+
+import getpass
+
+from optparse import OptionParser
+
+import requests
+
+from paramiko.client import AutoAddPolicy, SSHClient
+
+
+DEFAULT_SSH_PORT = 22
+DEFAULT_SOCKS_ADDR = "localhost:1080"
+DEFAULT_SOCKS_PORT = 1080
+
+
+def get_host_port(spec, default_port):
+    """
+    parse 'hostname:22' into a host and port, with the port optional
+    """
+    args = (spec.split(":", 1) + [default_port])[:2]
+    args[1] = int(args[1])
+    return args[0], args[1]
+
+
+def parse_options():
+    parser = OptionParser(
+        usage="usage: %prog [options] url-to-fetch",
+        description="Demo for providing a SOCKS proxy and using it "
+                    "with requests to request an URL",
+    )
+    parser.add_option(
+        "-u",
+        "--user",
+        action="store",
+        type="string",
+        help="username for SSH authentication",
+    )
+    parser.add_option(
+        "-K",
+        "--key",
+        action="store",
+        type="string",
+        dest="keyfile",
+        default=None,
+        help="private key file to use for SSH authentication",
+    )
+    parser.add_option(
+        "",
+        "--no-key",
+        action="store_false",
+        dest="look_for_keys",
+        default=True,
+        help="don't look for or use a private key file",
+    )
+    parser.add_option(
+        "-P",
+        "--password",
+        action="store_true",
+        dest="readpass",
+        default=False,
+        help="read password (for key or password auth) from stdin",
+    )
+    parser.add_option(
+        "-r",
+        "--remote",
+        action="store",
+        type="string",
+        metavar="host:port",
+        help="Host and port of the SSH server to connect to",
+    )
+    parser.add_option(
+        "-s",
+        "--socks-addr",
+        action="store",
+        type="string",
+        default=DEFAULT_SOCKS_ADDR,
+        metavar="host:port",
+        help="Host and port the SOCKS proxy should bind to. Defaults to %s" %
+             DEFAULT_SOCKS_ADDR,
+    )
+    options, args = parser.parse_args()
+
+    if len(args) != 1:
+        parser.error("Incorrect number of positional arguments.")
+    if not options.user or not options.remote or not options.socks_addr:
+        parser.error("Mandatory options missing.")
+
+    ssh_server, ssh_port = get_host_port(options.remote, DEFAULT_SSH_PORT)
+    socks_addr, socks_port = get_host_port(
+        options.socks_addr, DEFAULT_SOCKS_PORT
+    )
+    return (
+        ssh_server,
+        ssh_port,
+        options.user,
+        options.keyfile,
+        options.look_for_keys,
+        options.readpass,
+        socks_addr,
+        socks_port,
+        args[0]
+    )
+
+
+def main():
+    options = parse_options()
+    ssh_server = options[0]
+    ssh_port = options[1]
+    user = options[2]
+    keyfile = options[3]
+    look_for_keys = options[4]
+    readpass = options[5]
+    socks_addr = options[6]
+    socks_port = options[7]
+    url_to_fetch = options[8]
+
+    password = None
+    if readpass:
+        password = getpass.getpass("Enter SSH password: ")
+
+    with SSHClient() as ssh_client:
+        ssh_client.load_system_host_keys()
+        ssh_client.set_missing_host_key_policy(AutoAddPolicy())
+
+        try:
+            ssh_client.connect(
+                ssh_server,
+                port=ssh_port,
+                username=user,
+                key_filename=keyfile,
+                look_for_keys=look_for_keys,
+                password=password,
+            )
+        except Exception as e:
+            print("*** Failed to connect to server: {}".format(e))
+            exit(1)
+
+        proxy = ssh_client.open_socks_proxy(
+            bind_address=socks_addr,
+            port=socks_port
+        )
+
+        # Example of how to use with requests.
+        # Using the socks5h protocol for resolving host names on SOCKS
+        # server side works as well.
+        proxies = {
+            'http': 'socks5://{}:{}'.format(socks_addr, socks_port),
+            'https': 'socks5://{}:{}'.format(socks_addr, socks_port),
+        }
+        session = requests.Session()
+        session.proxies.update(proxies)
+        response = session.get(url_to_fetch)
+        print(response.text)
+
+        # Closing the SOCKS proxy is optional, as it would get closed together
+        # with the SSHClient as well.
+        proxy.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/paramiko/socks_proxy.py
+++ b/paramiko/socks_proxy.py
@@ -1,0 +1,551 @@
+# This file is part of paramiko.
+#
+# Paramiko is free software; you can redistribute it and/or modify it under the
+# terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# Paramiko is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Paramiko; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+
+"""
+SOCKS5 server implementation.
+"""
+
+from errno import ECONNREFUSED, EHOSTUNREACH, ENETDOWN, ENETUNREACH
+
+import select
+import socket
+import struct
+import threading
+
+try:
+    from socketserver import StreamRequestHandler, ThreadingTCPServer
+except ImportError:
+    from SocketServer import StreamRequestHandler, ThreadingTCPServer
+
+from paramiko.common import DEBUG, asbytes
+from paramiko.py3compat import BytesIO, byte_chr, byte_ord, u
+from paramiko.ssh_exception import NoValidConnectionsError
+from paramiko.util import (
+    families_and_addresses,
+    get_logger,
+    ip_addr_to_str,
+    ClosingContextManager
+)
+
+
+SOCKS5_VERSION = 0x05
+
+SOCKS5_CMD_CONNECT = 0x01
+
+SOCKS5_NO_AUTH_REQUIRED = 0x00
+SOCKS5_NO_ACCEPTABLE_METHOD = 0xff
+
+SOCKS5_ATYP_IPV4 = 0x01
+SOCKS5_ATYP_DOMAINNAME = 0x03
+SOCKS5_ATYP_IPV6 = 0x04
+
+SOCKS5_RESERVED = 0x00
+
+SOCKS5_SUCCEEDED = 0x00
+SOCKS5_GENERAL_SERVER_FAILURE = 0x01
+SOCKS5_CONNECTION_NOT_ALLOWED = 0x02
+SOCKS5_NETWORK_UNREACHABLE = 0x03
+SOCKS5_HOST_UNREACHABLE = 0x04
+SOCKS5_CONNECTION_REFUSED = 0x05
+SOCKS5_TTL_EXPIRED = 0x06
+SOCKS5_COMMAND_NOT_SUPPORTED = 0x07
+SOCKS5_ADDRESS_TYPE_NOT_SUPPORTED = 0x08
+
+
+class SOCKSMessage:
+    """
+    An SOCKS message is a stream of bytes that encodes some combination of
+    strings, integers and unsigned shorts. This class builds or breaks down
+    such a byte stream.
+
+    Normally you don't need to deal with anything this low-level, but it's
+    exposed for people implementing custom extensions, or features that
+    paramiko doesn't support yet.
+    """
+
+    def __init__(self, sock=None):
+        """
+        Create a new SOCKS message.
+
+        :param socket.socket sock:
+            socket object to read the message content from (passed in only when
+            decomposing a message).
+        """
+        if sock is not None:
+            self.packet = sock.makefile(mode="b")
+        else:
+            self.packet = BytesIO()
+
+    def __str__(self):
+        """
+        Return the byte stream content of this message, as a string/bytes obj.
+
+        :rtype: str
+        """
+        return u(self.asbytes())
+
+    def __repr__(self):
+        """
+        Returns a string representation of this object, for debugging.
+
+        :rtype: str
+        """
+        return "<paramiko.SOCKSMessage(" + repr(self.packet.getvalue()) + ")>"
+
+    def asbytes(self):
+        """
+        Return the byte stream content of this Message, as bytes.
+
+        :rtype: bytearray
+        """
+        return self.packet.getvalue()
+
+    def get_bytes(self, n):
+        """
+        Return the next ``n`` bytes of the message (as a `str`), without
+        decomposing into an int, decoded string, etc. Just the raw bytes are
+        returned.
+
+        :param int n: Number of bytes to get.
+
+        :rtype: bytearray
+        """
+        return self.packet.read(n)
+
+    def get_short(self):
+        """
+        Fetch an unsigned short from the stream.
+
+        This is used for network ports in SOCKS messages.
+
+        :rtype: int
+        """
+        return struct.unpack("!H", self.get_bytes(2))[0]
+
+    def get_int(self):
+        """
+        Fetch an int from the stream.
+
+        This is used for IPv4 IP addresses in SOCKS messages.
+
+        :rtype: int
+        """
+        return struct.unpack("!I", self.get_bytes(4))[0]
+
+    def get_int64(self):
+        """
+        Fetch a 64-bit int from the stream.
+
+        Two of such int64 are used for IPv6 IP addresses in SOCKS messages.
+
+        :return: a 64-bit unsigned integer (`long`).
+        :rtype: int
+        """
+        return struct.unpack("!Q", self.get_bytes(8))[0]
+
+    def get_char(self):
+        """
+        Fetch a single character from the stream and return its decoded value.
+        """
+        return byte_ord(struct.unpack("!c", self.get_bytes(1))[0])
+
+    def get_string(self):
+        """
+        Fetch a Unicode string from the stream.
+
+        Strings are used in SOCKS messages for the host name of the
+        destination when the domain name address type is used.
+
+        :rtype: str
+        """
+        return u(self.get_bytes(self.get_char()))
+
+    def add_bytes(self, b):
+        """
+        Write bytes to the stream, without any formatting.
+
+        :param str b: bytes to add
+
+        :rtype: SOCKSMessage
+        """
+        self.packet.write(b)
+        return self
+
+    def add_short(self, n):
+        """
+        Add an unsigned short to the stream.
+
+        :param int n: short to add
+
+        :rtype: SOCKSMessage
+        """
+        self.packet.write(struct.pack("!H", n))
+        return self
+
+    def add_int(self, n):
+        """
+        Add an integer to the stream.
+
+        This is used for IPv4 IP addresses in SOCKS messages.
+
+        :param int n: integer to add
+
+        :rtype: SOCKSMessage
+        """
+        self.packet.write(struct.pack("!I", n))
+        return self
+
+    def add_int64(self, n):
+        """
+        Add a 64-bit int to the stream.
+
+        Two of such int64 are used for IPv6 IP addresses in SOCKS messages.
+
+        :param long n: long int to add
+
+        :rtype: SOCKSMessage
+        """
+        self.packet.write(struct.pack("!Q", n))
+        return self
+
+    def add_char(self, c):
+        """
+        Add a char to the stream
+
+        :param c: character to add
+
+        :rtype: SOCKSMessage
+        """
+        self.packet.write(byte_chr(c))
+        return self
+
+    def add_string(self, s):
+        """
+        Add a string to the stream.
+
+        Strings are used in SOCKS messages for the host name of the
+        destination when the domain name address type is used.
+
+        :param str s: string to add
+
+        :rtype: SOCKSMessage
+        """
+        s = asbytes(s)
+        self.add_char(len(s))
+        self.packet.write(s)
+        return self
+
+
+class SOCKS5RequestHandler(StreamRequestHandler, object):
+    """
+    Request handler for SOCKS5 requests.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.logger = get_logger("paramiko.socks")
+        super(SOCKS5RequestHandler, self).__init__(*args, **kwargs)
+
+    def handle(self):
+        """
+        Handle incoming SOCKS requests.
+
+        This parses incoming SOCKS requests, establishes a new "direct-tcpip"
+        channel for each request and passes request and response data over the
+        channel.
+        """
+        self._log(
+            DEBUG,
+            "Accepting connection from {}".format(
+                ip_addr_to_str(self.client_address)
+            )
+        )
+
+        m = SOCKSMessage(self.request)
+        version = m.get_char()
+        num_methods = m.get_char()
+
+        if version != SOCKS5_VERSION:
+            self._log(
+                DEBUG,
+                "Request for unsupported SOCKS version {}".format(version)
+            )
+            self._send_response(status=SOCKS5_GENERAL_SERVER_FAILURE)
+            return
+
+        auth_methods = {m.get_char() for _ in range(num_methods)}
+
+        if SOCKS5_NO_AUTH_REQUIRED not in auth_methods:
+            m = SOCKSMessage()
+            m.add_char(SOCKS5_VERSION)
+            m.add_char(SOCKS5_NO_ACCEPTABLE_METHOD)
+            self.request.sendall(m.asbytes())
+            return
+
+        m = SOCKSMessage()
+        m.add_char(SOCKS5_VERSION)
+        m.add_char(SOCKS5_NO_AUTH_REQUIRED)
+        self.request.sendall(m.asbytes())
+
+        m = SOCKSMessage(self.request)
+        version = m.get_char()
+        cmd = m.get_char()
+        rsv = m.get_char()
+        address_type = m.get_char()
+
+        if version != SOCKS5_VERSION:
+            self._send_response(status=SOCKS5_GENERAL_SERVER_FAILURE)
+            return
+
+        if cmd != SOCKS5_CMD_CONNECT:
+            self._send_response(status=SOCKS5_COMMAND_NOT_SUPPORTED)
+            return
+
+        if rsv != SOCKS5_RESERVED:
+            self._send_response(status=SOCKS5_GENERAL_SERVER_FAILURE)
+            return
+
+        if address_type == SOCKS5_ATYP_IPV4:
+            address = socket.inet_ntoa(m.get_bytes(4))
+            port = m.get_short()
+            af_and_addrs = [(socket.AF_INET, (address, port))]
+        elif address_type == SOCKS5_ATYP_DOMAINNAME:
+            hostname = m.get_string()
+            port = m.get_short()
+            af_and_addrs = families_and_addresses(hostname, port)
+        elif address_type == SOCKS5_ATYP_IPV6:
+            address = socket.inet_ntop(socket.AF_INET6, m.get_bytes(16))
+            port = m.get_short()
+            af_and_addrs = [(socket.AF_INET6, (address, port))]
+        else:
+            self._send_response(status=SOCKS5_ADDRESS_TYPE_NOT_SUPPORTED)
+            return
+
+        channel = None
+        try:
+            channel, af, addr = self._open_channel(af_and_addrs)
+        except NoValidConnectionsError as e:
+            self._log(DEBUG, str(e))
+            self._send_response(status=SOCKS5_GENERAL_SERVER_FAILURE)
+            return
+        except socket.error as e:
+            if e.errno == ECONNREFUSED:
+                self._send_response(status=SOCKS5_CONNECTION_REFUSED)
+            elif e.errno == EHOSTUNREACH:
+                self._send_response(status=SOCKS5_HOST_UNREACHABLE)
+            elif e.errno in (ENETDOWN, ENETUNREACH):
+                self._send_response(status=SOCKS5_NETWORK_UNREACHABLE)
+            else:
+                self._send_response(status=SOCKS5_GENERAL_SERVER_FAILURE)
+            return
+        else:
+            self._log(
+                DEBUG,
+                "Established direct-tcpip channel with {}".format(
+                    ip_addr_to_str(addr)
+                )
+            )
+
+            self._send_response(af, addr)
+
+            self._forward_data(self.request, channel)
+        finally:
+            if channel:
+                channel.close()
+
+    def _open_channel(self, fa):
+        """
+        :param fa: list of pairs of address families and addresses to try for
+                   connecting.
+        :raises: socket.error: if a socket error occurred while connecting
+        :raises:
+            `.NoValidConnectionsError` - if there was any other error
+            connecting or establishing a channel
+        """
+
+        errors = {}
+        for af, addr in fa:
+            try:
+                channel = self.server.ssh_transport.open_channel(
+                    "direct-tcpip",
+                    dest_addr=addr,
+                    src_addr=self.request.getpeername()
+                )
+                return channel, af, addr
+            except socket.error as e:
+                # Raise anything that isn't a straight up connection error
+                # (such as a resolution error)
+                if e.errno not in (ECONNREFUSED, EHOSTUNREACH):
+                    raise
+                # Capture anything else so we know how the run looks once
+                # iteration is complete. Retain info about which attempt
+                # this was.
+                errors[addr] = e
+
+        # Make sure we explode usefully if no address family attempts
+        # succeeded. We've no way of knowing which error is the "right"
+        # one, so we construct a hybrid exception containing all the real
+        # ones, of a subclass that client code should still be watching for
+        # (socket.error)
+        if errors:
+            raise NoValidConnectionsError(errors)
+
+    def _send_response(self, af=None, addr=None, status=SOCKS5_SUCCEEDED):
+        """
+        Send a response for a SOCKS connection request.
+
+        :param af:
+        :param tuple(str, int) addr: address tuple
+        :param status:
+        """
+        m = SOCKSMessage()
+        m.add_char(SOCKS5_VERSION)
+        m.add_char(status)
+        m.add_char(SOCKS5_RESERVED)
+
+        if not af or not addr:
+            m.add_char(SOCKS5_ATYP_IPV4)
+            m.add_int(0)
+            m.add_short(0)
+        elif af == socket.AF_INET:
+            addr_unpacked = struct.unpack("!I", socket.inet_aton(addr[0]))[0]
+            m.add_char(SOCKS5_ATYP_IPV4)
+            m.add_int(addr_unpacked)
+            m.add_short(addr[1])
+        else:
+            hi, lo = struct.unpack(
+                "!QQ",
+                socket.inet_pton(socket.AF_INET6, addr[0])
+            )
+            m.add_char(SOCKS5_ATYP_IPV6)
+            m.add_int64(hi)
+            m.add_int64(lo)
+            m.add_short(addr[1])
+
+        self.request.sendall(m.asbytes())
+
+    def _forward_data(self, socks_client, channel):
+        """
+        Pass data between the SOCKS client and the TCP endpoint on the
+        other side of the SSH channel.
+
+        :param .SocketType socks_client: Socket used by the requesting client
+        :param .Channel channel: SSH channel to the destination
+        """
+        buf_size = 4096
+
+        while True:
+            r, _, _ = select.select([socks_client, channel], [], [])
+
+            if socks_client in r:
+                if channel.send(socks_client.recv(buf_size)) <= 0:
+                    break
+
+            if channel in r:
+                if socks_client.send(channel.recv(buf_size)) <= 0:
+                    break
+
+    def _log(self, level, msg, *args):
+        self.logger.log(level, msg, *args)
+
+
+class IPv6EnabledTCPServer(ThreadingTCPServer, object):
+    """
+    Threaded TCP server with support for IPv6 in addition to IPv4.
+    """
+
+    daemon_threads = True
+    allow_reuse_address = True
+    ssh_transport = None
+
+    def __init__(
+        self,
+        server_address,
+        RequestHandlerClass,
+        bind_and_activate=True
+    ):
+        """
+        Custom init method for TCPServer, adding support for IPv6.
+
+        :param tuple(str,int) server_address: tuple with the address to bind
+            the server to
+        :param RequestHandlerClass: class to use for handling requests
+        :param bool bind_and_activate: whether to bind and activate the socket
+            directly after initialization
+        """
+        af_and_addr = next(
+            families_and_addresses(*server_address),
+            None
+        )
+        if af_and_addr:
+            self.address_family, server_address = af_and_addr
+        super(IPv6EnabledTCPServer, self).__init__(
+            server_address,
+            RequestHandlerClass,
+            bind_and_activate
+        )
+
+
+class SOCKSProxy(ClosingContextManager):
+    """
+    Provides a SOCKS5 proxy.
+
+    Instances of this class may be used as context managers.
+    """
+
+    def __init__(self, transport, bind_address="localhost", port=1080):
+        """
+        Start a SOCKS proxy and make it available on a local socket.
+
+        :param .Transport transport: an open `.Transport` which is already
+            authenticated
+        :param str bind_address: the interface to bind to
+        :param int port: the port to bind to. Use 0 if you want to use a
+            random, unused port
+        """
+        self.server = IPv6EnabledTCPServer(
+            (bind_address, port), SOCKS5RequestHandler
+        )
+        self.server.ssh_transport = transport
+        threading.Thread(target=self.server.serve_forever).start()
+
+    def close(self):
+        """
+        Close the SOCKS proxy and its underlying channel.
+        """
+        if self.server:
+            self.server.shutdown()
+            self.server.server_close()
+            self.server = None
+
+    def get_address(self):
+        """
+        Return a tuple with address and port the proxy is bound to.
+
+        :return: tuple containing the address the SOCKS proxy is bound to
+        :rtype: tuple(str, int)
+        """
+        return self.server.server_address
+
+    def __repr__(self):
+        """
+        Return a string representation of the proxy.
+
+        :return: string representation of the proxy
+        :rtype: str
+        """
+        return "<paramiko.SOCKSProxy({})>".format(
+            ip_addr_to_str(self.get_address())
+        )

--- a/sites/docs/api/socks_proxy.rst
+++ b/sites/docs/api/socks_proxy.rst
@@ -1,0 +1,4 @@
+SOCKS proxy
+===========
+
+.. automodule:: paramiko.socks_proxy

--- a/sites/docs/index.rst
+++ b/sites/docs/index.rst
@@ -62,6 +62,7 @@ Other primary functions
     api/proxy
     api/server
     api/sftp
+    api/socks_proxy
 
 
 Miscellany

--- a/tests/test_socks_proxy.py
+++ b/tests/test_socks_proxy.py
@@ -1,0 +1,401 @@
+import socket
+import struct
+
+import mock
+import pytest
+
+from paramiko.py3compat import BytesIO
+from paramiko.socks_proxy import IPv6EnabledTCPServer, SOCKSMessage, SOCKSProxy
+
+
+AUTH_METHOD_REQUEST = b"\x05\x01\x00"
+CMD_REQUEST_IPV4 = b"\x05\x01\x00\x01\x7f\x00\x00\x01\x1f@"
+CMD_REQUEST_DOMAIN = b"\x05\x01\x00\x03\x09\x6C\x6F\x63\x61\x6C\x68\x6F\x73\x74\x1f\x40"  # noqa
+CMD_REQUEST_IPV6 = b"\x05\x01\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x1f@"  # noqa
+
+AUTH_METHOD_RESPONSE = b"\x05\x00"
+CMD_RESPONSE_IPV4 = b"\x05\x00\x00\x01\x7f\x00\x00\x01\x1f@"
+CMD_RESPONSE_IPV6 = b"\x05\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x1f@"  # noqa
+
+LOCALHOST_IPV4 = struct.unpack("!I", socket.inet_aton("127.0.0.1"))[0]
+LOCALHOST_IPV6_HI, LOCALHOST_IPV6_LO = struct.unpack(
+    "!QQ",
+    socket.inet_pton(socket.AF_INET6, "::1")
+)
+
+
+class TestSOCKSMessage:
+    def test_encode(self):
+        # auth method selection request
+        msg = SOCKSMessage()
+        msg.add_char(5)
+        msg.add_char(1)
+        msg.add_char(0)
+        assert msg.asbytes() == AUTH_METHOD_REQUEST
+
+        # auth method selection response
+        msg = SOCKSMessage()
+        msg.add_char(5)
+        msg.add_char(0)
+        assert msg.asbytes() == AUTH_METHOD_RESPONSE
+
+        # SOCKS CONNECT request for IPv4 destination
+        msg = SOCKSMessage()
+        msg.add_char(5)
+        msg.add_char(1)
+        msg.add_char(0)
+        msg.add_char(1)
+        msg.add_int(LOCALHOST_IPV4)
+        msg.add_short(8000)
+        assert msg.asbytes() == CMD_REQUEST_IPV4
+
+        # SOCKS response for IPv4 destination
+        msg = SOCKSMessage()
+        msg.add_char(5)
+        msg.add_char(0)
+        msg.add_char(0)
+        msg.add_char(1)
+        msg.add_int(LOCALHOST_IPV4)
+        msg.add_short(8000)
+        assert msg.asbytes() == CMD_RESPONSE_IPV4
+
+        # SOCKS CONNECT request for domain destination
+        msg = SOCKSMessage()
+        msg.add_char(5)
+        msg.add_char(1)
+        msg.add_char(0)
+        msg.add_char(3)
+        msg.add_string("localhost")
+        msg.add_short(8000)
+        assert msg.asbytes() == CMD_REQUEST_DOMAIN
+
+        # SOCKS CONNECT request for IPv6 destination
+        msg = SOCKSMessage()
+        msg.add_char(5)
+        msg.add_char(1)
+        msg.add_char(0)
+        msg.add_char(4)
+        msg.add_int64(LOCALHOST_IPV6_HI)
+        msg.add_int64(LOCALHOST_IPV6_LO)
+        msg.add_short(8000)
+        assert msg.asbytes() == CMD_REQUEST_IPV6
+
+        # SOCKS response for IPv6 destination
+        msg = SOCKSMessage()
+        msg.add_char(5)
+        msg.add_char(0)
+        msg.add_char(0)
+        msg.add_char(4)
+        msg.add_int64(LOCALHOST_IPV6_HI)
+        msg.add_int64(LOCALHOST_IPV6_LO)
+        msg.add_short(8000)
+        assert msg.asbytes() == CMD_RESPONSE_IPV6
+
+    def test_decode(self):
+        # auth method selection request
+        socket_mock = mock.Mock()
+        socket_mock.makefile.return_value = BytesIO(AUTH_METHOD_REQUEST)
+        msg = SOCKSMessage(socket_mock)
+        assert msg.get_char() == 5
+        assert msg.get_char() == 1
+        assert msg.get_char() == 0
+        assert msg.get_bytes(1) == b""
+
+        # auth method selection response
+        socket_mock = mock.Mock()
+        socket_mock.makefile.return_value = BytesIO(AUTH_METHOD_RESPONSE)
+        msg = SOCKSMessage(socket_mock)
+        assert msg.get_char() == 5
+        assert msg.get_char() == 0
+        assert msg.get_bytes(1) == b""
+
+        # SOCKS CONNECT request for IPv4 destination
+        socket_mock = mock.Mock()
+        socket_mock.makefile.return_value = BytesIO(CMD_REQUEST_IPV4)
+        msg = SOCKSMessage(socket_mock)
+        assert msg.get_char() == 5
+        assert msg.get_char() == 1
+        assert msg.get_char() == 0
+        assert msg.get_char() == 1
+        assert msg.get_int() == LOCALHOST_IPV4
+        assert msg.get_short() == 8000
+        assert msg.get_bytes(1) == b""
+
+        # SOCKS response for IPv4 destination
+        socket_mock = mock.Mock()
+        socket_mock.makefile.return_value = BytesIO(CMD_RESPONSE_IPV4)
+        msg = SOCKSMessage(socket_mock)
+        assert msg.get_char() == 5
+        assert msg.get_char() == 0
+        assert msg.get_char() == 0
+        assert msg.get_char() == 1
+        assert msg.get_int() == LOCALHOST_IPV4
+        assert msg.get_short() == 8000
+        assert msg.get_bytes(1) == b""
+
+        # SOCKS CONNECT request for domain destination
+        socket_mock = mock.Mock()
+        socket_mock.makefile.return_value = BytesIO(CMD_REQUEST_DOMAIN)
+        msg = SOCKSMessage(socket_mock)
+        assert msg.get_char() == 5
+        assert msg.get_char() == 1
+        assert msg.get_char() == 0
+        assert msg.get_char() == 3
+        assert msg.get_string() == "localhost"
+        assert msg.get_short() == 8000
+        assert msg.get_bytes(1) == b""
+
+        # SOCKS CONNECT request for IPv6 destination
+        socket_mock = mock.Mock()
+        socket_mock.makefile.return_value = BytesIO(CMD_REQUEST_IPV6)
+        msg = SOCKSMessage(socket_mock)
+        assert msg.get_char() == 5
+        assert msg.get_char() == 1
+        assert msg.get_char() == 0
+        assert msg.get_char() == 4
+        assert msg.get_int64() == LOCALHOST_IPV6_HI
+        assert msg.get_int64() == LOCALHOST_IPV6_LO
+        assert msg.get_short() == 8000
+        assert msg.get_bytes(1) == b""
+
+        # SOCKS response for IPv6 destination
+        socket_mock = mock.Mock()
+        socket_mock.makefile.return_value = BytesIO(CMD_RESPONSE_IPV6)
+        msg = SOCKSMessage(socket_mock)
+        assert msg.get_char() == 5
+        assert msg.get_char() == 0
+        assert msg.get_char() == 0
+        assert msg.get_char() == 4
+        assert msg.get_int64() == LOCALHOST_IPV6_HI
+        assert msg.get_int64() == LOCALHOST_IPV6_LO
+        assert msg.get_short() == 8000
+        assert msg.get_bytes(1) == b""
+
+
+class TestIPv6EnabledTCPServer:
+    @mock.patch("paramiko.socks_proxy.ThreadingTCPServer.__init__")
+    def test_ipv4(self, tcp_server_mock):
+        """
+        Test server is initialized for correct AF when given an IPv4 address.
+        """
+        request_handler_mock = mock.Mock()
+        server = IPv6EnabledTCPServer(
+            ("127.0.0.1", 1234), request_handler_mock
+        )
+        assert server.address_family == socket.AF_INET
+        tcp_server_mock.assert_called_once_with(
+            ("127.0.0.1", 1234), request_handler_mock, True
+        )
+
+    @mock.patch("paramiko.socks_proxy.ThreadingTCPServer.__init__")
+    def test_ipv6(self, tcp_server_mock):
+        """
+        Test server is initialized for correct AF when given an IPv6 address.
+        """
+        request_handler_mock = mock.Mock()
+        server = IPv6EnabledTCPServer(
+            ("::1", 1234), request_handler_mock
+        )
+        assert server.address_family == socket.AF_INET6
+        tcp_server_mock.assert_called_once_with(
+            ("::1", 1234, 0, 0), request_handler_mock, True
+        )
+
+    @mock.patch("paramiko.socks_proxy.ThreadingTCPServer.__init__")
+    @mock.patch("paramiko.socks_proxy.families_and_addresses")
+    def test_host(self, faa_mock, tcp_server_mock):
+        """
+        Test server is initialized for correct AF when given a host name.
+        """
+        faa_mock.return_value = iter([(
+            socket.AF_INET, ("127.0.0.1", 1234)
+        )])
+        request_handler_mock = mock.Mock()
+        server = IPv6EnabledTCPServer(
+            ("dummy.ipv4.test", 1234), request_handler_mock
+        )
+        assert server.address_family == socket.AF_INET
+        tcp_server_mock.assert_called_once_with(
+            ("127.0.0.1", 1234), request_handler_mock, True
+        )
+
+        tcp_server_mock.reset_mock()
+
+        faa_mock.return_value = iter([(
+            socket.AF_INET6, ("::1", 1234)
+        )])
+        request_handler_mock = mock.Mock()
+        server = IPv6EnabledTCPServer(
+            ("dummy.ipv6.test", 1234), request_handler_mock
+        )
+        assert server.address_family == socket.AF_INET6
+        tcp_server_mock.assert_called_once_with(
+            ("::1", 1234), request_handler_mock, True
+        )
+
+
+class TestSOCKSProxy:
+    @mock.patch("paramiko.socks_proxy.IPv6EnabledTCPServer")
+    def test_socks_proxy(self, tcp_server_mock):
+        """
+        Test correct initialization of SOCKSProxy.
+        """
+        tcp_server_obj_mock = tcp_server_mock.return_value
+        transport_mock = mock.Mock()
+
+        socks_proxy = SOCKSProxy(transport_mock)
+
+        assert socks_proxy.server == tcp_server_obj_mock
+        assert socks_proxy.server.ssh_transport == transport_mock
+        assert socks_proxy.get_address() == tcp_server_obj_mock.server_address
+
+        socks_proxy.close()
+
+        assert socks_proxy.server is None
+        tcp_server_obj_mock.shutdown.assert_called_once_with()
+        tcp_server_obj_mock.server_close.assert_called_once_with()
+
+    @pytest.mark.parametrize("msg, resp", [
+        pytest.param(
+            b"\x08\x01\x00",
+            b'\x05\x01\x00\x01\x00\x00\x00\x00\x00\x00',
+            id="invalid version"
+        ),
+        pytest.param(
+            b"\x05\x01\x01",
+            b"\x05\xff",
+            id="missing support for no auth 1"
+        ),
+        pytest.param(
+            b"\x05\x04\x01\x02\x03\x04",
+            b"\x05\xff",
+            id="missing support for no auth 2"
+        )
+    ])
+    def test_invalid_auth_method_message(self, msg, resp):
+        """
+        Test that the SOCKS proxy returns proper responses for invalid
+        auth method requests and closes the connection afterwards.
+        """
+        transport = mock.Mock()
+
+        with SOCKSProxy(transport, bind_address="127.0.0.1", port=0) \
+                as socks_proxy:
+            listen_addr = socks_proxy.get_address()
+
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.connect(listen_addr)
+            s.sendall(msg)
+            assert s.recv(32) == resp
+            assert s.recv(32) == b""
+            s.close()
+
+        transport.open_channel.assert_not_called()
+
+    @pytest.mark.parametrize("msg, resp", [
+        pytest.param(
+            b"\x08\x01\x00\x01\x7f\x00\x00\x01\x1f@",
+            b'\x05\x01\x00\x01\x00\x00\x00\x00\x00\x00',
+            id="invalid version"
+        ),
+        pytest.param(
+            b"\x05\x02\x00\x01\x7f\x00\x00\x01\x1f@",
+            b'\x05\x07\x00\x01\x00\x00\x00\x00\x00\x00',
+            id="unsupported command 1"
+        ),
+        pytest.param(
+            b"\x05\x03\x00\x01\x7f\x00\x00\x01\x1f@",
+            b'\x05\x07\x00\x01\x00\x00\x00\x00\x00\x00',
+            id="unsupported command 2"
+        ),
+        pytest.param(
+            b"\x05\x01\x01\x01\x7f\x00\x00\x01\x1f@",
+            b'\x05\x01\x00\x01\x00\x00\x00\x00\x00\x00',
+            id="unsupported reserved byte"
+        ),
+        pytest.param(
+            b"\x05\x01\x00\x02\x7f\x00\x00\x01\x1f@",
+            b'\x05\x08\x00\x01\x00\x00\x00\x00\x00\x00',
+            id="unsupported address type 1"
+        ),
+        pytest.param(
+            b"\x05\x01\x00\x05\x7f\x00\x00\x01\x1f@",
+            b'\x05\x08\x00\x01\x00\x00\x00\x00\x00\x00',
+            id="unsupported address type 2"
+        )
+    ])
+    def test_invalid_socks_message(self, msg, resp):
+        """
+        Test that the SOCKS proxy returns proper responses for invalid
+        socks requests and closes the connection afterwards.
+        """
+        transport = mock.Mock()
+
+        with SOCKSProxy(transport, bind_address="127.0.0.1", port=0) \
+                as socks_proxy:
+            listen_addr = socks_proxy.get_address()
+
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.connect(listen_addr)
+            s.sendall(AUTH_METHOD_REQUEST)
+            assert s.recv(32) == AUTH_METHOD_RESPONSE
+            s.sendall(msg)
+            assert s.recv(32) == resp
+            assert s.recv(32) == b""
+            s.close()
+
+        transport.open_channel.assert_not_called()
+
+    def test_socks_conn_ipv4(self):
+        """
+        Test a successful SOCKS connection to an IPv4 enabled host.
+        """
+        channel = mock.Mock()
+        transport = mock.Mock()
+        transport.open_channel.return_value = channel
+
+        with SOCKSProxy(transport, bind_address="127.0.0.1", port=0) \
+                as socks_proxy:
+            listen_addr = socks_proxy.get_address()
+
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.connect(listen_addr)
+            conn_addr = s.getsockname()
+            s.send(AUTH_METHOD_REQUEST)
+            assert s.recv(32) == AUTH_METHOD_RESPONSE
+            s.send(CMD_REQUEST_IPV4)
+            assert s.recv(32) == CMD_RESPONSE_IPV4
+            s.close()
+
+            transport.open_channel.assert_called_once_with(
+                "direct-tcpip",
+                dest_addr=("127.0.0.1", 8000),
+                src_addr=conn_addr
+            )
+
+    def test_socks_conn_ipv6(self):
+        """
+        Test a successful SOCKS connection to an IPv6 enabled host.
+        """
+        channel = mock.Mock()
+        transport = mock.Mock()
+        transport.open_channel.return_value = channel
+
+        with SOCKSProxy(transport, bind_address="::1", port=0) \
+                as socks_proxy:
+            listen_addr = socks_proxy.get_address()
+
+            s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+            s.connect(listen_addr)
+            conn_addr = s.getsockname()
+            s.send(AUTH_METHOD_REQUEST)
+            assert s.recv(32) == AUTH_METHOD_RESPONSE
+            s.send(CMD_REQUEST_IPV6)
+            assert s.recv(32) == CMD_RESPONSE_IPV6
+            s.close()
+
+            transport.open_channel.assert_called_once_with(
+                "direct-tcpip",
+                dest_addr=("::1", 8000),
+                src_addr=conn_addr
+            )


### PR DESCRIPTION
This adds SOCKS5 proxy functionality to paramiko as requested and
discussed in #955.

The functionality is nearly identical feature-wise to the one in
OpenSSH, with the notable exception that it only support SOCKS5 and not
SOCKS4. The reasoning behind it being that SOCKS4 was already
superseded by SOCKS5 25 (!) years ago and that SOCKS4 doesn't even
support tunneling requests to hosts using IPv6.

Common implementation details with OpenSSH include:
- supports starting multiple SOCKS5 servers bound to different
  local addresses for a single SSH connection
- exposes the SOCKS5 servers as local IPv4 or IPv6 stream sockets
- only supports a subset of SOCKS5, in particular tunneling of
  UDP-traffic, authentication and incoming connections aren't supported
- supports tunneling connections to IPv4 and IPv6 addresses, as well as
  connections to host names, by resolving them on the SOCKS server side
- 1:1 mapping between SOCKS5 requests and direct-tcpip channels

The implementation works with all Python versions supported by paramiko.
It has so far only been tested with Linux, but should work on other
operating systems as well. The implementation has been used productively
for several weeks so far, using `requests` with its SOCKS5 proxy
functionality as SOCKS5 client, and works without any problems.

If there are changes needed, before merging this PR, please just let me
know and I'd be happy to change it.