### PR TITLE
add sphinx setuptools integration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,3 +26,6 @@ looponfailroots = tests paramiko
 filterwarnings =
     ignore::DeprecationWarning:pkg_resources
     ignore::cryptography.utils.CryptographyDeprecationWarning
+
+[build_sphinx]
+source-dir = sites/docs


### PR DESCRIPTION
This setup.cfg file entry allows build documentation by
`python setup.py build_sphinx`.

Signed-off-by: Tomasz Kłoczko <kloczek@github.com>