### PR TITLE
Fix a bug of comparing keys with none

### DIFF
--- a/paramiko/pkey.py
+++ b/paramiko/pkey.py
@@ -140,6 +140,8 @@ class PKey(object):
         return cmp(self.asbytes(), other.asbytes())  # noqa
 
     def __eq__(self, other):
+        if other is None:
+            return False
         return self._fields == other._fields
 
     def __hash__(self):

--- a/tests/test_pkey.py
+++ b/tests/test_pkey.py
@@ -622,6 +622,11 @@ class KeyTest(unittest.TestCase):
         for key1, key2 in self.keys():
             assert key1 == key2
 
+    def test_keys_are_not_equal_to_none(self):
+        key2 = None
+        for key1, _ in self.keys():
+            assert key1 != key2
+
     def test_keys_are_hashable(self):
         # NOTE: this isn't a great test due to hashseed randomization under
         # Python 3 preventing use of static values, but it does still prove


### PR DESCRIPTION
This bug exists after version 2.7.2.