### PR TITLE
ProxyCommand leaves open pipes (Issue #1715)

### DIFF
--- a/paramiko/proxy.py
+++ b/paramiko/proxy.py
@@ -106,9 +106,7 @@ class ProxyCommand(ClosingContextManager):
 
                 r, w, x = select([self.process.stdout], [], [], select_timeout)
                 if r and r[0] == self.process.stdout:
-                    buffer += os.read(
-                        self.process.stdout.fileno(), size - len(buffer)
-                    )
+                    buffer += os.read(self.process.stdout.fileno(), size - len(buffer))
             return buffer
         except socket.timeout:
             if buffer:
@@ -119,7 +117,11 @@ class ProxyCommand(ClosingContextManager):
             raise ProxyCommandFailure(" ".join(self.cmd), e.strerror)
 
     def close(self):
-        os.kill(self.process.pid, signal.SIGTERM)
+        self.process.stdin.close()
+        self.process.stdout.close()
+        self.process.stderr.close()
+        self.process.terminate()
+        self.process.wait()
 
     @property
     def closed(self):


### PR DESCRIPTION
Followup issue #1715 and issue #1713 
ProxyCommand.close does not close stdin, stdout and stderr which leaves 3 open pipes after each connection. Eventually this results in OSError: Too many files open. I suggest the following fix (taking into account the suggested fix for issue https://github.com/paramiko/paramiko/issues/1713)

Suggested Fixes tested and working (over several thousand of devices).

**Before Fix:**
filedescriptor out of range in select() error message after 200-300 SSH connections through a proxy SSH.

After Running Python script (get running config on device)
Filedescriptor Exception raised after 200/300 Devices, Scripts exited with error but Open Pipes remain opened): 

lsof | grep "python" | grep "pipe" | awk '{print $2}' | wc -l shows a very high number of open pipe connexion:

```
root@b3894971d232:/opt# lsof | grep "python" | grep "pipe" | awk '{print $2}' | wc -l
66921
```

Relaunching the same script raises immediately the Fildescriptor Exception (Open Pipes consumes too many Open Files reaching ulimit for bad reason)

**After Fix:**
Same Script runs without Filedescription Exception.
After exiting the script, the lsof comman does normal open pipes number.

```
root@b3894971d232:/opt# lsof | grep "python" | grep "pipe" | awk '{print $2}' | wc -l 
5429
```



