### PR TITLE
Use WaitForSingleObject() for ProxyCommand instead of select() on Windows

### DIFF
--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,4 +1,3 @@
-import signal
 import socket
 
 from mock import patch
@@ -95,11 +94,10 @@ class TestProxyCommand(object):
         assert info.value.error == "whoops"
 
     @patch("paramiko.proxy.subprocess.Popen")
-    @patch("paramiko.proxy.os.kill")
-    def test_close_kills_subprocess(self, os_kill, Popen):
+    def test_close_kills_subprocess(self, Popen):
         proxy = ProxyCommand("hi")
         proxy.close()
-        os_kill.assert_called_once_with(Popen.return_value.pid, signal.SIGTERM)
+        Popen.return_value.terminate.assert_called_once_with()
 
     @patch("paramiko.proxy.subprocess.Popen")
     def test_closed_exposes_whether_subprocess_has_exited(self, Popen):


### PR DESCRIPTION
Proposed fix for #512.

`select()` with non-socket objects doesn't work on Windows, but `WaitForSingleObject()` is able to wait for stdout of ProxyCommand.