### PR TITLE
Use `HostKeys.save` in `Client.save_host_keys`.

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -142,14 +142,7 @@ class SSHClient(ClosingContextManager):
         if self._host_keys_filename is not None:
             self.load_host_keys(self._host_keys_filename)
 
-        with open(filename, "w") as f:
-            for hostname, keys in self._host_keys.items():
-                for keytype, key in keys.items():
-                    f.write(
-                        "{} {} {}\n".format(
-                            hostname, keytype, key.get_base64()
-                        )
-                    )
+        self._host_keys.save(filename)
 
     def get_host_keys(self):
         """


### PR DESCRIPTION
The code is currently duplicated in both methods.