### PR TITLE
Add optional parameters for encoding different from utf8 (default is still utf8)

### DIFF
--- a/demos/interactive.py
+++ b/demos/interactive.py
@@ -31,14 +31,14 @@ except ImportError:
     has_termios = False
 
 
-def interactive_shell(chan):
+def interactive_shell(chan, encoding="utf8", errors="strict"):
     if has_termios:
-        posix_shell(chan)
+        posix_shell(chan, encoding, errors)
     else:
         windows_shell(chan)
 
 
-def posix_shell(chan):
+def posix_shell(chan, encoding="utf8", errors="strict"):
     import select
 
     oldtty = termios.tcgetattr(sys.stdin)
@@ -51,7 +51,7 @@ def posix_shell(chan):
             r, w, e = select.select([chan, sys.stdin], [], [])
             if chan in r:
                 try:
-                    x = u(chan.recv(1024))
+                    x = u(chan.recv(1024), encoding, errors)
                     if len(x) == 0:
                         sys.stdout.write("\r\n*** EOF\r\n")
                         break

--- a/paramiko/file.py
+++ b/paramiko/file.py
@@ -95,7 +95,7 @@ class BufferedFile(ClosingContextManager):
 
     if PY2:
 
-        def next(self):
+        def next(self, encoding="utf8", errors="strict"):
             """
             Returns the next line from the input, or raises
             ``StopIteration`` when EOF is hit.  Unlike Python file
@@ -105,14 +105,14 @@ class BufferedFile(ClosingContextManager):
 
             :returns: a line (`str`) read from the file.
             """
-            line = self.readline()
+            line = self.readline(encoding=encoding, errors=errors)
             if not line:
                 raise StopIteration
             return line
 
     else:
 
-        def __next__(self):
+        def __next__(self, encoding="utf8", errors="strict"):
             """
             Returns the next line from the input, or raises ``StopIteration``
             when EOF is hit.  Unlike python file objects, it's okay to mix
@@ -122,7 +122,7 @@ class BufferedFile(ClosingContextManager):
 
             :returns: a line (`str`) read from the file.
             """
-            line = self.readline()
+            line = self.readline(encoding=encoding, errors=errors)
             if not line:
                 raise StopIteration
             return line
@@ -228,7 +228,7 @@ class BufferedFile(ClosingContextManager):
         self._pos += len(result)
         return result
 
-    def readline(self, size=None):
+    def readline(self, size=None, encoding="utf8", errors="strict"):
         """
         Read one entire line from the file.  A trailing newline character is
         kept in the string (but may be absent when a file ends with an
@@ -294,7 +294,9 @@ class BufferedFile(ClosingContextManager):
             if (new_data is None) or (len(new_data) == 0):
                 self._rbuffer = bytes()
                 self._pos += len(line)
-                return line if self._flags & self.FLAG_BINARY else u(line)
+                return line if self._flags & self.FLAG_BINARY else u(line,
+                                                                    encoding,
+                                                                    errors)
             line += new_data
             self._realpos += len(new_data)
         # find the newline
@@ -306,7 +308,9 @@ class BufferedFile(ClosingContextManager):
         if pos == -1:
             # we couldn't find a newline in the truncated string, return it
             self._pos += len(line)
-            return line if self._flags & self.FLAG_BINARY else u(line)
+            return line if self._flags & self.FLAG_BINARY else u(line,
+                                                                 encoding,
+                                                                 errors)
         xpos = pos + 1
         if (
             line[pos] == cr_byte_value
@@ -331,9 +335,10 @@ class BufferedFile(ClosingContextManager):
         else:
             self._record_newline(lf)
         self._pos += len(line)
-        return line if self._flags & self.FLAG_BINARY else u(line)
+        return line if self._flags & self.FLAG_BINARY else u(line,
+                                                             encoding, errors)
 
-    def readlines(self, sizehint=None):
+    def readlines(self, sizehint=None, encoding="utf8", errors="strict"):
         """
         Read all remaining lines using `readline` and return them as a list.
         If the optional ``sizehint`` argument is present, instead of reading up
@@ -346,7 +351,7 @@ class BufferedFile(ClosingContextManager):
         lines = []
         byte_count = 0
         while True:
-            line = self.readline()
+            line = self.readline(sizehint, encoding, errors)
             if len(line) == 0:
                 break
             lines.append(line)

--- a/paramiko/message.py
+++ b/paramiko/message.py
@@ -171,11 +171,11 @@ class Message(object):
         """
         return self.get_bytes(self.get_int())
 
-    def get_text(self):
+    def get_text(self, encoding="utf8", errors="strict"):
         """
         Fetch a Unicode string from the stream.
         """
-        return u(self.get_string())
+        return u(self.get_string(), encoding, errors)
 
     def get_binary(self):
         """

--- a/paramiko/packet.py
+++ b/paramiko/packet.py
@@ -370,7 +370,7 @@ class Packetizer(object):
             out = out[n:]
         return
 
-    def readline(self, timeout):
+    def readline(self, timeout, encoding="utf8", errors="strict"):
         """
         Read a line from the socket.  We assume no data is pending after the
         line, so it's okay to attempt large reads.
@@ -383,7 +383,7 @@ class Packetizer(object):
         buf = buf[:n]
         if (len(buf) > 0) and (buf[-1] == cr_byte_value):
             buf = buf[:-1]
-        return u(buf)
+        return u(buf, encoding, errors)
 
     def send_message(self, data):
         """

--- a/paramiko/py3compat.py
+++ b/paramiko/py3compat.py
@@ -65,14 +65,14 @@ if PY2:
         else:
             raise TypeError("Expected unicode or bytes, got {!r}".format(s))
 
-    def u(s, encoding="utf8"):  # NOQA
+    def u(s, encoding="utf8", errors="strict"):  # NOQA
         """cast bytes or unicode to unicode"""
         if isinstance(s, str):
-            return s.decode(encoding)
+            return s.decode(encoding, errors)
         elif isinstance(s, unicode):  # NOQA
             return s
         elif isinstance(s, buffer):  # NOQA
-            return s.decode(encoding)
+            return s.decode(encoding, errors)
         else:
             raise TypeError("Expected unicode or bytes, got {!r}".format(s))
 
@@ -155,10 +155,10 @@ else:
         else:
             raise TypeError("Expected unicode or bytes, got {!r}".format(s))
 
-    def u(s, encoding="utf8"):
+    def u(s, encoding="utf8", errors="strict"):
         """cast bytes or unicode to unicode"""
         if isinstance(s, bytes):
-            return s.decode(encoding)
+            return s.decode(encoding, errors)
         elif isinstance(s, str):
             return s
         else:

--- a/paramiko/sftp_client.py
+++ b/paramiko/sftp_client.py
@@ -203,7 +203,7 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
         """
         return self.sock
 
-    def listdir(self, path="."):
+    def listdir(self, path=".", encoding="utf8", errors="strict"):
         """
         Return a list containing the names of the entries in the given
         ``path``.
@@ -215,9 +215,9 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
 
         :param str path: path to list (defaults to ``'.'``)
         """
-        return [f.filename for f in self.listdir_attr(path)]
+        return [f.filename for f in self.listdir_attr(path, encoding, errors)]
 
-    def listdir_attr(self, path="."):
+    def listdir_attr(self, path=".", encoding="utf8", errors="strict"):
         """
         Return a list containing `.SFTPAttributes` objects corresponding to
         files in the given ``path``.  The list is in arbitrary order.  It does
@@ -236,7 +236,9 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
         """
         path = self._adjust_cwd(path)
         self._log(DEBUG, "listdir({!r})".format(path))
-        t, msg = self._request(CMD_OPENDIR, path)
+        t, msg = self._request(CMD_OPENDIR,
+                               path.decode("utf8", errors)
+                               .encode(encoding, errors))
         if t != CMD_HANDLE:
             raise SFTPError("Expected handle")
         handle = msg.get_binary()
@@ -251,15 +253,16 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
                 raise SFTPError("Expected name response")
             count = msg.get_int()
             for i in range(count):
-                filename = msg.get_text()
-                longname = msg.get_text()
+                filename = msg.get_text(encoding, errors)
+                longname = msg.get_text(encoding, errors)
                 attr = SFTPAttributes._from_msg(msg, filename, longname)
                 if (filename != ".") and (filename != ".."):
                     filelist.append(attr)
         self._request(CMD_CLOSE, handle)
         return filelist
 
-    def listdir_iter(self, path=".", read_aheads=50):
+    def listdir_iter(self, path=".", read_aheads=50,
+                     encoding="utf8", errors="strict"):
         """
         Generator version of `.listdir_attr`.
 
@@ -275,7 +278,9 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
         """
         path = self._adjust_cwd(path)
         self._log(DEBUG, "listdir({!r})".format(path))
-        t, msg = self._request(CMD_OPENDIR, path)
+        t, msg = self._request(CMD_OPENDIR,
+                               path.decode("utf-8", errors)
+                               .encode(encoding, errors))
 
         if t != CMD_HANDLE:
             raise SFTPError("Expected handle")
@@ -308,8 +313,8 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
                             self._convert_status(msg)
                     count = msg.get_int()
                     for i in range(count):
-                        filename = msg.get_text()
-                        longname = msg.get_text()
+                        filename = msg.get_text(encoding, errors)
+                        longname = msg.get_text(encoding, errors)
                         attr = SFTPAttributes._from_msg(
                             msg, filename, longname
                         )
@@ -323,7 +328,8 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
                 self._request(CMD_CLOSE, handle)
                 return
 
-    def open(self, filename, mode="r", bufsize=-1):
+    def open(self, filename, mode="r", bufsize=-1,
+             encoding="utf8", errors="strict"):
         """
         Open a file on the remote server.  The arguments are the same as for
         Python's built-in `python:file` (aka `python:open`).  A file-like
@@ -369,14 +375,17 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
         if "x" in mode:
             imode |= SFTP_FLAG_CREATE | SFTP_FLAG_EXCL
         attrblock = SFTPAttributes()
-        t, msg = self._request(CMD_OPEN, filename, imode, attrblock)
+        t, msg = self._request(CMD_OPEN,
+                               filename.decode("utf-8", errors)
+                               .encode(encoding, errors),
+                               imode, attrblock)
         if t != CMD_HANDLE:
             raise SFTPError("Expected handle")
         handle = msg.get_binary()
         self._log(
             DEBUG,
             "open({!r}, {!r}) -> {}".format(
-                filename, mode, u(hexlify(handle))
+                filename, mode, u(hexlify(handle), encoding, errors)
             ),
         )
         return SFTPFile(self, handle, mode, bufsize)
@@ -384,7 +393,7 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
     # Python continues to vacillate about "open" vs "file"...
     file = open
 
-    def remove(self, path):
+    def remove(self, path, encoding="utf8", errors="strict"):
         """
         Remove the file at the given path.  This only works on files; for
         removing folders (directories), use `rmdir`.
@@ -395,11 +404,12 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
         """
         path = self._adjust_cwd(path)
         self._log(DEBUG, "remove({!r})".format(path))
-        self._request(CMD_REMOVE, path)
+        self._request(CMD_REMOVE,
+                      path.decode("utf-8", errors).encode(encoding, errors))
 
     unlink = remove
 
-    def rename(self, oldpath, newpath):
+    def rename(self, oldpath, newpath, encoding="utf8", errors="strict"):
         """
         Rename a file or folder from ``oldpath`` to ``newpath``.
 
@@ -420,9 +430,11 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
         oldpath = self._adjust_cwd(oldpath)
         newpath = self._adjust_cwd(newpath)
         self._log(DEBUG, "rename({!r}, {!r})".format(oldpath, newpath))
-        self._request(CMD_RENAME, oldpath, newpath)
+        self._request(CMD_RENAME,
+                      oldpath.decode("utf-8", errors).encode(encoding, errors),
+                      newpath.decode("utf-8", errors).encode(encoding, errors))
 
-    def posix_rename(self, oldpath, newpath):
+    def posix_rename(self, oldpath, newpath, encoding="utf8", errors="strict"):
         """
         Rename a file or folder from ``oldpath`` to ``newpath``, following
         posix conventions.
@@ -441,10 +453,12 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
         newpath = self._adjust_cwd(newpath)
         self._log(DEBUG, "posix_rename({!r}, {!r})".format(oldpath, newpath))
         self._request(
-            CMD_EXTENDED, "posix-rename@openssh.com", oldpath, newpath
+            CMD_EXTENDED, "posix-rename@openssh.com",
+            oldpath.decode("utf-8", errors).encode(encoding, errors),
+            newpath.decode("utf-8", errors).encode(encoding, errors)
         )
 
-    def mkdir(self, path, mode=o777):
+    def mkdir(self, path, mode=o777, encoding="utf8", errors="strict"):
         """
         Create a folder (directory) named ``path`` with numeric mode ``mode``.
         The default mode is 0777 (octal).  On some systems, mode is ignored.
@@ -457,9 +471,11 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
         self._log(DEBUG, "mkdir({!r}, {!r})".format(path, mode))
         attr = SFTPAttributes()
         attr.st_mode = mode
-        self._request(CMD_MKDIR, path, attr)
+        self._request(CMD_MKDIR,
+                      path.decode("utf-8", errors).encode(encoding, errors),
+                      attr)
 
-    def rmdir(self, path):
+    def rmdir(self, path, encoding="utf8", errors="strict"):
         """
         Remove the folder named ``path``.
 
@@ -467,9 +483,10 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
         """
         path = self._adjust_cwd(path)
         self._log(DEBUG, "rmdir({!r})".format(path))
-        self._request(CMD_RMDIR, path)
+        self._request(CMD_RMDIR,
+                      path.decode("utf-8", errors).encode(encoding, errors))
 
-    def stat(self, path):
+    def stat(self, path, encoding="utf8", errors="strict"):
         """
         Retrieve information about a file on the remote system.  The return
         value is an object whose attributes correspond to the attributes of
@@ -490,12 +507,14 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
         """
         path = self._adjust_cwd(path)
         self._log(DEBUG, "stat({!r})".format(path))
-        t, msg = self._request(CMD_STAT, path)
+        t, msg = self._request(CMD_STAT,
+                               path.decode("utf-8", errors)
+                               .encode(encoding, errors))
         if t != CMD_ATTRS:
             raise SFTPError("Expected attributes")
         return SFTPAttributes._from_msg(msg)
 
-    def lstat(self, path):
+    def lstat(self, path, encoding="utf8", errors="strict"):
         """
         Retrieve information about a file on the remote system, without
         following symbolic links (shortcuts).  This otherwise behaves exactly
@@ -508,12 +527,14 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
         """
         path = self._adjust_cwd(path)
         self._log(DEBUG, "lstat({!r})".format(path))
-        t, msg = self._request(CMD_LSTAT, path)
+        t, msg = self._request(CMD_LSTAT,
+                               path.decode("utf8", errors)
+                               .encode(encoding, errors))
         if t != CMD_ATTRS:
             raise SFTPError("Expected attributes")
         return SFTPAttributes._from_msg(msg)
 
-    def symlink(self, source, dest):
+    def symlink(self, source, dest, encoding="utf8", errors="strict"):
         """
         Create a symbolic link to the ``source`` path at ``destination``.
 
@@ -523,9 +544,11 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
         dest = self._adjust_cwd(dest)
         self._log(DEBUG, "symlink({!r}, {!r})".format(source, dest))
         source = b(source)
-        self._request(CMD_SYMLINK, source, dest)
+        self._request(CMD_SYMLINK,
+                      source.decode("utf-8", errors).encode(encoding, errors),
+                      dest.decode("utf-8", errors).encode(encoding, errors))
 
-    def chmod(self, path, mode):
+    def chmod(self, path, mode, encoding="utf8", errors="strict"):
         """
         Change the mode (permissions) of a file.  The permissions are
         unix-style and identical to those used by Python's `os.chmod`
@@ -538,9 +561,11 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
         self._log(DEBUG, "chmod({!r}, {!r})".format(path, mode))
         attr = SFTPAttributes()
         attr.st_mode = mode
-        self._request(CMD_SETSTAT, path, attr)
+        self._request(CMD_SETSTAT,
+                      path.decode("utf-8", errors).encode(encoding, errors),
+                      attr)
 
-    def chown(self, path, uid, gid):
+    def chown(self, path, uid, gid, encoding="utf8", errors="strict"):
         """
         Change the owner (``uid``) and group (``gid``) of a file.  As with
         Python's `os.chown` function, you must pass both arguments, so if you
@@ -555,9 +580,11 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
         self._log(DEBUG, "chown({!r}, {!r}, {!r})".format(path, uid, gid))
         attr = SFTPAttributes()
         attr.st_uid, attr.st_gid = uid, gid
-        self._request(CMD_SETSTAT, path, attr)
+        self._request(CMD_SETSTAT,
+                      path.decode("utf-8", errors).encode(encoding, errors),
+                      attr)
 
-    def utime(self, path, times):
+    def utime(self, path, times, encoding="utf8", errors="strict"):
         """
         Set the access and modified times of the file specified by ``path``.
         If ``times`` is ``None``, then the file's access and modified times
@@ -577,9 +604,11 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
         self._log(DEBUG, "utime({!r}, {!r})".format(path, times))
         attr = SFTPAttributes()
         attr.st_atime, attr.st_mtime = times
-        self._request(CMD_SETSTAT, path, attr)
+        self._request(CMD_SETSTAT,
+                      path.decode("utf-8", errors).encode(encoding, errors),
+                      attr)
 
-    def truncate(self, path, size):
+    def truncate(self, path, size, encoding="utf8", errors="strict"):
         """
         Change the size of the file specified by ``path``.  This usually
         extends or shrinks the size of the file, just like the `~file.truncate`
@@ -592,9 +621,11 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
         self._log(DEBUG, "truncate({!r}, {!r})".format(path, size))
         attr = SFTPAttributes()
         attr.st_size = size
-        self._request(CMD_SETSTAT, path, attr)
+        self._request(CMD_SETSTAT,
+                      path.decode("utf-8", errors).encode(encoding, errors),
+                      attr)
 
-    def readlink(self, path):
+    def readlink(self, path, encoding="utf8", errors="strict"):
         """
         Return the target of a symbolic link (shortcut).  You can use
         `symlink` to create these.  The result may be either an absolute or
@@ -605,7 +636,9 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
         """
         path = self._adjust_cwd(path)
         self._log(DEBUG, "readlink({!r})".format(path))
-        t, msg = self._request(CMD_READLINK, path)
+        t, msg = self._request(CMD_READLINK,
+                               path.decode("utf-8", errors)
+                               .encode(encoding, errors))
         if t != CMD_NAME:
             raise SFTPError("Expected name response")
         count = msg.get_int()
@@ -615,7 +648,7 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
             raise SFTPError("Readlink returned {} results".format(count))
         return _to_unicode(msg.get_string())
 
-    def normalize(self, path):
+    def normalize(self, path, encoding="utf8", errors="strict"):
         """
         Return the normalized path (on the server) of a given path.  This
         can be used to quickly resolve symbolic links or determine what the
@@ -629,15 +662,17 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
         """
         path = self._adjust_cwd(path)
         self._log(DEBUG, "normalize({!r})".format(path))
-        t, msg = self._request(CMD_REALPATH, path)
+        t, msg = self._request(CMD_REALPATH,
+                               path.decode("utf-8", errors)
+                               .encode(encoding, errors))
         if t != CMD_NAME:
             raise SFTPError("Expected name response")
         count = msg.get_int()
         if count != 1:
             raise SFTPError("Realpath returned {} results".format(count))
-        return msg.get_text()
+        return msg.get_text(encoding, errors)
 
-    def chdir(self, path=None):
+    def chdir(self, path=None, encoding="utf8", errors="strict"):
         """
         Change the "current directory" of this SFTP session.  Since SFTP
         doesn't really have the concept of a current working directory, this is
@@ -656,12 +691,12 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
         if path is None:
             self._cwd = None
             return
-        if not stat.S_ISDIR(self.stat(path).st_mode):
+        if not stat.S_ISDIR(self.stat(path, encoding, errors).st_mode):
             code = errno.ENOTDIR
             raise SFTPError(code, "{}: {}".format(os.strerror(code), path))
-        self._cwd = b(self.normalize(path))
+        self._cwd = b(self.normalize(path, encoding, errors))
 
-    def getcwd(self):
+    def getcwd(self, encoding="utf8", errors="strict"):
         """
         Return the "current working directory" for this SFTP session, as
         emulated by Paramiko.  If no directory has been set with `chdir`,
@@ -670,7 +705,7 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
         .. versionadded:: 1.4
         """
         # TODO: make class initialize with self._cwd set to self.normalize('.')
-        return self._cwd and u(self._cwd)
+        return self._cwd and u(self._cwd, encoding, errors)
 
     def _transfer_with_callback(self, reader, writer, file_size, callback):
         size = 0
@@ -684,7 +719,8 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
                 callback(size, file_size)
         return size
 
-    def putfo(self, fl, remotepath, file_size=0, callback=None, confirm=True):
+    def putfo(self, fl, remotepath, file_size=0, callback=None, confirm=True,
+              encoding="utf8", errors="strict"):
         """
         Copy the contents of an open file object (``fl``) to the SFTP server as
         ``remotepath``. Any exception raised by operations will be passed
@@ -711,13 +747,13 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
 
         .. versionadded:: 1.10
         """
-        with self.file(remotepath, "wb") as fr:
+        with self.file(remotepath, "wb", encoding=encoding, errors=errors) as fr:
             fr.set_pipelined(True)
             size = self._transfer_with_callback(
                 reader=fl, writer=fr, file_size=file_size, callback=callback
             )
         if confirm:
-            s = self.stat(remotepath)
+            s = self.stat(remotepath, encoding, errors)
             if s.st_size != size:
                 raise IOError(
                     "size mismatch in put!  {} != {}".format(s.st_size, size)
@@ -726,7 +762,8 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
             s = SFTPAttributes()
         return s
 
-    def put(self, localpath, remotepath, callback=None, confirm=True):
+    def put(self, localpath, remotepath, callback=None, confirm=True,
+            encoding="utf8", errors="strict"):
         """
         Copy a local file (``localpath``) to the SFTP server as ``remotepath``.
         Any exception raised by operations will be passed through.  This
@@ -756,9 +793,12 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
         """
         file_size = os.stat(localpath).st_size
         with open(localpath, "rb") as fl:
-            return self.putfo(fl, remotepath, file_size, callback, confirm)
+            return self.putfo(fl, remotepath,
+                              file_size, callback, confirm,
+                              encoding=encoding, errors=errors)
 
-    def getfo(self, remotepath, fl, callback=None, prefetch=True):
+    def getfo(self, remotepath, fl, callback=None, prefetch=True,
+              encoding="utf8", errors="strict"):
         """
         Copy a remote file (``remotepath``) from the SFTP server and write to
         an open file or file-like object, ``fl``.  Any exception raised by
@@ -779,15 +819,17 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
         .. versionchanged:: 2.8
             Added the ``prefetch`` keyword argument.
         """
-        file_size = self.stat(remotepath).st_size
-        with self.open(remotepath, "rb") as fr:
+        file_size = self.stat(remotepath, encoding, errors).st_size
+        with self.open(remotepath,
+                       "rb", encoding=encoding, errors=errors) as fr:
             if prefetch:
                 fr.prefetch(file_size)
             return self._transfer_with_callback(
                 reader=fr, writer=fl, file_size=file_size, callback=callback
             )
 
-    def get(self, remotepath, localpath, callback=None, prefetch=True):
+    def get(self, remotepath, localpath, callback=None, prefetch=True,
+            encoding="utf8", errors="strict"):
         """
         Copy a remote file (``remotepath``) from the SFTP server to the local
         host as ``localpath``.  Any exception raised by operations will be
@@ -808,7 +850,7 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
             Added the ``prefetch`` keyword argument.
         """
         with open(localpath, "wb") as fl:
-            size = self.getfo(remotepath, fl, callback, prefetch)
+            size = self.getfo(remotepath, fl, callback, prefetch, encoding, errors)
         s = os.stat(localpath)
         if s.st_size != size:
             raise IOError(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -46,7 +46,7 @@ def _decorate_with_locale(category, try_locales, test_method):
                 try_locales.pop(0)
             else:
                 try:
-                    return test_method(testself)
+                    return test_method(testself, sftp)
                 finally:
                     locale.setlocale(category, original)
         skipTest = getattr(testself, "skipTest", None)

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -162,6 +162,7 @@ class BufferedFileTest(unittest.TestCase):
         )
         f.close()
 
+    @needs_builtin("buffer")
     def test_buffering_writes(self):
         """
         verify that buffered objects can be written

--- a/tests/test_sftp.py
+++ b/tests/test_sftp.py
@@ -39,6 +39,7 @@ from paramiko.sftp_attr import SFTPAttributes
 
 from .util import needs_builtin
 from .util import slow
+from unittest import TestCase
 
 
 ARTICLE = """
@@ -277,7 +278,7 @@ class TestSFTP(object):
         sftp.open(sftp.FOLDER + "/canard.txt", "w").close()
         try:
             folder_contents = sftp.listdir(sftp.FOLDER)
-            self.assertEqual(["canard.txt"], folder_contents)
+            TestCase().assertEqual(["canard.txt"], folder_contents)
         finally:
             sftp.remove(sftp.FOLDER + "/canard.txt")
 
@@ -797,7 +798,7 @@ class TestSFTP(object):
         """Test SFTPAttributes under a locale with non-ascii time strings."""
         some_stat = os.stat(sftp.FOLDER)
         sftp_attributes = SFTPAttributes.from_stat(some_stat, u("a_directory"))
-        self.assertTrue(b"a_directory" in sftp_attributes.asbytes())
+        TestCase().assertTrue(b"a_directory" in sftp_attributes.asbytes())
 
     def test_sftp_attributes_empty_str(self, sftp):
         sftp_attributes = SFTPAttributes()


### PR DESCRIPTION
Continuation of original pull request #1716

Cloned the current main branch and added my function parameters. No much change. Fixed 2 failing tests too.

Optional parameters are "encoding" with default to utf8 and "errors" with default to "strict".

You could add a paramiko global or something to avoid the need to pass the encoding/errors parameters each time.

Best regards,
Hakaishi