### PR TITLE
Improve exception message when connection closed while reading protocol banner

### DIFF
--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -2271,9 +2271,13 @@ class Transport(threading.Thread, ClosingContextManager):
                 buf = self.packetizer.readline(timeout)
             except ProxyCommandFailure:
                 raise
+            except EOFError:
+                raise SSHException(
+                    "Connection closed by remote host while reading SSH protocol banner"  # noqa
+                )
             except Exception as e:
                 raise SSHException(
-                    "Error reading SSH protocol banner" + str(e)
+                    "Error reading SSH protocol banner: " + str(e)
                 )
             if buf[:4] == "SSH-":
                 break

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+- :bug:`2063` Improve `SSHException` message when a connection is closed by
+  the server during the SSH banner phase, for example due to OpenSSH rejecting
+  connections due to a ``MaxStartups`` setting. This allows distinguishing between
+  connectivity issues and other errors. Patch courtesy of ``@jun66j5``.
 - :bug:`1822` (via, and relating to, far too many other issues to mention here)
   Update `~paramiko.client.SSHClient` so it explicitly closes its wrapped
   socket object upon encountering socket errors at connection time. This should


### PR DESCRIPTION
Now with added changelog entry.

Fixes #2063, closes #2063.