### PR TITLE
don't throw exception when comparing PKey to non-PKey

### DIFF
--- a/paramiko/pkey.py
+++ b/paramiko/pkey.py
@@ -140,7 +140,7 @@ class PKey(object):
         return cmp(self.asbytes(), other.asbytes())  # noqa
 
     def __eq__(self, other):
-        return self._fields == other._fields
+        return isinstance(other, PKey) and self._fields == other._fields
 
     def __hash__(self):
         return hash(self._fields)

--- a/tests/test_pkey.py
+++ b/tests/test_pkey.py
@@ -626,6 +626,11 @@ class KeyTest(unittest.TestCase):
         for key1, key2 in self.keys():
             assert key1 == key2
 
+    def test_keys_are_not_equal_to_other(self):
+        for value in [None, True, ""]:
+            for key1, _ in self.keys():
+                assert key1 != value
+
     def test_keys_are_hashable(self):
         # NOTE: this isn't a great test due to hashseed randomization under
         # Python 3 preventing use of static values, but it does still prove


### PR DESCRIPTION
Fixes https://github.com/paramiko/paramiko/issues/2023