### PR TITLE
Error log added when an unknown response code is received

### DIFF
--- a/paramiko/sftp_client.py
+++ b/paramiko/sftp_client.py
@@ -27,7 +27,7 @@ import weakref
 from paramiko import util
 from paramiko.channel import Channel
 from paramiko.message import Message
-from paramiko.common import INFO, DEBUG, o777
+from paramiko.common import INFO, DEBUG, o777, ERROR
 from paramiko.py3compat import b, u, long
 from paramiko.sftp import (
     BaseSFTP,
@@ -904,6 +904,7 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
         elif code == SFTP_PERMISSION_DENIED:
             raise IOError(errno.EACCES, text)
         else:
+            self._log(ERROR, "Unexpected response code #{}".format(code))
             raise IOError(text)
 
     def _adjust_cwd(self, path):

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -1,7 +1,7 @@
 =========
 Changelog
 =========
-
+- :bug:`-` Error log added when an unknown response code is received by _convert_status method in sftp_client.
 - :release:`2.9.2 <2022-01-08>`
 - :bug:`-` Connecting to servers which support ``server-sig-algs`` but which
   have no overlap between that list and what a Paramiko client supports, now


### PR DESCRIPTION
Error log added when an unknown response code is received by _convert_status method in sftp_client.
Otherwise you can't debug easily because nothing relevant is raised (eg :  raise IOError(text) and it is literally written "text") 