### PR TITLE
Use poll instead of select to support large file descriptor numbers

### DIFF
--- a/paramiko/sftp.py
+++ b/paramiko/sftp.py
@@ -176,11 +176,14 @@ class BaseSFTP(object):
                 # if the socket is closed.  (for some reason, recv() won't ever
                 # return or raise an exception, but calling select on a closed
                 # socket will.)
+                poller = select.poll()
+                poller.register(self.sock, select.POLLIN)
                 while True:
-                    read, write, err = select.select([self.sock], [], [], 0.1)
+                    read = poller.poll(0.1)
                     if len(read) > 0:
                         x = self.sock.recv(n)
                         break
+                poller.unregister(self.sock)
             else:
                 x = self.sock.recv(n)
 


### PR DESCRIPTION
Processes that have a large number of file descriptors or even a few with large numbers will fail using the library in the current state due to file descriptors larger than 1024 which select can't handle. ref: https://man7.org/linux/man-pages/man2/select.2.html (search for FD_SETSIZE)