### PR TITLE
replace `except:` with `except Exception:`

### DIFF
--- a/demos/demo.py
+++ b/demos/demo.py
@@ -182,6 +182,6 @@ except Exception as e:
     traceback.print_exc()
     try:
         t.close()
-    except:
+    except Exception:
         pass
     sys.exit(1)

--- a/demos/demo_server.py
+++ b/demos/demo_server.py
@@ -141,7 +141,7 @@ try:
     t.set_gss_host(socket.getfqdn(""))
     try:
         t.load_server_moduli()
-    except:
+    except Exception:
         print("(Failed to load moduli -- gex will be unsupported.)")
         raise
     t.add_server_key(host_key)
@@ -180,6 +180,6 @@ except Exception as e:
     traceback.print_exc()
     try:
         t.close()
-    except:
+    except Exception:
         pass
     sys.exit(1)

--- a/demos/demo_sftp.py
+++ b/demos/demo_sftp.py
@@ -138,6 +138,6 @@ except Exception as e:
     traceback.print_exc()
     try:
         t.close()
-    except:
+    except Exception:
         pass
     sys.exit(1)

--- a/demos/demo_simple.py
+++ b/demos/demo_simple.py
@@ -111,6 +111,6 @@ except Exception as e:
     traceback.print_exc()
     try:
         client.close()
-    except:
+    except Exception:
         pass
     sys.exit(1)

--- a/paramiko/agent.py
+++ b/paramiko/agent.py
@@ -132,7 +132,7 @@ class AgentProxyThread(threading.Thread):
             ):
                 raise AuthenticationException("Unable to connect to SSH agent")
             self._communicate()
-        except:
+        except Exception:
             # XXX Not sure what to do here ... raise or pass ?
             raise
 
@@ -187,7 +187,7 @@ class AgentLocalProxy(AgentProxyThread):
             conn.listen(1)
             (r, addr) = conn.accept()
             return r, addr
-        except:
+        except Exception:
             raise
 
 
@@ -215,7 +215,7 @@ def get_agent_connection():
         try:
             conn.connect(os.environ["SSH_AUTH_SOCK"])
             return conn
-        except:
+        except Exception:
             # probably a dangling env var: the ssh agent is gone
             return
     elif sys.platform == "win32":

--- a/paramiko/channel.py
+++ b/paramiko/channel.py
@@ -136,7 +136,7 @@ class Channel(ClosingContextManager):
     def __del__(self):
         try:
             self.close()
-        except:
+        except Exception:
             pass
 
     def __repr__(self):

--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -357,7 +357,7 @@ class SSHClient(ClosingContextManager):
                     if timeout is not None:
                         try:
                             sock.settimeout(timeout)
-                        except:
+                        except Exception:
                             pass
                     sock.connect(addr)
                     # Break out of the loop on success

--- a/paramiko/pkey.py
+++ b/paramiko/pkey.py
@@ -373,7 +373,7 @@ class PKey:
             )
         try:
             encryption_type, saltstr = headers["dek-info"].split(",")
-        except:
+        except Exception:
             raise SSHException("Can't parse DEK-info in private key file")
         if encryption_type not in self._CIPHER_TABLE:
             raise SSHException(

--- a/paramiko/primes.py
+++ b/paramiko/primes.py
@@ -118,7 +118,7 @@ class ModulusPack:
                     continue
                 try:
                     self._parse_modulus(line)
-                except:
+                except Exception:
                     continue
 
     def get_modulus(self, min, prefer, max):

--- a/paramiko/server.py
+++ b/paramiko/server.py
@@ -690,7 +690,7 @@ class SubsystemHandler(threading.Thread):
             self.__transport._log(ERROR, util.tb_strings())
         try:
             self.finish_subsystem()
-        except:
+        except Exception:
             pass
 
     def start_subsystem(self, name, transport, channel):

--- a/paramiko/sftp_file.py
+++ b/paramiko/sftp_file.py
@@ -519,7 +519,7 @@ class SFTPFile(BufferedFile):
     def _get_size(self):
         try:
             return self.stat().st_size
-        except:
+        except Exception:
             return 0
 
     def _start_prefetch(self, chunks):

--- a/paramiko/sftp_server.py
+++ b/paramiko/sftp_server.py
@@ -158,7 +158,7 @@ class SFTPServer(BaseSFTP, SubsystemHandler):
                 # send some kind of failure message, at least
                 try:
                     self._send_status(request_number, SFTP_FAILURE)
-                except:
+                except Exception:
                     pass
 
     def finish_subsystem(self):

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -2221,7 +2221,7 @@ class Transport(threading.Thread, ClosingContextManager):
                 finally:
                     self.lock.release()
             self.sock.close()
-        except:
+        except Exception:
             # Don't raise spurious 'NoneType has no attribute X' errors when we
             # wake up during interpreter shutdown. Or rather -- raise
             # everything *if* sys.modules (used as a convenient sentinel)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -155,7 +155,7 @@ class AuthTest(unittest.TestCase):
                 password="error",
             )
             self.assertTrue(False)
-        except:
+        except Exception:
             etype, evalue, etb = sys.exc_info()
             self.assertEqual(BadAuthenticationType, etype)
             self.assertEqual(["publickey"], evalue.allowed_types)
@@ -170,7 +170,7 @@ class AuthTest(unittest.TestCase):
         try:
             self.tc.auth_password(username="slowdive", password="error")
             self.assertTrue(False)
-        except:
+        except Exception:
             etype, evalue, etb = sys.exc_info()
             self.assertTrue(issubclass(etype, AuthenticationException))
         self.tc.auth_password(username="slowdive", password="pygmalion")
@@ -251,7 +251,7 @@ class AuthTest(unittest.TestCase):
         self.tc.connect(hostkey=self.public_host_key)
         try:
             self.tc.auth_password("bad-server", "hello")
-        except:
+        except Exception:
             etype, evalue, etb = sys.exc_info()
             self.assertTrue(issubclass(etype, AuthenticationException))
 
@@ -266,7 +266,7 @@ class AuthTest(unittest.TestCase):
         self.tc.connect()
         try:
             self.tc.auth_password("unresponsive-server", "hello")
-        except:
+        except Exception:
             etype, evalue, etb = sys.exc_info()
             self.assertTrue(issubclass(etype, AuthenticationException))
             self.assertTrue("Authentication timeout" in str(evalue))

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -56,7 +56,7 @@ class BufferedFileTest(unittest.TestCase):
         try:
             f.write(b"hi")
             self.assertTrue(False, "no exception on write to read-only file")
-        except:
+        except Exception:
             pass
         f.close()
 
@@ -64,7 +64,7 @@ class BufferedFileTest(unittest.TestCase):
         try:
             f.read(1)
             self.assertTrue(False, "no exception to read from write-only file")
-        except:
+        except Exception:
             pass
         f.close()
 

--- a/tests/test_kex_gss.py
+++ b/tests/test_kex_gss.py
@@ -85,7 +85,7 @@ class GSSKexTest(KerberosTestCase):
         self.ts.set_gss_host(self.realm.hostname)
         try:
             self.ts.load_server_moduli()
-        except:
+        except Exception:
             print("(Failed to load moduli -- gex will be unsupported.)")
         server = NullServer()
         self.ts.start_server(self.event, server)

--- a/tests/test_sftp.py
+++ b/tests/test_sftp.py
@@ -182,11 +182,11 @@ class TestSFTP:
             # -f' a-like, jeez
             try:
                 sftp.remove(sftp.FOLDER + "/first.txt")
-            except:
+            except Exception:
                 pass
             try:
                 sftp.remove(sftp.FOLDER + "/second.txt")
-            except:
+            except Exception:
                 pass
 
     def testa_posix_rename(self, sftp):
@@ -211,11 +211,11 @@ class TestSFTP:
         finally:
             try:
                 sftp.remove(sftp.FOLDER + "/a")
-            except:
+            except Exception:
                 pass
             try:
                 sftp.remove(sftp.FOLDER + "/b")
-            except:
+            except Exception:
                 pass
 
     def test_folder(self, sftp):
@@ -442,15 +442,15 @@ class TestSFTP:
         finally:
             try:
                 sftp.remove(sftp.FOLDER + "/link.txt")
-            except:
+            except Exception:
                 pass
             try:
                 sftp.remove(sftp.FOLDER + "/link2.txt")
-            except:
+            except Exception:
                 pass
             try:
                 sftp.remove(sftp.FOLDER + "/original.txt")
-            except:
+            except Exception:
                 pass
 
     def test_flush_seek(self, sftp):
@@ -470,7 +470,7 @@ class TestSFTP:
         finally:
             try:
                 sftp.remove(sftp.FOLDER + "/happy.txt")
-            except:
+            except Exception:
                 pass
 
     def test_realpath(self, sftp):
@@ -520,15 +520,15 @@ class TestSFTP:
             sftp.chdir(root)
             try:
                 sftp.unlink(sftp.FOLDER + "/alpha/beta/fish")
-            except:
+            except Exception:
                 pass
             try:
                 sftp.rmdir(sftp.FOLDER + "/alpha/beta")
-            except:
+            except Exception:
                 pass
             try:
                 sftp.rmdir(sftp.FOLDER + "/alpha")
-            except:
+            except Exception:
                 pass
 
     def test_get_put(self, sftp):
@@ -719,7 +719,7 @@ class TestSFTP:
             sftp.chdir(root)
             try:
                 sftp.rmdir(sftp.FOLDER + "/alpha")
-            except:
+            except Exception:
                 pass
 
     def test_seek_append(self, sftp):

--- a/tests/test_sftp_big.py
+++ b/tests/test_sftp_big.py
@@ -59,7 +59,7 @@ class TestBigSFTP:
             for i in range(numfiles):
                 try:
                     sftp.remove(f"{sftp.FOLDER}/file{i}.txt")
-                except:
+                except Exception:
                     pass
 
     def test_big_file(self, sftp):


### PR DESCRIPTION
The difference is that `except Exception:` will not catch `SystemExit`, `KeyboardInterrupt` and `GeneratorExit`. Usually these exceptions (especially `KeyboardInterrupt`) should not be caught.