### PR TITLE
Prefer built-in unittest.mock over external package

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,7 +5,7 @@ pytest==4.4.2
 pytest-relaxed==1.1.5
 # pytest-xdist for test dir watching and the inv guard task
 pytest-xdist==1.28.0
-mock==2.0.0
+mock==2.0.0;python_version<"3.3"
 # Linting!
 flake8==3.8.3
 # Formatting!

--- a/tests/test_channelfile.py
+++ b/tests/test_channelfile.py
@@ -1,4 +1,7 @@
-from mock import patch, MagicMock
+try:
+    from unittest.mock import patch, MagicMock
+except ImportError:
+    from mock import patch, MagicMock
 
 from paramiko import Channel, ChannelFile, ChannelStderrFile, ChannelStdinFile
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -34,7 +34,10 @@ import weakref
 from tempfile import mkstemp
 
 from pytest_relaxed import raises
-from mock import patch, Mock
+try:
+    from unittest.mock import patch, Mock
+except ImportError:
+    from mock import patch, Mock
 
 import paramiko
 from paramiko import SSHClient

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -34,6 +34,7 @@ import weakref
 from tempfile import mkstemp
 
 from pytest_relaxed import raises
+
 try:
     from unittest.mock import patch, Mock
 except ImportError:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,7 +7,11 @@ from socket import gaierror
 from paramiko.py3compat import string_types
 
 from invoke import Result
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
+
 from pytest import raises, mark, fixture
 
 from paramiko import (

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,6 +7,7 @@ from socket import gaierror
 from paramiko.py3compat import string_types
 
 from invoke import Result
+
 try:
     from unittest.mock import patch
 except ImportError:

--- a/tests/test_kex.py
+++ b/tests/test_kex.py
@@ -24,7 +24,11 @@ from binascii import hexlify, unhexlify
 import os
 import unittest
 
-from mock import Mock, patch
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
+
 import pytest
 
 from cryptography.hazmat.backends import default_backend

--- a/tests/test_pkey.py
+++ b/tests/test_pkey.py
@@ -41,7 +41,12 @@ from paramiko.common import o600
 
 from cryptography.exceptions import UnsupportedAlgorithm
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateNumbers
-from mock import patch, Mock
+
+try:
+    from unittest.mock import patch, Mock
+except ImportError:
+    from mock import patch, Mock
+
 import pytest
 
 from .util import _support, is_low_entropy, requires_sha1_signing

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,7 +1,11 @@
 import signal
 import socket
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
+
 from pytest import raises
 
 from paramiko import ProxyCommand, ProxyCommandFailure

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -30,7 +30,11 @@ import time
 import threading
 import random
 import unittest
-from mock import Mock
+
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 from paramiko import (
     AuthHandler,


### PR DESCRIPTION
Prefer and use built-in unittest.mock in Python 3.3+ instead of unnecessarily requiring the external mock package. This helps distributions that are phasing out Python 2 to remove redundant packages.

This is based on #1666 by @mgorny and also addresses #2027.