### PR TITLE
add 3 (0+1+2) seconds retry

### DIFF
--- a/paramiko/packet.py
+++ b/paramiko/packet.py
@@ -604,10 +604,13 @@ class Packetizer(object):
         start = time.time()
         while True:
             try:
-                x = self.__socket.recv(128)
-                if len(x) == 0:
-                    raise EOFError()
-                break
+                for i in range(2):
+                    time.sleep(i)
+                    x = self.__socket.recv(128)
+                    if len(x) == 0:
+                        continue
+                    else:
+                        break
             except socket.timeout:
                 pass
             except EnvironmentError as e:


### PR DESCRIPTION
This is to handle slow connections (especially in the context of a honeypot or dodgy network).

I kept receiving this error:
![image](https://user-images.githubusercontent.com/42625905/179472727-aab1cd9a-4499-4ed5-b61b-8201a9062bba.png)

After some poking around online I couldn't find an issue so I looked through the code near the stack trace, found the _read_timeout where I saw the socket receiving with NO delay. I added an increasing delay and it fixed the problem.

Pushing this so it doesn't inconvenience people in the future as it took me a bit to work out.

**NOTE**: This applies to the server. I have not tested this with the client.