### PR TITLE
Change default bufsize for SFTP files to match the max request size

### DIFF
--- a/paramiko/sftp_file.py
+++ b/paramiko/sftp_file.py
@@ -57,11 +57,14 @@ class SFTPFile(BufferedFile):
     # Some sftp servers will choke if you send read/write requests larger than
     # this size.
     MAX_REQUEST_SIZE = 32768
+    DEFAULT_BUFSIZE = MAX_REQUEST_SIZE
 
     def __init__(self, sftp, handle, mode="r", bufsize=-1):
         BufferedFile.__init__(self)
         self.sftp = sftp
         self.handle = handle
+        if bufsize < 0:
+            bufsize = self.DEFAULT_BUFSIZE
         BufferedFile._set_mode(self, mode, bufsize)
         self.pipelined = False
         self._prefetching = False


### PR DESCRIPTION
I'd be very interested to hear if my reasoning for the change makes sense.

In the default case (where `bufsize` is -1) the default value of 8KB is used as the buffer for the SFTP file. This means if we accept a bunch of writes that are greater than 8KB but less than 32KB we'll submit a packet below the maximum size we're allowed, potentially affecting throughput. An example where I've observed this is streaming a large file through an SFTP file where the source data is also writing in 8KB chunks.

In terms of tradeoffs I can think of it does mean by default, on reads, we'll request at least 32KB at a time vs the 8KB we're currently doing. 
Also it means memory usage per SFTP_file instance will increase by 4x which may be sad if someone has a lot of files.

Interested to hear thoughts if the potential trade offs are acceptable.