### PR TITLE
Use unittest.mock for Python => 3.3

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,7 +5,7 @@ pytest==4.4.2
 pytest-relaxed==1.1.5
 # pytest-xdist for test dir watching and the inv guard task
 pytest-xdist==1.28.0
-mock==2.0.0
+mock==2.0.0; python_version < '3.3'
 # Linting!
 flake8==3.8.3
 # Formatting!

--- a/tests/test_channelfile.py
+++ b/tests/test_channelfile.py
@@ -1,4 +1,7 @@
-from mock import patch, MagicMock
+try:
+    from mock import patch, MagicMock
+except ImportError:
+    from unittest.mock import patch, MagicMock
 
 from paramiko import Channel, ChannelFile, ChannelStderrFile, ChannelStdinFile
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -35,7 +35,10 @@ from tempfile import mkstemp
 
 import pytest
 from pytest_relaxed import raises
-from mock import patch, Mock
+try:
+    from mock import patch, Mock
+except ImportError:
+    from unittest.mock import patch, Mock
 
 import paramiko
 from paramiko import SSHClient

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,7 +11,10 @@ try:
 except ImportError:
     Result = None
 
-from mock import patch
+try:
+    from mock import patch
+except ImportError:
+    from unittest.mock import patch
 from pytest import raises, mark, fixture
 
 from paramiko import (

--- a/tests/test_kex.py
+++ b/tests/test_kex.py
@@ -24,7 +24,10 @@ from binascii import hexlify, unhexlify
 import os
 import unittest
 
-from mock import Mock, patch
+try:
+    from mock import Mock, patch
+except ImportError:
+    from unittest.mock import Mock, patch
 import pytest
 
 from cryptography.hazmat.backends import default_backend

--- a/tests/test_pkey.py
+++ b/tests/test_pkey.py
@@ -41,7 +41,10 @@ from paramiko.common import o600
 
 from cryptography.exceptions import UnsupportedAlgorithm
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateNumbers
-from mock import patch, Mock
+try:
+    from mock import patch, Mock
+except ImportError:
+    from unittest.mock import patch, Mock
 import pytest
 
 from .util import _support, is_low_entropy, requires_sha1_signing

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,7 +1,10 @@
 import signal
 import socket
 
-from mock import patch
+try:
+    from mock import patch
+except ImportError:
+    from unittest.mock import patch
 from pytest import raises
 
 from paramiko import ProxyCommand, ProxyCommandFailure

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -30,7 +30,10 @@ import time
 import threading
 import random
 import unittest
-from mock import Mock
+try:
+    from mock import Mock
+except ImportError:
+    from unittest.mock import Mock
 
 from paramiko import (
     AuthHandler,


### PR DESCRIPTION
Since Python 3.3 unittest.mock has been included in Python itself and it's no longer required to use an external module.