### PR TITLE
Check that the requested user matches the user from krb5 token

### DIFF
--- a/paramiko/ssh_gss.py
+++ b/paramiko/ssh_gss.py
@@ -123,6 +123,7 @@ class _SSH_GSSAuth(object):
         self._gss_deleg_creds = gss_deleg_creds
         self._gss_host = None
         self._username = None
+        self._username_from_krb5_token = None
         self._session_id = None
         self._service = "ssh-connection"
         """
@@ -542,6 +543,9 @@ class _SSH_GSSAPI_NEW(_SSH_GSSAuth):
         if self._gss_srv_ctxt is None:
             self._gss_srv_ctxt = gssapi.SecurityContext(usage="accept")
         token = self._gss_srv_ctxt.step(recv_token)
+        self._username_from_krb5_token = str(self._gss_srv_ctxt.initiator_name).split('@')[0]
+        if self._username != self._username_from_krb5_token:
+            raise SSHException("Requested username does not match user from krb5 ticket")
         self._gss_srv_ctxt_status = self._gss_srv_ctxt.complete
         return token
 


### PR DESCRIPTION
So I was trying to write a custom SSH server off of paramiko, which is when we realized that paramiko just simply trusts the __username__ whenever gssapi auth is used. The idea behind this PR is to compare the provided username with the initiator-name in the client provided token. Though I am not a 100% sure if this is a general enough fix. It just splices on '@' and takes the first element in the array.  I am well aware of the disclaimer given in the Server documentation, https://docs.paramiko.org/en/stable/api/server.html#paramiko.server.ServerInterface.check_auth_gssapi_with_mic
 but I was wondering if paramiko should (or could even , _in the general sense_) incorporate this check?