### PR TITLE
refactor: use absolute imports

### DIFF
--- a/paramiko/agent.py
+++ b/paramiko/agent.py
@@ -367,7 +367,7 @@ class Agent(AgentSSH):
                 # probably a dangling env var: the ssh agent is gone
                 return
         elif sys.platform == "win32":
-            from . import win_pageant
+            from paramiko import win_pageant
 
             if win_pageant.can_talk_to_agent():
                 conn = win_pageant.PageantConnection()

--- a/paramiko/config.py
+++ b/paramiko/config.py
@@ -29,7 +29,7 @@ import shlex
 import socket
 from functools import partial
 
-from .py3compat import StringIO
+from paramiko.py3compat import StringIO
 
 invoke, invoke_import_error = None, None
 try:
@@ -37,7 +37,7 @@ try:
 except ImportError as e:
     invoke_import_error = e
 
-from .ssh_exception import CouldNotCanonicalize, ConfigParseError
+from paramiko.ssh_exception import CouldNotCanonicalize, ConfigParseError
 
 
 SSH_PORT = 22

--- a/paramiko/win_pageant.py
+++ b/paramiko/win_pageant.py
@@ -33,7 +33,7 @@ try:
 except ImportError:
     import thread  # Python 2.5-2.7
 
-from . import _winapi
+from paramiko import _winapi
 
 
 _AGENT_COPYDATA_ID = 0x804e50ba


### PR DESCRIPTION
This PR is intended to help improve the security of applications using paramiko by using explicit paths.

Relative paths can potentially be exploited my malicious libraries. This coupled with the potential use of sudo capabilities can allow for privilege escalation.

This is due to the module cache being world writable within CPython.