### PR TITLE
Add six to `install_requires`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,6 +90,6 @@ setup(
     # TODO 3.0: alternately, given how prevalent ed25519 is now, and how we use
     # invoke for (increasing) subproc stuff, consider making the default flavor
     # "full" and adding a "minimal" or similar that is just-crypto?
-    install_requires=["bcrypt>=3.1.3", "cryptography>=2.5", "pynacl>=1.0.1"],
+    install_requires=["bcrypt>=3.1.3", "cryptography>=2.5", "pynacl>=1.0.1", "six"],
     extras_require=extras_require,
 )


### PR DESCRIPTION
Hi 👋 

[six](https://pypi.org/project/six/) is imported and used, in Paramiko, [here](https://github.com/paramiko/paramiko/blob/main/paramiko/pkey.py#L30). 

Unfortunately, since it's not listed as a dependency, importing paramiko seems to fail: 

```
Feb 10 10:53:57 info   File "/app/....py", line 6, in <module>
Feb 10 10:53:57 info     import paramiko
Feb 10 10:53:57 info   File "/usr/local/lib/python3.10/site-packages/paramiko/__init__.py", line 22, in <module>
Feb 10 10:53:57 info     from paramiko.transport import SecurityOptions, Transport
Feb 10 10:53:57 info   File "/usr/local/lib/python3.10/site-packages/paramiko/transport.py", line 91, in <module>
Feb 10 10:53:57 info     from paramiko.dsskey import DSSKey
Feb 10 10:53:57 info   File "/usr/local/lib/python3.10/site-packages/paramiko/dsskey.py", line 37, in <module>
Feb 10 10:53:57 info     from paramiko.pkey import PKey
Feb 10 10:53:57 info   File "/usr/local/lib/python3.10/site-packages/paramiko/pkey.py", line 30, in <module>
Feb 10 10:53:57 info     import six
Feb 10 10:53:57 info ModuleNotFoundError: No module named 'six'
```

This PR adds it to setup.py's `install_requires`. Currently haven't specified a version range.