### PR TITLE
Tweak disabled_algorithms instrux in changelog

### DIFF
--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -143,9 +143,10 @@ Changelog
     required if your target systems do not support either RSA2 or the
     ``server-sig-algs`` protocol extension.
 
-    Specifically, you need to specify one or both of ``disabled_algorithms={'keys':
-    ['rsa-sha2-256', 'rsa-sha2-512']}`` or ``disabled_algorithms={'pubkeys':
-    ['rsa-sha2-256', 'rsa-sha2-512']}``in either `SSHClient
+    Specifically, you need to specify one or both of ``'keys':
+    ['rsa-sha2-256', 'rsa-sha2-512']`` or ``'pubkeys':
+    ['rsa-sha2-256', 'rsa-sha2-512']`` as items in a ``dict`` passed to
+    the ``disabled_algorithms`` argument of either `SSHClient
     <paramiko.client.SSHClient.__init__>` or `Transport
     <paramiko.transport.Transport.__init__>`. See below for details on why.
 

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -143,8 +143,9 @@ Changelog
     required if your target systems do not support either RSA2 or the
     ``server-sig-algs`` protocol extension.
 
-    Specifically, you need to specify ``disabled_algorithms={'keys':
-    ['rsa-sha2-256', 'rsa-sha2-512']}`` in either `SSHClient
+    Specifically, you need to specify one or both of ``disabled_algorithms={'keys':
+    ['rsa-sha2-256', 'rsa-sha2-512']}`` or ``disabled_algorithms={'pubkeys':
+    ['rsa-sha2-256', 'rsa-sha2-512']}``in either `SSHClient
     <paramiko.client.SSHClient.__init__>` or `Transport
     <paramiko.transport.Transport.__init__>`. See below for details on why.
 


### PR DESCRIPTION
Some use cases need `pubkeys` declared in `disabled_algorithms`,
instead of (or in addition to) `keys`, and this should be
highlighted at the top of the changelog entry for visibility.