### PR TITLE
Ignore `InvalidHostKey` exceptions loading host keys.

### DIFF
--- a/paramiko/hostkeys.py
+++ b/paramiko/hostkeys.py
@@ -99,7 +99,7 @@ class HostKeys(MutableMapping):
                     continue
                 try:
                     e = HostKeyEntry.from_line(line, lineno)
-                except SSHException:
+                except (SSHException, InvalidHostKey):
                     continue
                 if e is not None:
                     _hostnames = e.hostnames


### PR DESCRIPTION
Similar to https://github.com/paramiko/paramiko/pull/500 but covers the extra exception that may be raised.