### PR TITLE
kexinit - use same kex algorithms as in security_options

### DIFF
--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -2261,12 +2261,12 @@ class Transport(threading.Thread, ClosingContextManager):
             if (self._modulus_pack is None) and (len(kex_mp) > 0):
                 # can't do group-exchange if we don't have a pack of potential
                 # primes
-                pkex = [
+                kex_algos = [
                     k
                     for k in self.get_security_options().kex
                     if not k.startswith(mp_required_prefix)
                 ]
-                self.get_security_options().kex = pkex
+                self.get_security_options().kex = kex_algos
             available_server_keys = list(
                 filter(
                     list(self.server_key_dict.keys()).__contains__,
@@ -2287,7 +2287,8 @@ class Transport(threading.Thread, ClosingContextManager):
             # NOTE: doing this here handily means we don't even consider this
             # value when agreeing on real kex algo to use (which is a common
             # pitfall when adding this apparently).
-            kex_algos.append("ext-info-c")
+            if "ext-info-c" not in kex_algos:
+                kex_algos.append("ext-info-c")
 
         # Similar to ext-info, but used in both server modes, so done outside
         # of above if/else.


### PR DESCRIPTION
**Send modified kex algorithm list to client:**

I had problems with some ssh implementations like MobaXterm (https://github.com/ssh-mitm/ssh-mitm/issues/95) wich is based on SecureBlackbox.

When testing MobaXterm with paramiko versions < 2.9 it works without any problems. Due to the changes introduced in paramiko 2.10 which adds compatibility for OpenSSH 8.9 and the deprecated ssh-rsa algorithms, connections from MobaXterm wont work anymore.

After some tests with the kex algorithms I found out, that the algorithm list is modified and set for the security options. The unmodified list is sent to the client.

The list sent to the client includes "diffie-hellman-group-exchange-sha1" and "diffie-hellman-group-exchange-sha256" but not the list which is stored in the securiry options. (see https://datatracker.ietf.org/doc/html/rfc4419)

If MobaXterm wants to connect, the server raises an error because of an unsupported algorithm.

I have tested the changes with against the OpenSSH 8.9 client. Using this client the "diffie-hellman-group-exchange-sha*" algorithms are used.

Using the modified list with MobaXterm does not include the "diffie-hellman-group-exchange-sha*" algorithms and the client can connect without any problems.

**Only add "ext-info-c" if not present**

The second change checks if "ext-info-c" is already in the kex_algos list and only adds it, if it is not present: https://datatracker.ietf.org/doc/html/draft-ssh-ext-info-04#section-2.1

> The indicator name is added without quotes, and MAY be added at any position in the name-list,...