### PR TITLE
Allow addition of HostKeyEntrys to HostKeys

### DIFF
--- a/paramiko/hostkeys.py
+++ b/paramiko/hostkeys.py
@@ -72,6 +72,21 @@ class HostKeys(MutableMapping):
                 e.key = key
                 return
         self._entries.append(HostKeyEntry([hostname], key))
+        
+    def add_host_key_entry(self, hostkeyentry):
+        """
+        Add a host key entry to the table from a host key entry.
+        This will remove any hostnames that overlap with existing hosts
+        before adding the entry.
+        
+        :param HostKeyEntry hostkeyentry: the host key entry to add
+        """
+        _hostnames = hostkeyentry.hostnames
+        for h in _hostnames:
+            if self.check(h, hostkeyentry.key):
+                hostkeyentry.hostnames.remove(h)
+        if len(hostkeyentry.hostnames) > 0:
+           self._entries.append(hostkeyentry)        
 
     def load(self, filename):
         """
@@ -98,12 +113,7 @@ class HostKeys(MutableMapping):
                 except SSHException:
                     continue
                 if e is not None:
-                    _hostnames = e.hostnames
-                    for h in _hostnames:
-                        if self.check(h, e.key):
-                            e.hostnames.remove(h)
-                    if len(e.hostnames):
-                        self._entries.append(e)
+                    self.add_host_key_entry(e)
 
     def save(self, filename):
         """


### PR DESCRIPTION
To address #1134.

This also allows users to add their own file parsing behaviour. For example if the user wishes to ignore lines that raise `InvalidHostKeyError`s .
