### PR TITLE
Fixes #2045 Timeouts should be decided with a monotonic clock

### DIFF
--- a/paramiko/auth_handler.py
+++ b/paramiko/auth_handler.py
@@ -59,6 +59,7 @@ from paramiko.common import (
     MSG_USERAUTH_GSSAPI_MIC,
     MSG_NAMES,
     cMSG_USERAUTH_BANNER,
+    timer,
 )
 from paramiko.message import Message
 from paramiko.py3compat import b, u
@@ -234,7 +235,7 @@ class AuthHandler(object):
     def wait_for_response(self, event):
         max_ts = None
         if self.transport.auth_timeout is not None:
-            max_ts = time.time() + self.transport.auth_timeout
+            max_ts = timer() + self.transport.auth_timeout
         while True:
             event.wait(0.1)
             if not self.transport.is_active():
@@ -244,7 +245,7 @@ class AuthHandler(object):
                 raise e
             if event.is_set():
                 break
-            if max_ts is not None and max_ts <= time.time():
+            if max_ts is not None and max_ts <= timer():
                 raise AuthenticationException("Authentication timeout.")
 
         if not self.is_authenticated():

--- a/paramiko/buffered_pipe.py
+++ b/paramiko/buffered_pipe.py
@@ -25,6 +25,7 @@ read operations are blocking and can have a timeout set.
 import array
 import threading
 import time
+from paramiko.common import timer
 from paramiko.py3compat import PY2, b
 
 
@@ -156,10 +157,10 @@ class BufferedPipe(object):
                 # loop here in case we get woken up but a different thread has
                 # grabbed everything in the buffer.
                 while (len(self._buffer) == 0) and not self._closed:
-                    then = time.time()
+                    then = timer()
                     self._cv.wait(timeout)
                     if timeout is not None:
-                        timeout -= time.time() - then
+                        timeout -= timer() - then
                         if timeout <= 0.0:
                             raise PipeTimeout()
 

--- a/paramiko/channel.py
+++ b/paramiko/channel.py
@@ -41,6 +41,7 @@ from paramiko.common import (
     cMSG_CHANNEL_FAILURE,
     cMSG_CHANNEL_EOF,
     cMSG_CHANNEL_CLOSE,
+    timer
 )
 from paramiko.message import Message
 from paramiko.py3compat import bytes_types
@@ -1314,10 +1315,10 @@ class Channel(ClosingContextManager):
             while self.out_window_size == 0:
                 if self.closed or self.eof_sent:
                     return 0
-                then = time.time()
+                then = timer()
                 self.out_buffer_cv.wait(timeout)
                 if timeout is not None:
-                    timeout -= time.time() - then
+                    timeout -= timer() - then
                     if timeout <= 0.0:
                         raise socket.timeout()
         # we have some window to squeeze into

--- a/paramiko/common.py
+++ b/paramiko/common.py
@@ -21,6 +21,7 @@ Common constants and global variables.
 """
 import logging
 from paramiko.py3compat import byte_chr, PY2, long, b
+import time
 
 (
     MSG_DISCONNECT,
@@ -247,3 +248,6 @@ MIN_PACKET_SIZE = 2 ** 12
 
 # Max windows size according to http://www.ietf.org/rfc/rfc4254.txt
 MAX_WINDOW_SIZE = 2 ** 32 - 1
+
+# Monotonic clock for measuring durations and timeouts
+timer = time.time

--- a/paramiko/common.py
+++ b/paramiko/common.py
@@ -21,7 +21,7 @@ Common constants and global variables.
 """
 import logging
 from paramiko.py3compat import byte_chr, PY2, long, b
-import time
+import timeit
 
 (
     MSG_DISCONNECT,
@@ -250,4 +250,4 @@ MIN_PACKET_SIZE = 2 ** 12
 MAX_WINDOW_SIZE = 2 ** 32 - 1
 
 # Monotonic clock for measuring durations and timeouts
-timer = time.time
+timer = timeit.default_timer

--- a/paramiko/packet.py
+++ b/paramiko/packet.py
@@ -37,6 +37,7 @@ from paramiko.common import (
     DEBUG,
     xffffffff,
     zero_byte,
+    timer,
 )
 from paramiko.py3compat import u, byte_ord
 from paramiko.ssh_exception import SSHException, ProxyCommandFailure
@@ -119,7 +120,7 @@ class Packetizer(object):
 
         # keepalives:
         self.__keepalive_interval = 0
-        self.__keepalive_last = time.time()
+        self.__keepalive_last = timer()
         self.__keepalive_callback = None
 
         self.__timer = None
@@ -234,7 +235,7 @@ class Packetizer(object):
         """
         self.__keepalive_interval = interval
         self.__keepalive_callback = callback
-        self.__keepalive_last = time.time()
+        self.__keepalive_last = timer()
 
     def read_timer(self):
         self.__timer_expired = True
@@ -328,7 +329,7 @@ class Packetizer(object):
         return out
 
     def write_all(self, out):
-        self.__keepalive_last = time.time()
+        self.__keepalive_last = timer()
         iteration_with_zero_as_return_value = 0
         while len(out) > 0:
             retry_write = False
@@ -595,13 +596,13 @@ class Packetizer(object):
         ):
             # wait till we're encrypting, and not in the middle of rekeying
             return
-        now = time.time()
+        now = timer()
         if now > self.__keepalive_last + self.__keepalive_interval:
             self.__keepalive_callback()
             self.__keepalive_last = now
 
     def _read_timeout(self, timeout):
-        start = time.time()
+        start = timer()
         while True:
             try:
                 x = self.__socket.recv(128)
@@ -617,7 +618,7 @@ class Packetizer(object):
                     raise
             if self.__closed:
                 raise EOFError()
-            now = time.time()
+            now = timer()
             if now - start >= timeout:
                 raise socket.timeout()
         return x

--- a/paramiko/proxy.py
+++ b/paramiko/proxy.py
@@ -32,6 +32,7 @@ try:
 except ImportError as e:
     subprocess_import_error = e
 
+from paramiko.common import timer
 from paramiko.ssh_exception import ProxyCommandFailure
 from paramiko.util import ClosingContextManager
 
@@ -95,11 +96,11 @@ class ProxyCommand(ClosingContextManager):
         """
         try:
             buffer = b""
-            start = time.time()
+            start = timer()
             while len(buffer) < size:
                 select_timeout = None
                 if self.timeout is not None:
-                    elapsed = time.time() - start
+                    elapsed = timer() - start
                     if elapsed >= self.timeout:
                         raise socket.timeout()
                     select_timeout = self.timeout - elapsed

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -111,12 +111,12 @@ class TestProxyCommand(object):
         assert proxy.closed is True
         assert proxy._closed is True
 
-    @patch("paramiko.proxy.time.time")
+    @patch("paramiko.proxy.timer")
     @patch("paramiko.proxy.subprocess.Popen")
     @patch("paramiko.proxy.os.read")
     @patch("paramiko.proxy.select")
     def test_timeout_affects_whether_timeout_is_raised(
-        self, select, os_read, Popen, time
+        self, select, os_read, Popen, timer
     ):
         stdout = Popen.return_value.stdout
         select.return_value = [stdout], None, None
@@ -127,7 +127,7 @@ class TestProxyCommand(object):
         # Implicit 'no raise' check
         assert proxy.recv(3) == b"meh"
         # Use settimeout to set timeout, and it is honored
-        time.side_effect = [0, 10]  # elapsed > 7
+        timer.side_effect = [0, 10]  # elapsed > 7
         proxy = ProxyCommand("ohnoz")
         proxy.settimeout(7)
         assert proxy.timeout == 7


### PR DESCRIPTION
I've tried to retain Python 2.7 compatibility by using `timeit.default_timer` as the monotonic clock. If Python 2.7 support was not needed this change would be simpler.
