### PR TITLE
Add Transport factory to SSHClient.connect

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -237,6 +237,7 @@ class SSHClient(ClosingContextManager):
         gss_trust_dns=True,
         passphrase=None,
         disabled_algorithms=None,
+        transport_factory=Transport,
     ):
         """
         Connect to an SSH server and authenticate to it.  The server's host key
@@ -314,6 +315,10 @@ class SSHClient(ClosingContextManager):
         :param dict disabled_algorithms:
             an optional dict passed directly to `.Transport` and its keyword
             argument of the same name.
+        :param transport_factory: an optional callable that takes in a new `socket`
+            `gss_kex`, `gss_deleg_creds`, `disabled_algorithms` and generates a
+            `.Transport` instance to be used by this client. Defaults to
+            `.Transport.__init__`.
 
         :raises:
             `.BadHostKeyException` -- if the server's host key could not be
@@ -371,7 +376,7 @@ class SSHClient(ClosingContextManager):
             if len(errors) == len(to_try):
                 raise NoValidConnectionsError(errors)
 
-        t = self._transport = Transport(
+        t = self._transport = transport_factory(
             sock,
             gss_kex=gss_kex,
             gss_deleg_creds=gss_deleg_creds,


### PR DESCRIPTION
Adds a transport_factory argument to `SSHClient.connect` that allows you to dynamically generate a Transport instance without, and therefore modify inner connection parameters before a connection gets established.

This should address some of the issues in #2054 with minial changes to the API and no changes to Transport while allowing for arbitrary control over Transports API.

An example of how to use this:

```python
def make_transport(sock, *args, **kwargs) -> Transport:
    t = Transport(sock, *args, **kwargs)
    o = t.get_security_options()
    o.ciphers = ('aes256-cbc',)  # only allow aes256-cbc
    return t

client = SSHClient()
client.connect("example.com", transport_factory=make_transport)

```

Given this, it's probably a good idea to deprecate the args to `SSHClient.connect` that just get passed to `Transport`, as they make this a bit more awkward to deal with (ie. we wouldn't need `*args` and `**kwargs`).