### PR TITLE
Don't use functions from nonexistent py3compat module in demos.

### DIFF
--- a/demos/demo.py
+++ b/demos/demo.py
@@ -28,7 +28,6 @@ import socket
 import sys
 import time
 import traceback
-from paramiko.py3compat import input
 
 import paramiko
 
@@ -61,9 +60,7 @@ def agent_auth(transport, username):
 
 def manual_auth(username, hostname):
     default_auth = "p"
-    auth = input(
-        "Auth by (p)assword, (r)sa key, or (d)ss key? [%s] " % default_auth
-    )
+    auth = input("Auth by (p)assword, (r)sa key, or (d)ss key? [%s] " % default_auth)
     if len(auth) == 0:
         auth = default_auth
 
@@ -130,14 +127,10 @@ try:
         sys.exit(1)
 
     try:
-        keys = paramiko.util.load_host_keys(
-            os.path.expanduser("~/.ssh/known_hosts")
-        )
+        keys = paramiko.util.load_host_keys(os.path.expanduser("~/.ssh/known_hosts"))
     except IOError:
         try:
-            keys = paramiko.util.load_host_keys(
-                os.path.expanduser("~/ssh/known_hosts")
-            )
+            keys = paramiko.util.load_host_keys(os.path.expanduser("~/ssh/known_hosts"))
         except IOError:
             print("*** Unable to open host keys file")
             keys = {}

--- a/demos/demo_keygen.py
+++ b/demos/demo_keygen.py
@@ -26,7 +26,6 @@ from optparse import OptionParser
 from paramiko import DSSKey
 from paramiko import RSAKey
 from paramiko.ssh_exception import SSHException
-from paramiko.py3compat import u
 
 usage = """
 %prog [-v] [-b bits] -t type [-N new_passphrase] [-f output_keyfile]"""
@@ -144,9 +143,7 @@ if __name__ == "__main__":
         raise SSHException("DSA Keys must be 1024 bits")
 
     if ktype not in key_dispatch_table:
-        raise SSHException(
-            "Unknown %s algorithm to generate keys pair" % ktype
-        )
+        raise SSHException("Unknown %s algorithm to generate keys pair" % ktype)
 
     # generating private key
     prv = key_dispatch_table[ktype].generate(bits=bits, progress_func=pfunc)
@@ -162,7 +159,7 @@ if __name__ == "__main__":
     if options.verbose:
         print("done.")
 
-    hash = u(hexlify(pub.get_fingerprint()))
+    hash = hexlify(pub.get_fingerprint()).decode()
     print(
         "Fingerprint: %d %s %s.pub (%s)"
         % (

--- a/demos/demo_server.py
+++ b/demos/demo_server.py
@@ -27,7 +27,6 @@ import threading
 import traceback
 
 import paramiko
-from paramiko.py3compat import b, u, decodebytes
 
 
 # setup logging
@@ -36,7 +35,7 @@ paramiko.util.log_to_file("demo_server.log")
 host_key = paramiko.RSAKey(filename="test_rsa.key")
 # host_key = paramiko.DSSKey(filename='test_dss.key')
 
-print("Read key: " + u(hexlify(host_key.get_fingerprint())))
+print("Read key: " + hexlify(host_key.get_fingerprint()).decode())
 
 
 class Server(paramiko.ServerInterface):
@@ -48,7 +47,7 @@ class Server(paramiko.ServerInterface):
         b"KDqIexkgHAfID/6mqvmnSJf0b5W8v5h2pI/stOSwTQ+pxVhwJ9ctYDhRSlF0iT"
         b"UWT10hcuO4Ks8="
     )
-    good_pub_key = paramiko.RSAKey(data=decodebytes(data))
+    good_pub_key = paramiko.RSAKey(data=base64.decodebytes(data))
 
     def __init__(self):
         self.event = threading.Event()
@@ -64,7 +63,7 @@ class Server(paramiko.ServerInterface):
         return paramiko.AUTH_FAILED
 
     def check_auth_publickey(self, username, key):
-        print("Auth attempt with key: " + u(hexlify(key.get_fingerprint())))
+        print("Auth attempt with key: " + hexlify(key.get_fingerprint()).decode())
         if (username == "robey") and (key == self.good_pub_key):
             return paramiko.AUTH_SUCCESSFUL
         return paramiko.AUTH_FAILED
@@ -165,9 +164,7 @@ try:
         sys.exit(1)
 
     chan.send("\r\n\r\nWelcome to my dorky little BBS!\r\n\r\n")
-    chan.send(
-        "We are on fire all the time!  Hooray!  Candy corn for everyone!\r\n"
-    )
+    chan.send("We are on fire all the time!  Hooray!  Candy corn for everyone!\r\n")
     chan.send("Happy birthday to Robot Dave!\r\n\r\n")
     chan.send("Username: ")
     f = chan.makefile("rU")

--- a/demos/demo_sftp.py
+++ b/demos/demo_sftp.py
@@ -28,7 +28,6 @@ import sys
 import traceback
 
 import paramiko
-from paramiko.py3compat import input
 
 
 # setup logging
@@ -72,9 +71,7 @@ else:
 hostkeytype = None
 hostkey = None
 try:
-    host_keys = paramiko.util.load_host_keys(
-        os.path.expanduser("~/.ssh/known_hosts")
-    )
+    host_keys = paramiko.util.load_host_keys(os.path.expanduser("~/.ssh/known_hosts"))
 except IOError:
     try:
         # try ~/ssh/ too, because windows can't have a folder named ~/.ssh/

--- a/demos/demo_simple.py
+++ b/demos/demo_simple.py
@@ -25,7 +25,6 @@ import os
 import socket
 import sys
 import traceback
-from paramiko.py3compat import input
 
 import paramiko
 
@@ -94,9 +93,7 @@ try:
             )
         except Exception:
             # traceback.print_exc()
-            password = getpass.getpass(
-                "Password for %s@%s: " % (username, hostname)
-            )
+            password = getpass.getpass("Password for %s@%s: " % (username, hostname))
             client.connect(hostname, port, username, password)
 
     chan = client.invoke_shell()

--- a/demos/forward.py
+++ b/demos/forward.py
@@ -163,8 +163,7 @@ def parse_options():
         type="string",
         dest="user",
         default=getpass.getuser(),
-        help="username for SSH authentication (default: %s)"
-        % getpass.getuser(),
+        help="username for SSH authentication (default: %s)" % getpass.getuser(),
     )
     parser.add_option(
         "-K",
@@ -240,14 +239,11 @@ def main():
         sys.exit(1)
 
     verbose(
-        "Now forwarding port %d to %s:%d ..."
-        % (options.port, remote[0], remote[1])
+        "Now forwarding port %d to %s:%d ..." % (options.port, remote[0], remote[1])
     )
 
     try:
-        forward_tunnel(
-            options.port, remote[0], remote[1], client.get_transport()
-        )
+        forward_tunnel(options.port, remote[0], remote[1], client.get_transport())
     except KeyboardInterrupt:
         print("C-c: Port forwarding stopped.")
         sys.exit(0)

--- a/demos/interactive.py
+++ b/demos/interactive.py
@@ -19,7 +19,6 @@
 
 import socket
 import sys
-from paramiko.py3compat import u
 
 # windows does not have termios...
 try:
@@ -51,7 +50,7 @@ def posix_shell(chan):
             r, w, e = select.select([chan, sys.stdin], [], [])
             if chan in r:
                 try:
-                    x = u(chan.recv(1024))
+                    x = chan.recv(1024).decode()
                     if len(x) == 0:
                         sys.stdout.write("\r\n*** EOF\r\n")
                         break

--- a/demos/rforward.py
+++ b/demos/rforward.py
@@ -77,9 +77,7 @@ def reverse_forward_tunnel(server_port, remote_host, remote_port, transport):
         chan = transport.accept(1000)
         if chan is None:
             continue
-        thr = threading.Thread(
-            target=handler, args=(chan, remote_host, remote_port)
-        )
+        thr = threading.Thread(target=handler, args=(chan, remote_host, remote_port))
         thr.setDaemon(True)
         thr.start()
 
@@ -136,8 +134,7 @@ def parse_options():
         type="string",
         dest="user",
         default=getpass.getuser(),
-        help="username for SSH authentication (default: %s)"
-        % getpass.getuser(),
+        help="username for SSH authentication (default: %s)" % getpass.getuser(),
     )
     parser.add_option(
         "-K",


### PR DESCRIPTION
Due to the removal of `py3compat.py`, some demos stopped working correctly.

This PR replaces the missing functions with alternatives, such as `bytes.decode()` instead of `u()`, or `base64.decodebytes()` in place of `py3compat.decodebytes()`.

I also formatted the files using black.