### PR TITLE
CircleCI: Add Python 3.10 to the testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ workflows:
           requires: ["Test 3.6 (w/ coverage, latest crypto)"]
           matrix:
             parameters:
-              version: ["3.7", "3.8", "3.9"]
+              version: ["3.7", "3.8", "3.9", "3.10"]
       # Test doc building if main test suite passed (no real reason to spend
       # all those credits if the main tests would also fail...)
       - orb/docs:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,8 +2,8 @@
 invoke==1.6.0
 invocations==2.3.0
 pytest==4.4.2; python_version < '3.10'
-# pytest-relaxed is incompatible with Pytest 6 (current is 6.2.5)
-pytest==5.4.3; python_version >= '3.10'
+# pytest-relaxed is incompatible with Pytest 5 or 6 (current is 6.2.5)
+pytest==4.6.11; python_version >= '3.10'
 pytest-relaxed==1.1.5
 # pytest-xdist for test dir watching and the inv guard task
 pytest-xdist==1.28.0; python_version < '3.10'

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,8 +6,7 @@ pytest==4.4.2; python_version < '3.10'
 pytest==4.6.11; python_version >= '3.10'
 pytest-relaxed==1.1.5
 # pytest-xdist for test dir watching and the inv guard task
-pytest-xdist==1.28.0; python_version < '3.10'
-pytest-xdist==2.4.0; python_version >= '3.10'
+pytest-xdist==1.28.0
 mock==2.0.0
 # Linting!
 flake8==3.8.3

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,10 +1,12 @@
 # Invocations for common project tasks
 invoke==1.6.0
 invocations==2.3.0
-pytest==4.4.2
+pytest==4.4.2; python_version < '3.10'
+pytest==6.2.5; python_version >= '3.10'
 pytest-relaxed==1.1.5
 # pytest-xdist for test dir watching and the inv guard task
-pytest-xdist==1.28.0
+pytest-xdist==1.28.0; python_version < '3.10'
+pytest-xdist==2.4.0; python_version >= '3.10'
 mock==2.0.0
 # Linting!
 flake8==3.8.3

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,7 +7,8 @@ pytest==6.2.5; python_version >= '3.10'
 pytest-relaxed==1.1.5; python_version < '3.10'
 # pytest-xdist for test dir watching and the inv guard task
 pytest-xdist==1.28.0; python_version < '3.10'
-pytest-xdist==2.4.0; python_version >= '3.10'mock==2.0.0
+pytest-xdist==2.4.0; python_version >= '3.10'
+mock==2.0.0
 # Linting!
 flake8==3.8.3
 # Formatting!

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,12 +2,12 @@
 invoke==1.6.0
 invocations==2.3.0
 pytest==4.4.2; python_version < '3.10'
+pytest==6.2.5; python_version >= '3.10'
 # pytest-relaxed is incompatible with Pytest 5 or 6 (current is 6.2.5)
-pytest==4.6.11; python_version >= '3.10'
-pytest-relaxed==1.1.5
+pytest-relaxed==1.1.5; python_version < '3.10'
 # pytest-xdist for test dir watching and the inv guard task
-pytest-xdist==1.28.0
-mock==2.0.0
+pytest-xdist==1.28.0; python_version < '3.10'
+pytest-xdist==2.4.0; python_version >= '3.10'mock==2.0.0
 # Linting!
 flake8==3.8.3
 # Formatting!

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,7 +2,8 @@
 invoke==1.6.0
 invocations==2.3.0
 pytest==4.4.2; python_version < '3.10'
-pytest==6.2.5; python_version >= '3.10'
+# pytest-relaxed is incompatible with Pytest 6 (current is 6.2.5)
+pytest==5.4.3; python_version >= '3.10'
 pytest-relaxed==1.1.5
 # pytest-xdist for test dir watching and the inv guard task
 pytest-xdist==1.28.0; python_version < '3.10'


### PR DESCRIPTION
Related to #1870

[Collecting pytest==4.4.2](https://app.circleci.com/pipelines/github/paramiko/paramiko/76/workflows/6e412a2d-29af-4adf-b7a5-69ac034d8b70/jobs/224?invite=true#step-104-9)