### PR TITLE
add newline before requires_sha1_signing definition

### DIFF
--- a/tests/util.py
+++ b/tests/util.py
@@ -172,6 +172,7 @@ def sha1_signing_unsupported():
     except UnsupportedAlgorithm as e:
         return e._reason is _Reasons.UNSUPPORTED_HASH
 
+
 requires_sha1_signing = unittest.skipIf(
     sha1_signing_unsupported(), "SHA-1 signing not supported"
 )


### PR DESCRIPTION
This should fix the CI failure related to style in `tests/util.py`