### PR TITLE
prevent exceeding limits on cloud environments which appear to lead to os level Timeouts during sock.connect

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -350,6 +350,7 @@ class SSHClient(ClosingContextManager):
                     # Break out of the loop on success
                     break
                 except socket.error as e:
+                    sock.close()
                     # Raise anything that isn't a straight up connection error
                     # (such as a resolution error)
                     if e.errno not in (ECONNREFUSED, EHOSTUNREACH):


### PR DESCRIPTION
On error, the socket should be closed to free up the underlying file descriptor.

The sock.close() function was introduced in socket 3.7 so I am not sure whether this will cause any issues with older versions of python...? The notes from that indicate that os.close() will not work in all cases, however it might be an acceptable stand in for most use cases (eg. linux).

(I've tried to run the pytest test suite, however on windows there is an error due to the (requireNonAsciiLocale) tests using the pytest.skip function outside of a test. On removing those tests, two tests fail: test_symlink, testa_posix_rename. However those tests also fail without this change, and appear to be just as I am on Windows not linux)