### PR TITLE
Support non-utf8 path in SFTPClient

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -549,13 +549,15 @@ class SSHClient(ClosingContextManager):
         chan.invoke_shell()
         return chan
 
-    def open_sftp(self):
+    def open_sftp(self, encoding="utf8"):
         """
         Open an SFTP session on the SSH server.
 
+        :param str encoding: which text encoding used to process strings
+
         :return: a new `.SFTPClient` session object
         """
-        return self._transport.open_sftp_client()
+        return self._transport.open_sftp_client(encoding=encoding)
 
     def get_transport(self):
         """

--- a/paramiko/message.py
+++ b/paramiko/message.py
@@ -40,18 +40,22 @@ class Message(object):
 
     big_int = long(0xff000000)
 
-    def __init__(self, content=None):
+    def __init__(self, content=None, encoding="utf8"):
         """
         Create a new SSH2 message.
 
         :param str content:
             the byte stream to use as the message content (passed in only when
             decomposing a message).
+        :param str encoding:
+            which text encoding are used to decode string from bytes
         """
         if content is not None:
             self.packet = BytesIO(content)
         else:
             self.packet = BytesIO()
+
+        self.text_encoding = encoding
 
     def __str__(self):
         """
@@ -175,7 +179,7 @@ class Message(object):
         """
         Fetch a Unicode string from the stream.
         """
-        return u(self.get_string())
+        return u(self.get_string(), self.text_encoding)
 
     def get_binary(self):
         """

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -1084,17 +1084,19 @@ class Transport(threading.Thread, ClosingContextManager):
         self._tcp_handler = None
         self.global_request("cancel-tcpip-forward", (address, port), wait=True)
 
-    def open_sftp_client(self):
+    def open_sftp_client(self, encoding="utf8"):
         """
         Create an SFTP client channel from an open transport.  On success, an
         SFTP session will be opened with the remote host, and a new
         `.SFTPClient` object will be returned.
 
+        :param str encoding: which text encoding used to process strings
+
         :return:
             a new `.SFTPClient` referring to an sftp session (channel) across
             this transport
         """
-        return SFTPClient.from_transport(self)
+        return SFTPClient.from_transport(self, encoding=encoding)
 
     def send_ignore(self, byte_count=None):
         """


### PR DESCRIPTION
This PR add ability to customize text encoding to use in SFTP client which can solve issue #546

The only problem is that repeating `encoding='utf8'` everywhere is not elegant at all. Do some one have better idea?

I think it could be solved by giving default value `None` to `encoding` and assign default value it in `py3compat.{u,b}`