### PR TITLE
Sporadic exception when exiting with sys.exit

### DIFF
--- a/paramiko/file.py
+++ b/paramiko/file.py
@@ -58,7 +58,10 @@ class BufferedFile (ClosingContextManager):
         self._size = 0
 
     def __del__(self):
-        self.close()
+        try:
+            self.close()
+        except TypeError:
+            pass
         
     def __iter__(self):
         """


### PR DESCRIPTION
Sometimes when exiting there is a TypeError which
prints: Exception ignored in: <function BufferedFile.__del__ at ...>
TypeError: 'NoneType' object is not callable
Add a try/except statement to silence the output

Fix: #1078