### PR TITLE
update pins to support python 3.10, add to test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ workflows:
           requires: ["Test"]
           matrix:
             parameters:
-              version: ["3.7", "3.8", "3.9"]
+              version: ["3.7", "3.8", "3.9", "3.10"]
       # Test doc building if main test suite passed (no real reason to spend
       # all those credits if the main tests would also fail...)
       - orb/docs:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,10 +1,17 @@
 # Invocations for common project tasks
 invoke==1.6.0
 invocations==2.6.0
-pytest==4.4.2
-pytest-relaxed==1.1.5
+# Pinning has some disadvantages when testing across multiple Python versions
+# 3.6 specific pins
+pytest==4.4.2;python_version=='3.6'
+pytest-relaxed==1.1.5;python_version=='3.6'
 # pytest-xdist for test dir watching and the inv guard task
-pytest-xdist==1.28.0
+pytest-xdist==1.28.0;python_version=='3.6'
+# 3.7+ specific
+pytest==7.2.0;python_version>='3.7'
+pytest-xdist==3.1.0;python_version>='3.7'
+pytest-relaxed==2.0.0;python_version>='3.7'
+
 mock==2.0.0
 # Linting!
 flake8==3.8.3


### PR DESCRIPTION
This is a minimally invasive fix to get py310 testing going. py311 will require https://github.com/pyinvoke/invoke/commit/406a45e854f6e8df4aa0de01e3b731fea2b1f1ec to be in the next invoke release, sorry @bitprophet 😄 