### PR TITLE
Support __bytes__() method for asbytes() argument

### DIFF
--- a/paramiko/common.py
+++ b/paramiko/common.py
@@ -205,6 +205,13 @@ def asbytes(s):
             # asbytes() method, which many of our internal classes implement.
             return s.asbytes()
         except AttributeError:
+            # If object have implemented __bytes__() method, we can use it for
+            # conversion. See "Python data model reference".
+            # NOTE: We MUST check method support before calling because bytes(s)
+            # can return a zero-filled bytes object of a length `s` if `s` is
+            # one of integer types (python int() or numpy.uint() e.g.).
+            if hasattr(s, "__bytes__"):
+                return bytes(s)
             # Finally, just do nothing & assume this object is sufficiently
             # byte-y or buffer-y that everything will work out (or that callers
             # are capable of handling whatever it is.)

--- a/paramiko/sftp_client.py
+++ b/paramiko/sftp_client.py
@@ -27,7 +27,7 @@ import weakref
 from paramiko import util
 from paramiko.channel import Channel
 from paramiko.message import Message
-from paramiko.common import INFO, DEBUG, o777
+from paramiko.common import asbytes, INFO, DEBUG, o777
 from paramiko.py3compat import b, u, long
 from paramiko.sftp import (
     BaseSFTP,
@@ -522,7 +522,7 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
         """
         dest = self._adjust_cwd(dest)
         self._log(DEBUG, "symlink({!r}, {!r})".format(source, dest))
-        source = b(source)
+        source = asbytes(source)
         self._request(CMD_SYMLINK, source, dest)
 
     def chmod(self, path, mode):
@@ -659,7 +659,7 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
         if not stat.S_ISDIR(self.stat(path).st_mode):
             code = errno.ENOTDIR
             raise SFTPError(code, "{}: {}".format(os.strerror(code), path))
-        self._cwd = b(self.normalize(path))
+        self._cwd = asbytes(self.normalize(path))
 
     def getcwd(self):
         """
@@ -911,7 +911,7 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
         Return an adjusted path if we're emulating a "current working
         directory" for the server.
         """
-        path = b(path)
+        path = asbytes(path)
         if self._cwd is None:
             return path
         if len(path) and path[0:1] == b_slash:


### PR DESCRIPTION
This is fix for #1853 

Python pathlib supports conversion to bytes via call bytes(pathlibobject) (used internal __bytes__() method). So I added support for __bytes__() in asbytes() function from common.py. Then use asbytes() in sftp_client.py similarly to how this function is used elsewhere.

Outside of #1853 this patch allows asbytes() convert any objects which supports native conversion to bytes.