### PR TITLE
Make changes to allow paramiko to mostly work under FIPS

### DIFF
--- a/paramiko/pkey.py
+++ b/paramiko/pkey.py
@@ -23,7 +23,6 @@ Common API for all public keys.
 import base64
 from binascii import unhexlify
 import os
-from hashlib import md5
 import re
 import struct
 
@@ -184,7 +183,7 @@ class PKey(object):
             a 16-byte `string <str>` (binary) of the MD5 fingerprint, in SSH
             format.
         """
-        return md5(self.asbytes()).digest()
+        return util.md5(self.asbytes(), usedforsecurity=False).digest()
 
     def get_base64(self):
         """
@@ -395,7 +394,7 @@ class PKey(object):
         keysize = self._CIPHER_TABLE[encryption_type]["keysize"]
         mode = self._CIPHER_TABLE[encryption_type]["mode"]
         salt = unhexlify(b(saltstr))
-        key = util.generate_key_bytes(md5, salt, password, keysize)
+        key = util.generate_key_bytes(util.md5, salt, password, keysize)
         decryptor = Cipher(
             cipher(key), mode(salt), backend=default_backend()
         ).decryptor()

--- a/paramiko/util.py
+++ b/paramiko/util.py
@@ -23,6 +23,7 @@ Useful functions used by the rest of paramiko.
 from __future__ import generators
 
 import errno
+import hashlib
 import sys
 import struct
 import traceback
@@ -306,3 +307,27 @@ class ClosingContextManager(object):
 
 def clamp_value(minimum, val, maximum):
     return max(minimum, min(val, maximum))
+
+
+try:
+    _ = hashlib.md5(usedforsecurity=False)  # nosec
+
+    def md5(string=b"", usedforsecurity=True):
+        """Return an md5 hashlib object using usedforsecurity parameter
+
+        For python distributions that support the usedforsecurity keyword
+        parameter, this passes the parameter through as expected.
+        See https://bugs.python.org/issue9216
+        """
+        return hashlib.md5(string, usedforsecurity=usedforsecurity)  # nosec
+
+
+except TypeError:
+
+    def md5(string=b"", usedforsecurity=True):
+        """Return an md5 hashlib object without usedforsecurity parameter
+
+        For python distributions that do not yet support this keyword
+        parameter, we drop the parameter
+        """
+        return hashlib.md5(string)  # nosec


### PR DESCRIPTION
Right now, because of a couple of invocations of md5() to generate
fingerprints for log messages, paramiko does not work on systems where
FIPS mode is enabled.  This is because hashlib.md5() fails when FIPS
mode is enabled on the kernel.

An attribute has been added to hashlib in python 3.9 to allow
the use of md5() in non-security contexts.  This is because FIPS allows
the use of md5() when secret data is not involved - which is exactly the
case here.

This attribute "usedforsecurity" has been backported to python versions
prior to python 3.9 on some distributions.  We therefore add a check
to confirm whether the attribute is supported, and if so, annotate
accordingly to allow the operation to succeed.

See https://bugs.python.org/issue9216 for more details.