### PR TITLE
 Update paramiko to use sha256

### DIFF
--- a/paramiko/pkey.py
+++ b/paramiko/pkey.py
@@ -23,7 +23,7 @@ Common API for all public keys.
 import base64
 from binascii import unhexlify
 import os
-from hashlib import md5
+from hashlib import sha256
 import re
 import struct
 
@@ -177,14 +177,14 @@ class PKey(object):
 
     def get_fingerprint(self):
         """
-        Return an MD5 fingerprint of the public part of this key.  Nothing
+        Return an SHA256 fingerprint of the public part of this key.  Nothing
         secret is revealed.
 
         :return:
-            a 16-byte `string <str>` (binary) of the MD5 fingerprint, in SSH
+            a 32-byte `string <str>` (binary) of the SHA256 fingerprint, in SSH
             format.
         """
-        return md5(self.asbytes()).digest()
+        return sha256(self.asbytes()).digest()
 
     def get_base64(self):
         """
@@ -402,7 +402,7 @@ class PKey(object):
         keysize = self._CIPHER_TABLE[encryption_type]["keysize"]
         mode = self._CIPHER_TABLE[encryption_type]["mode"]
         salt = unhexlify(b(saltstr))
-        key = util.generate_key_bytes(md5, salt, password, keysize)
+        key = util.generate_key_bytes(sha256, salt, password, keysize)
         decryptor = Cipher(
             cipher(key), mode(salt), backend=default_backend()
         ).decryptor()

--- a/paramiko/sftp_server.py
+++ b/paramiko/sftp_server.py
@@ -23,7 +23,7 @@ Server-mode SFTP support.
 import os
 import errno
 import sys
-from hashlib import md5, sha1
+from hashlib import md5, sha1, sha256
 
 from paramiko import util
 from paramiko.sftp import (
@@ -81,7 +81,7 @@ from paramiko.sftp import (
     SFTP_OP_UNSUPPORTED,
 )
 
-_hash_class = {"sha1": sha1, "md5": md5}
+_hash_class = {"sha256": sha256, "sha1": sha1, "md5": md5}
 
 
 class SFTPServer(BaseSFTP, SubsystemHandler):


### PR DESCRIPTION
- Background: SOAR apps like SSH use paramiko for ssh
connection. However, paramiko does not support sha256 internally,
which results in `[digital envelope routines: EVP_DigestInit_ex] disabled for FIPS.`
error on FIPS enabled instance

- Fix: Fork from the orginal repo and allow sha256 instead of md5.
Future apps will point to this repo instead of the orginal repo