### PR TITLE
Speed up SFTP transfer speed

### DIFF
--- a/paramiko/py3compat.py
+++ b/paramiko/py3compat.py
@@ -63,7 +63,7 @@ if PY2:
         elif isinstance(s, buffer):  # NOQA
             return s
         else:
-            raise TypeError("Expected unicode or bytes, got {!r}".format(s))
+            raise TypeError("Expected unicode or bytes, got {}".format(type(s)))
 
     def u(s, encoding="utf8"):  # NOQA
         """cast bytes or unicode to unicode"""
@@ -74,7 +74,7 @@ if PY2:
         elif isinstance(s, buffer):  # NOQA
             return s.decode(encoding)
         else:
-            raise TypeError("Expected unicode or bytes, got {!r}".format(s))
+            raise TypeError("Expected unicode or bytes, got {}".format(type(s)))
 
     def b2s(s):
         return s
@@ -153,7 +153,7 @@ else:
         elif isinstance(s, str):
             return s.encode(encoding)
         else:
-            raise TypeError("Expected unicode or bytes, got {!r}".format(s))
+            raise TypeError("Expected unicode or bytes, got {}".format(type(s)))
 
     def u(s, encoding="utf8"):
         """cast bytes or unicode to unicode"""
@@ -162,7 +162,7 @@ else:
         elif isinstance(s, str):
             return s
         else:
-            raise TypeError("Expected unicode or bytes, got {!r}".format(s))
+            raise TypeError("Expected unicode or bytes, got {}".format(type(s)))
 
     def b2s(s):
         return s.decode() if isinstance(s, bytes) else s


### PR DESCRIPTION
Speed up SFTP transfer speed by remove unnecessary `__repr__` function calls.


My test code:
```python
from time import time
from io import BytesIO

from paramiko.client import AutoAddPolicy, SSHClient

def main() -> None:
    # create fileobj to transfer
    file_obj = BytesIO()
    file_obj.seek(4 * 1024 * 1024 * 1024 - 1)
    file_obj.write(b"1")
    file_obj.seek(0)

    ssh_client = SSHClient()
    ssh_client.set_missing_host_key_policy(AutoAddPolicy())
    ssh_client.connect(hostname="<hostname>", username="<username>", password="<password>", compress=True)
    
    sftp_client = ssh_client.open_sftp()

    start_time = time()
    sftp_client.putfo(file_obj, "/dev/shm/chunk.bin")

    print(f"{time() - start_time}s")


if __name__ == "__main__":
    main()
```

before: 
cost 111.59725689888s
![20220827055031](https://user-images.githubusercontent.com/15361117/186995462-cee9cec0-cdbd-4086-b290-0e9cb612b836.png)

after:
cost 42.47094106674194s
![20220827055318](https://user-images.githubusercontent.com/15361117/186995712-a7464eb5-19b6-4b29-a664-d5fb3f6438ea.png)

