### PR TITLE
Fix and improve `get_hostnames()` for configs with `Match` directives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.py	diff=python

--- a/paramiko/config.py
+++ b/paramiko/config.py
@@ -319,7 +319,12 @@ class SSHConfig(object):
         """
         hosts = set()
         for entry in self._config:
-            hosts.update(entry["host"])
+            if "host" in entry:
+                hosts.update(entry["host"])
+            elif "matches" in entry:
+                for condition in entry["matches"]:
+                    if condition["type"] == "host":
+                        hosts.update(condition["param"].split(","))
         return hosts
 
     def _pattern_matches(self, patterns, target):

--- a/paramiko/config.py
+++ b/paramiko/config.py
@@ -520,7 +520,7 @@ class SSHConfig(object):
             if type_.startswith("!"):
                 match["negate"] = True
                 type_ = type_[1:]
-            match["type"] = type_
+            match["type"] = type_.lower()
             # all/canonical have no params (everything else does)
             if type_ in ("all", "canonical"):
                 matches.append(match)

--- a/tests/configs/match-host-glob-list
+++ b/tests/configs/match-host-glob-list
@@ -1,4 +1,4 @@
-Match host *ever
+Match Host *ever
     User matrim
 
 Match host somehost,someotherhost

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -332,6 +332,11 @@ Host abcqwerty\r\nHostName 127.0.0.1\r\n
         expected = {"*", "*.example.com", "spoo.example.com"}
         assert self.config.get_hostnames() == expected
 
+    def test_get_hostnames_with_match(self):
+        config = load_config("match-host-glob-list")
+        expected = {"*", "*ever", "somehost", "someotherhost", "goo*", "!goof"}
+        assert config.get_hostnames() == expected
+
     def test_quoted_host_names(self):
         config = SSHConfig.from_text(
             """


### PR DESCRIPTION
Fix and improve 'get_hostnames()' for configs with 'Match' directives

SSHConfig.get_hostnames() is unprepared to be called for configs with
'Match' directives, as this function expects every entry in the config
to have a "host" key, which is not the case when the config contains
"Match" directives.

Improve the function by checking for "matches" entries, and
additionnally check if the condition of the 'Match' directive is "host",
in which case add the listed hosts to the set of hosts returned.

---
Additionnally:
- Commit 2/3 accepts capitalized `Match` conditions
- Commit 3/3 includes a `.gitattributes` file for [Python-aware Git diffs and such](https://git-scm.com/docs/gitattributes#_defining_a_custom_hunk_header)

This should supersede https://github.com/paramiko/paramiko/pull/1674.
