### PR TITLE
SHA2 with ssh agent

### DIFF
--- a/paramiko/agent.py
+++ b/paramiko/agent.py
@@ -66,8 +66,8 @@ class AgentSSH(object):
             a tuple of `.AgentKey` objects representing keys available on the
             SSH agent
         """
-        rsa_prefs = tuple(filter(lambda sha: sha in SHA_MAP, sec_opts.key_types))
-        return tuple(map(lambda key: AgentKey(self, key, rsa_prefs), self._keys))
+        rsa_prefs = tuple((sha for sha in sec_opts if sha in SHA_MAP))
+        return tuple((AgentKey(self, key, rsa_prefs) for key in self._keys))
 
     def _connect(self, conn):
         self._conn = conn
@@ -406,7 +406,7 @@ class AgentKey(PKey):
         self.blob = blob
         self.public_blob = None
         self.name = Message(blob).get_text()
-        if(self.name in rsa_prefs):
+        if self.name in rsa_prefs:
             self.name = rsa_prefs[0]
 
     def asbytes(self):

--- a/paramiko/agent.py
+++ b/paramiko/agent.py
@@ -67,8 +67,7 @@ class AgentSSH(object):
             SSH agent
         """
         rsa_prefs = tuple(
-            lambda sha: sha in SHA_MAP,
-            sec_opts.key_types
+            filter(lambda sha: sha in SHA_MAP, sec_opts.key_types)
         )
         return tuple((AgentKey(self, key, rsa_prefs) for key in self._keys))
 

--- a/paramiko/agent.py
+++ b/paramiko/agent.py
@@ -66,7 +66,10 @@ class AgentSSH(object):
             a tuple of `.AgentKey` objects representing keys available on the
             SSH agent
         """
-        rsa_prefs = tuple((sha for sha in sec_opts if sha in SHA_MAP))
+        rsa_prefs = tuple(
+            lambda sha: sha in SHA_MAP,
+            sec_opts.key_types
+        )
         return tuple((AgentKey(self, key, rsa_prefs) for key in self._keys))
 
     def _connect(self, conn):

--- a/paramiko/agent.py
+++ b/paramiko/agent.py
@@ -48,8 +48,9 @@ SSH_AGENT_RSA_SHA2_512 = 4
 SHA_MAP = {
     "ssh-rsa": 0,
     "rsa-sha2-256": SSH_AGENT_RSA_SHA2_256,
-    "rsa-sha2-512": SSH_AGENT_RSA_SHA2_512
+    "rsa-sha2-512": SSH_AGENT_RSA_SHA2_512,
 }
+
 
 class AgentSSH(object):
     def __init__(self):

--- a/paramiko/agent.py
+++ b/paramiko/agent.py
@@ -406,7 +406,6 @@ class AgentKey(PKey):
         self.blob = blob
         self.public_blob = None
         self.name = Message(blob).get_text()
-        # not sure how to better "negotiate": https://datatracker.ietf.org/doc/html/draft-ietf-curdle-rsa-sha2-12#section-3.3
         if(self.name in rsa_prefs):
             self.name = rsa_prefs[0]
 
@@ -424,8 +423,6 @@ class AgentKey(PKey):
         msg.add_byte(cSSH2_AGENTC_SIGN_REQUEST)
         msg.add_string(self.blob)
         msg.add_string(data)
-        # https://tools.ietf.org/id/draft-miller-ssh-agent-01.html#sigflagnum
-        # choose sha strategy based on name; sha1 = 0, sha256 = 2, sha512 = 4, bit 1 is reserved
         msg.add_int(SHA_MAP[self.name])
         ptype, result = self.agent._send_message(msg)
         if ptype != SSH2_AGENT_SIGN_RESPONSE:

--- a/paramiko/agent.py
+++ b/paramiko/agent.py
@@ -42,6 +42,14 @@ SSH2_AGENT_IDENTITIES_ANSWER = 12
 cSSH2_AGENTC_SIGN_REQUEST = byte_chr(13)
 SSH2_AGENT_SIGN_RESPONSE = 14
 
+SSH_AGENT_RSA_SHA2_256 = 2
+SSH_AGENT_RSA_SHA2_512 = 4
+
+SHA_MAP = {
+    "ssh-rsa": 0,
+    "rsa-sha2-256": SSH_AGENT_RSA_SHA2_256,
+    "rsa-sha2-512": SSH_AGENT_RSA_SHA2_512
+}
 
 class AgentSSH(object):
     def __init__(self):

--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -692,7 +692,7 @@ class SSHClient(ClosingContextManager):
             if self._agent is None:
                 self._agent = Agent()
 
-            for key in self._agent.get_keys(self._transport.get_security_options()): # Generate keys based on sha preference in this connection
+            for key in self._agent.get_keys(self._transport.get_security_options()):
                 try:
                     id_ = hexlify(key.get_fingerprint())
                     self._log(DEBUG, "Trying SSH agent key {}".format(id_))

--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -692,7 +692,7 @@ class SSHClient(ClosingContextManager):
             if self._agent is None:
                 self._agent = Agent()
 
-            for key in self._agent.get_keys():
+            for key in self._agent.get_keys(self._transport.get_security_options()): # Generate keys based on sha preference in this connection
                 try:
                     id_ = hexlify(key.get_fingerprint())
                     self._log(DEBUG, "Trying SSH agent key {}".format(id_))

--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -692,7 +692,8 @@ class SSHClient(ClosingContextManager):
             if self._agent is None:
                 self._agent = Agent()
 
-            for key in self._agent.get_keys(self._transport.get_security_options()):
+            sec_opts = self._transport.get_security_options()
+            for key in self._agent.get_keys(sec_opts):
                 try:
                     id_ = hexlify(key.get_fingerprint())
                     self._log(DEBUG, "Trying SSH agent key {}".format(id_))


### PR DESCRIPTION
I've been trying to get an ssh connection working with this project to my server. At first I thought just the rsa-sha2 algorithms were missing. Trying out https://github.com/paramiko/paramiko/pull/1643 still did not work as I was using an ssh-agent.

This PR will dynamically assign the SHA algorithm as specified in preferred keys. It won't effectively change anything until the `_preferred_keys` include those rsa-sha2 algorithms (defined in https://github.com/paramiko/paramiko/pull/1643).
While opening this PR I also noticed https://github.com/paramiko/paramiko/pull/1644 which seems to be a partial implementation that just changes the flag, might be good to consider it for ongoing refinement.

This is the first time I'm doing python library programming and contributing to a python project. I know very little about pip, running tests and probably a bunch of other stuff, so don't hesitate to give me feedback :).