### PR TITLE
Allow user to specify file mode to use with "log_to_file()" function

### DIFF
--- a/paramiko/util.py
+++ b/paramiko/util.py
@@ -245,14 +245,21 @@ def get_thread_id():
         return ret
 
 
-def log_to_file(filename, level=DEBUG):
-    """send paramiko logs to a logfile,
-    if they're not already going somewhere"""
+def log_to_file(filename, level=DEBUG, file_mode="a"):
+    """
+    send paramiko logs to a logfile, if they're not already going somewhere.
+
+    :param file_mode: File mode to open the provided file path with.
+                      Defaults to "a". In some scenarios (e.g. when file mode
+                      is /dev/{stdout,stderr} you may want to use "w" otherwise
+                      "Illegal seek" error will be thrown when trying to open
+                      the file).
+    """
     logger = logging.getLogger("paramiko")
     if len(logger.handlers) > 0:
         return
     logger.setLevel(level)
-    f = open(filename, "a")
+    f = open(filename, file_mode)
     handler = logging.StreamHandler(f)
     frm = "%(levelname)-.3s [%(asctime)s.%(msecs)03d] thr=%(_threadid)-3d"
     frm += " %(name)s: %(message)s"


### PR DESCRIPTION
This pull request allows user to specify file mode to use when opening a provided file path in ``log_to_file()`` function. It defaults to ``a`` so the change is fully backward compatible.

## Background, Context

On some Linux distros, trying to open ``/dev/{stdout,stderr}`` in append mode will throw "Illegal seek" exception such as the one shown below:

```bash
Traceback (most recent call last):
  File "test_gce_timeout.py", line 2, in <module>
    from libcloud.storage.providers import Provider, get_driver
  File "/home/kami/w/libcloud/libcloud/libcloud/__init__.py", line 130, in <module>
    _init_once()
  File "/home/kami/w/libcloud/libcloud/libcloud/__init__.py", line 115, in _init_once
    raise e
  File "/home/kami/w/libcloud/libcloud/libcloud/__init__.py", line 109, in _init_once
    paramiko.util.log_to_file(filename=path, level=logging.DEBUG)
  File "/home/kami/.virtualenvs/libcloud-py3/lib/python3.6/site-packages/paramiko/util.py", line 255, in log_to_file
    f = open(filename, "a")
OSError: [Errno 29] Illegal seek
```

Solution / workaround is to open file in a write mode aka ``w``.

Here is how we currently handle this in Libcloud - https://github.com/apache/libcloud/blob/trunk/libcloud/__init__.py#L87, https://github.com/apache/libcloud/blob/trunk/libcloud/__init__.py#L109.