### PR TITLE
added timeout in transport connect function

### DIFF
--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -1278,7 +1278,7 @@ class Transport(threading.Thread, ClosingContextManager):
         gss_kex=False,
         gss_deleg_creds=True,
         gss_trust_dns=True,
-        timeout = None,
+        timeout=None,
     ):
         """
         Negotiate an SSH2 session, and optionally verify the server's host key

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -1278,6 +1278,7 @@ class Transport(threading.Thread, ClosingContextManager):
         gss_kex=False,
         gss_deleg_creds=True,
         gss_trust_dns=True,
+        timeout = None,
     ):
         """
         Negotiate an SSH2 session, and optionally verify the server's host key
@@ -1346,7 +1347,7 @@ class Transport(threading.Thread, ClosingContextManager):
             gssapi_requested=gss_kex or gss_auth,
         )
 
-        self.start_client()
+        self.start_client(timeout=timeout)
 
         # check host key if we were given one
         # If GSS-API Key Exchange was performed, we are not required to check


### PR DESCRIPTION
I added timeout when making ssh connect with transport class 
is actually because pysftp which is wrapper around the paramiko uses the transport class for making initial connection.