### PR TITLE
Added timeout for Channel operations

### DIFF
--- a/paramiko/channel.py
+++ b/paramiko/channel.py
@@ -63,10 +63,10 @@ def open_only(func):
     @wraps(func)
     def _check(self, *args, **kwds):
         if (
-            self.closed
-            or self.eof_received
-            or self.eof_sent
-            or not self.active
+                self.closed
+                or self.eof_received
+                or self.eof_sent
+                or not self.active
         ):
             raise SSHException("Channel is not open")
         return func(self, *args, **kwds)
@@ -162,12 +162,13 @@ class Channel(ClosingContextManager):
 
     @open_only
     def get_pty(
-        self,
-        term="vt100",
-        width=80,
-        height=24,
-        width_pixels=0,
-        height_pixels=0,
+            self,
+            term="vt100",
+            width=80,
+            height=24,
+            width_pixels=0,
+            height_pixels=0,
+            timeout=None
     ):
         """
         Request a pseudo-terminal from the server.  This is usually used right
@@ -182,6 +183,7 @@ class Channel(ClosingContextManager):
         :param int height: height (in characters) of the terminal screen
         :param int width_pixels: width (in pixels) of the terminal screen
         :param int height_pixels: height (in pixels) of the terminal screen
+        :param float timeout: timeout (in seconds) for the server's response
 
         :raises:
             `.SSHException` -- if the request was rejected or the channel was
@@ -200,10 +202,10 @@ class Channel(ClosingContextManager):
         m.add_string(bytes())
         self._event_pending()
         self.transport._send_user_message(m)
-        self._wait_for_event()
+        self._wait_for_event(timeout=timeout)
 
     @open_only
-    def invoke_shell(self):
+    def invoke_shell(self, timeout=None):
         """
         Request an interactive shell session on this channel.  If the server
         allows it, the channel will then be directly connected to the stdin,
@@ -216,6 +218,8 @@ class Channel(ClosingContextManager):
         When the shell exits, the channel will be closed and can't be reused.
         You must open a new channel if you wish to open another shell.
 
+        :param: float timeout: timeout (in seconds) for server's response
+
         :raises:
             `.SSHException` -- if the request was rejected or the channel was
             closed
@@ -227,10 +231,10 @@ class Channel(ClosingContextManager):
         m.add_boolean(True)
         self._event_pending()
         self.transport._send_user_message(m)
-        self._wait_for_event()
+        self._wait_for_event(timeout=timeout)
 
     @open_only
-    def exec_command(self, command):
+    def exec_command(self, command, timeout=None):
         """
         Execute a command on the server.  If the server allows it, the channel
         will then be directly connected to the stdin, stdout, and stderr of
@@ -241,6 +245,7 @@ class Channel(ClosingContextManager):
         another command.
 
         :param str command: a shell command to execute.
+        :param: float timeout: timeout (in seconds) for server's response
 
         :raises:
             `.SSHException` -- if the request was rejected or the channel was
@@ -254,10 +259,10 @@ class Channel(ClosingContextManager):
         m.add_string(command)
         self._event_pending()
         self.transport._send_user_message(m)
-        self._wait_for_event()
+        self._wait_for_event(timeout=timeout)
 
     @open_only
-    def invoke_subsystem(self, subsystem):
+    def invoke_subsystem(self, subsystem, timeout=None):
         """
         Request a subsystem on the server (for example, ``sftp``).  If the
         server allows it, the channel will then be directly connected to the
@@ -267,6 +272,7 @@ class Channel(ClosingContextManager):
         reused.
 
         :param str subsystem: name of the subsystem being requested.
+        :param: float timeout: timeout (in seconds) for server's response
 
         :raises:
             `.SSHException` -- if the request was rejected or the channel was
@@ -280,7 +286,7 @@ class Channel(ClosingContextManager):
         m.add_string(subsystem)
         self._event_pending()
         self.transport._send_user_message(m)
-        self._wait_for_event()
+        self._wait_for_event(timeout=timeout)
 
     @open_only
     def resize_pty(self, width=80, height=24, width_pixels=0, height_pixels=0):
@@ -376,7 +382,7 @@ class Channel(ClosingContextManager):
         """
         return self.closed or self.status_event.is_set()
 
-    def recv_exit_status(self):
+    def recv_exit_status(self, timeout=None):
         """
         Return the exit status from the process on the server.  This is
         mostly useful for retrieving the results of an `exec_command`.
@@ -395,11 +401,13 @@ class Channel(ClosingContextManager):
             In these cases, ensuring that `.recv_exit_status` is called *after*
             `.Channel.recv` (or, again, using threads) can avoid the hang.
 
+        :param: float timeout: timeout (in seconds) for server's response
+
         :return: the exit code (as an `int`) of the process on the server.
 
         .. versionadded:: 1.2
         """
-        self.status_event.wait()
+        self.status_event.wait(timeout=timeout)
         assert self.status_event.is_set()
         return self.exit_status
 
@@ -426,12 +434,12 @@ class Channel(ClosingContextManager):
 
     @open_only
     def request_x11(
-        self,
-        screen_number=0,
-        auth_protocol=None,
-        auth_cookie=None,
-        single_connection=False,
-        handler=None,
+            self,
+            screen_number=0,
+            auth_protocol=None,
+            auth_cookie=None,
+            single_connection=False,
+            handler=None,
     ):
         """
         Request an x11 session on this channel.  If the server allows it,
@@ -1215,8 +1223,8 @@ class Channel(ClosingContextManager):
         self.event.clear()
         self.event_ready = False
 
-    def _wait_for_event(self):
-        self.event.wait()
+    def _wait_for_event(self, timeout=None):
+        self.event.wait(timeout=timeout)
         assert self.event.is_set()
         if self.event_ready:
             return


### PR DESCRIPTION
When trying to work with Channel object some of the operations are unnecessarily blocking,
added the ability to pass a timeout parameter to the methods in Channel so that if one chooses to limit the running time of some method from some reason he is able to.