### PR TITLE
Print exceptions along with the initial log message

### DIFF
--- a/paramiko/auth_handler.py
+++ b/paramiko/auth_handler.py
@@ -95,8 +95,8 @@ class AuthHandler(object):
         self.gss_host = None
         self.gss_deleg_creds = True
 
-    def _log(self, *args):
-        return self.transport._log(*args)
+    def _log(self, *args, **kwargs):
+        return self.transport._log(*args, **kwargs)
 
     def is_authenticated(self):
         return self.authenticated

--- a/paramiko/channel.py
+++ b/paramiko/channel.py
@@ -1208,8 +1208,8 @@ class Channel(ClosingContextManager):
         self.transport._send_user_message(m)
         return size
 
-    def _log(self, level, msg, *args):
-        self.logger.log(level, "[chan " + self._name + "] " + msg, *args)
+    def _log(self, level, msg, *args, **kwargs):
+        self.logger.log(level, "[chan " + self._name + "] " + msg, *args, **kwargs)
 
     def _event_pending(self):
         self.event.clear()

--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -766,8 +766,8 @@ class SSHClient(ClosingContextManager):
             raise saved_exception
         raise SSHException("No authentication methods available")
 
-    def _log(self, level, msg):
-        self._transport._log(level, msg)
+    def _log(self, level, msg, *args, **kwargs):
+        self._transport._log(level, msg, *args, **kwargs)
 
 
 class MissingHostKeyPolicy(object):

--- a/paramiko/packet.py
+++ b/paramiko/packet.py
@@ -578,14 +578,14 @@ class Packetizer(object):
 
     # ...protected...
 
-    def _log(self, level, msg):
+    def _log(self, level, msg, *args, **kwargs):
         if self.__logger is None:
             return
         if issubclass(type(msg), list):
             for m in msg:
-                self.__logger.log(level, m)
+                self.__logger.log(level, m, *args, **kwargs)
         else:
-            self.__logger.log(level, msg)
+            self.__logger.log(level, msg, *args, **kwargs)
 
     def _check_keepalive(self):
         if (

--- a/paramiko/server.py
+++ b/paramiko/server.py
@@ -684,11 +684,9 @@ class SubsystemHandler(threading.Thread):
         except Exception as e:
             self.__transport._log(
                 ERROR,
-                'Exception in subsystem handler for "{}": {}'.format(
-                    self.__name, e
-                ),
+                'Exception in subsystem handler for "{}"'.format(self.__name),
+                exc_info=True,
             )
-            self.__transport._log(ERROR, util.tb_strings())
         try:
             self.finish_subsystem()
         except:

--- a/paramiko/sftp.py
+++ b/paramiko/sftp.py
@@ -154,8 +154,8 @@ class BaseSFTP(object):
         self._send_packet(CMD_VERSION, msg)
         return version
 
-    def _log(self, level, msg, *args):
-        self.logger.log(level, msg, *args)
+    def _log(self, level, msg, *args, **kwargs):
+        self.logger.log(level, msg, *args, **kwargs)
 
     def _write_all(self, out):
         while len(out) > 0:

--- a/paramiko/sftp_client.py
+++ b/paramiko/sftp_client.py
@@ -169,10 +169,10 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
         chan.invoke_subsystem("sftp")
         return cls(chan)
 
-    def _log(self, level, msg, *args):
+    def _log(self, level, msg, *args, **kwargs):
         if isinstance(msg, list):
             for m in msg:
-                self._log(level, m, *args)
+                self._log(level, m, *args, **kwargs)
         else:
             # NOTE: these bits MUST continue using %-style format junk because
             # logging.Logger.log() explicitly requires it. Grump.
@@ -182,7 +182,8 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
             super(SFTPClient, self)._log(
                 level,
                 "[chan %s] " + msg,
-                *([self.sock.get_name()] + list(args))
+                *([self.sock.get_name()] + list(args)),
+                **kwargs
             )
 
     def close(self):

--- a/paramiko/sftp_server.py
+++ b/paramiko/sftp_server.py
@@ -125,15 +125,19 @@ class SFTPServer(BaseSFTP, SubsystemHandler):
         self.folder_table = {}
         self.server = sftp_si(server, *largs, **kwargs)
 
-    def _log(self, level, msg):
+    def _log(self, level, msg, *args, **kwargs):
         if issubclass(type(msg), list):
             for m in msg:
                 super(SFTPServer, self)._log(
-                    level, "[chan " + self.sock.get_name() + "] " + m
+                    level, "[chan " + self.sock.get_name() + "] " + m,
+                    *args,
+                    **kwargs
                 )
         else:
             super(SFTPServer, self)._log(
-                level, "[chan " + self.sock.get_name() + "] " + msg
+                level, "[chan " + self.sock.get_name() + "] " + msg,
+                *args,
+                **kwargs
             )
 
     def start_subsystem(self, name, transport, channel):

--- a/paramiko/sftp_server.py
+++ b/paramiko/sftp_server.py
@@ -152,16 +152,14 @@ class SFTPServer(BaseSFTP, SubsystemHandler):
                 self._log(DEBUG, "EOF -- end of session")
                 return
             except Exception as e:
-                self._log(DEBUG, "Exception on channel: " + str(e))
-                self._log(DEBUG, util.tb_strings())
+                self._log(DEBUG, "Exception on channel", exc_info=True)
                 return
             msg = Message(data)
             request_number = msg.get_int()
             try:
                 self._process(t, request_number, msg)
             except Exception as e:
-                self._log(DEBUG, "Exception in server processing: " + str(e))
-                self._log(DEBUG, util.tb_strings())
+                self._log(DEBUG, "Exception in server processing", exc_info=True)
                 # send some kind of failure message, at least
                 try:
                     self._send_status(request_number, SFTP_FAILURE)

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -2182,11 +2182,11 @@ class Transport(threading.Thread, ClosingContextManager):
             except SSHException as e:
                 self._log(
                     ERROR,
-                    "Exception ({}): {}".format(
-                        "server" if self.server_mode else "client", e
+                    "Exception ({})".format(
+                        "server" if self.server_mode else "client"
                     ),
+                    exc_info=True,
                 )
-                self._log(ERROR, util.tb_strings())
                 self.saved_exception = e
             except EOFError as e:
                 self._log(DEBUG, "EOF in transport thread")
@@ -2202,8 +2202,7 @@ class Transport(threading.Thread, ClosingContextManager):
                 self._log(ERROR, "Socket exception: " + emsg)
                 self.saved_exception = e
             except Exception as e:
-                self._log(ERROR, "Unknown exception: " + str(e))
-                self._log(ERROR, util.tb_strings())
+                self._log(ERROR, "Unknown exception", exc_info=True)
                 self.saved_exception = e
             _active_threads.remove(self)
             for chan in list(self._channels.values()):

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -1865,12 +1865,12 @@ class Transport(threading.Thread, ClosingContextManager):
 
     # internals...
 
-    def _log(self, level, msg, *args):
+    def _log(self, level, msg, *args, **kwargs):
         if issubclass(type(msg), list):
             for m in msg:
-                self.logger.log(level, m)
+                self.logger.log(level, m, **kwargs)
         else:
-            self.logger.log(level, msg, *args)
+            self.logger.log(level, msg, *args, **kwargs)
 
     def _get_modulus_pack(self):
         """used by KexGex to find primes for group exchange"""

--- a/paramiko/util.py
+++ b/paramiko/util.py
@@ -135,10 +135,6 @@ def bit_length(n):
         return bitlen
 
 
-def tb_strings():
-    return "".join(traceback.format_exception(*sys.exc_info())).split("\n")
-
-
 def generate_key_bytes(hash_alg, salt, key, nbytes):
     """
     Given a password, passphrase, or other human-source key, scramble it


### PR DESCRIPTION
By using the built-in exc_info functionality, the exception will be part of the initial log entry, preventing it from for instance creating separate events in Sentry.

Builds on the work in https://github.com/paramiko/paramiko/pull/1737 and https://github.com/paramiko/paramiko/pull/406