### PR TITLE
add `Ed25519Key.generate()` and drop requirement of nacl

### DIFF
--- a/paramiko/ed25519key.py
+++ b/paramiko/ed25519key.py
@@ -15,16 +15,24 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA.
 
 import bcrypt
-
+from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric import ed25519
 from cryptography.hazmat.primitives.ciphers import Cipher
-
-import nacl.signing
 
 from paramiko.message import Message
 from paramiko.pkey import PKey, OPENSSH_AUTH_MAGIC, _unpad_openssh
-from paramiko.util import b
 from paramiko.ssh_exception import SSHException, PasswordRequiredException
+from paramiko.util import b
+
+
+def public_bytes_raw(verify_key):
+    try:
+        # for cryptography>=40.0, new API enabled
+        return verify_key.public_bytes_raw()
+    except AttributeError:
+        # for backward support
+        return verify_key._raw_public_bytes()
 
 
 class Ed25519Key(PKey):
@@ -42,7 +50,13 @@ class Ed25519Key(PKey):
     name = "ssh-ed25519"
 
     def __init__(
-        self, msg=None, data=None, filename=None, password=None, file_obj=None
+        self,
+        msg=None,
+        data=None,
+        filename=None,
+        password=None,
+        file_obj=None,
+        vals=None,
     ):
         self.public_blob = None
         verifying_key = signing_key = None
@@ -54,7 +68,11 @@ class Ed25519Key(PKey):
                 key_type=self.name,
                 cert_type="ssh-ed25519-cert-v01@openssh.com",
             )
-            verifying_key = nacl.signing.VerifyKey(msg.get_binary())
+            verifying_key = ed25519.Ed25519PublicKey.from_public_bytes(
+                msg.get_binary()
+            )
+        elif vals:
+            signing_key, verifying_key = vals
         elif filename is not None:
             with open(filename, "r") as f:
                 pkformat, data = self._read_private_key("OPENSSH", f)
@@ -68,7 +86,7 @@ class Ed25519Key(PKey):
             raise ValueError("need a key")
 
         self._signing_key = signing_key
-        self._verifying_key = verifying_key
+        self._verifying_key = verifying_key or signing_key.public_key()
 
     def _parse_signing_key_data(self, data, password):
         from paramiko.transport import Transport
@@ -150,10 +168,13 @@ class Ed25519Key(PKey):
             key_data = message.get_binary()
             # The second half of the key data is yet another copy of the public
             # key...
-            signing_key = nacl.signing.SigningKey(key_data[:32])
+            signing_key = ed25519.Ed25519PrivateKey.from_private_bytes(
+                key_data[:32]
+            )
             # Verify that all the public keys are the same...
+            # noinspection PyTypeChecker
             assert (
-                signing_key.verify_key.encode()
+                public_bytes_raw(signing_key.public_key())
                 == public
                 == public_keys[i]
                 == key_data[32:]
@@ -166,23 +187,30 @@ class Ed25519Key(PKey):
             raise SSHException("Invalid key")
         return signing_keys[0]
 
+    @classmethod
+    def generate(cls):
+        """
+        Generate a new private Ed25519 key.
+        This factory function can be used to generate
+        a new host key or authentication key.
+
+        :returns: A new private key (`.Ed25519Key`) object
+        """
+        private_key = ed25519.Ed25519PrivateKey.generate()
+        return Ed25519Key(vals=(private_key, private_key.public_key()))
+
     def asbytes(self):
-        if self.can_sign():
-            v = self._signing_key.verify_key
-        else:
-            v = self._verifying_key
         m = Message()
         m.add_string(self.name)
-        m.add_string(v.encode())
+        m.add_string(public_bytes_raw(self._verifying_key))
         return m.asbytes()
 
     @property
     def _fields(self):
-        if self.can_sign():
-            v = self._signing_key.verify_key
-        else:
-            v = self._verifying_key
-        return (self.get_name(), v)
+        return (
+            self.get_name(),
+            public_bytes_raw(self._verifying_key),
+        )
 
     # TODO 4.0: remove
     def get_name(self):
@@ -197,7 +225,7 @@ class Ed25519Key(PKey):
     def sign_ssh_data(self, data, algorithm=None):
         m = Message()
         m.add_string(self.name)
-        m.add_string(self._signing_key.sign(data).signature)
+        m.add_string(self._signing_key.sign(data))
         return m
 
     def verify_ssh_sig(self, data, msg):
@@ -205,8 +233,8 @@ class Ed25519Key(PKey):
             return False
 
         try:
-            self._verifying_key.verify(data, msg.get_binary())
-        except nacl.exceptions.BadSignatureError:
+            self._verifying_key.verify(msg.get_binary(), data)
+        except InvalidSignature:
             return False
         else:
             return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ dependencies = [
   "bcrypt>=3.2",
   "cryptography>=3.3",
   "invoke>=2.0",
-  "pynacl>=1.5",
 ]
 optional-dependencies = { gssapi = [
   "pyasn1>=0.1.7",

--- a/sites/www/installing.rst
+++ b/sites/www/installing.rst
@@ -23,8 +23,7 @@ Paramiko has only a few **direct dependencies**:
 
 - The big one, with its own sub-dependencies, is Cryptography; see :ref:`its
   specific note below <cryptography>` for more details;
-- `bcrypt <https://pypi.org/project/bcrypt/>`_ and `pynacl
-  <https://pypi.org/project/PyNaCl/>`_ for Ed25519 key support.
+- `bcrypt <https://pypi.org/project/bcrypt/>`_ for Ed25519 key support.
 
 There are also a handful of **optional dependencies** you may install using
 `setuptools 'extras'


### PR DESCRIPTION
note: cryptography>=2.6 has ed25519 support, so maybe we can boost the version requirement to 2.6 for merge test?