### PR TITLE
Fix invalid signature received from PuTTY with RSA key

### DIFF
--- a/paramiko/rsakey.py
+++ b/paramiko/rsakey.py
@@ -141,9 +141,16 @@ class RSAKey(PKey):
         if isinstance(key, rsa.RSAPrivateKey):
             key = key.public_key()
 
+        # NOTE: pad received signature with leading zeros, key.verify()
+        # expects a signature of key size (e.g. PuTTY doesn't pad)
+        sign = msg.get_binary()
+        diff = key.key_size - len(sign) * 8
+        if diff > 0:
+            sign = b"\x00" * ((diff + 7) // 8) + sign
+
         try:
             key.verify(
-                msg.get_binary(),
+                sign,
                 data,
                 padding.PKCS1v15(),
                 self.HASHES[sig_algorithm](),


### PR DESCRIPTION
I noticed that paramiko ssh server rejects userauth request when PuTTY accessing with RSA key, at 0.5% - 1.0%.

```
INFO: Auth rejected: invalid signature
```

Investigating it, I noticed openssh server pads leading zeros to a signature before verifying the signature. Because `RSA_verify()` expects a signature of key size and PuTTY sends a signature without zero leading padding.

I think we should pad with leading zeros to a signature before passing it to `.verify()`.

See also:
* https://github.com/openssh/openssh-portable/commit/ceae9d1c333c24894cccddc861c1b9b6d208a8bc
* https://github.com/openssh/openssh-portable/blob/V_8_8_P1/ssh-rsa.c#L302-L311
* https://documentation.help/PuTTY/config-ssh-bug-sig.html