### PR TITLE
Fix exception handling when another exception already occurred.

### DIFF
--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -2271,6 +2271,8 @@ class Transport(threading.Thread, ClosingContextManager):
                 buf = self.packetizer.readline(timeout)
             except ProxyCommandFailure:
                 raise
+            except ConnectionResetError:
+                raise
             except Exception as e:
                 raise SSHException(
                     "Error reading SSH protocol banner" + str(e)


### PR DESCRIPTION
SSH script will exit with the following error "During handling of the above exception, another exception occurred", when we try to ssh from host A into a host B that has record of A in hosts.deny.

