### PR TITLE
Use assertEqual instead of assertEquals for Python 3.12 compatibility.

### DIFF
--- a/tests/test_gssapi.py
+++ b/tests/test_gssapi.py
@@ -54,7 +54,7 @@ class GSSAPITest(KerberosTestCase):
 
         oid = encoder.encode(ObjectIdentifier(self.krb5_mech))
         mech, __ = decoder.decode(oid)
-        self.assertEquals(self.krb5_mech, mech.__str__())
+        self.assertEqual(self.krb5_mech, mech.__str__())
 
     def _gssapi_sspi_test(self):
         """
@@ -107,16 +107,16 @@ class GSSAPITest(KerberosTestCase):
             if self.server_mode:
                 c_token = gss_ctxt.step(c_token)
                 gss_ctxt_status = gss_ctxt.established
-                self.assertEquals(False, gss_ctxt_status)
+                self.assertEqual(False, gss_ctxt_status)
                 # Accept a GSS-API context.
                 gss_srv_ctxt = gssapi.AcceptContext()
                 s_token = gss_srv_ctxt.step(c_token)
                 gss_ctxt_status = gss_srv_ctxt.established
                 self.assertNotEquals(None, s_token)
-                self.assertEquals(True, gss_ctxt_status)
+                self.assertEqual(True, gss_ctxt_status)
                 # Establish the client context
                 c_token = gss_ctxt.step(s_token)
-                self.assertEquals(None, c_token)
+                self.assertEqual(None, c_token)
             else:
                 while not gss_ctxt.established:
                     c_token = gss_ctxt.step(c_token)
@@ -127,7 +127,7 @@ class GSSAPITest(KerberosTestCase):
             if self.server_mode:
                 # Check MIC
                 status = gss_srv_ctxt.verify_mic(mic_msg, mic_token)
-                self.assertEquals(0, status)
+                self.assertEqual(0, status)
         elif _API == "PYTHON-GSSAPI-NEW":
             if self.server_mode:
                 gss_flags = (
@@ -157,16 +157,16 @@ class GSSAPITest(KerberosTestCase):
             if self.server_mode:
                 c_token = gss_ctxt.step(c_token)
                 gss_ctxt_status = gss_ctxt.complete
-                self.assertEquals(False, gss_ctxt_status)
+                self.assertEqual(False, gss_ctxt_status)
                 # Accept a GSS-API context.
                 gss_srv_ctxt = gssapi.SecurityContext(usage="accept")
                 s_token = gss_srv_ctxt.step(c_token)
                 gss_ctxt_status = gss_srv_ctxt.complete
                 self.assertNotEquals(None, s_token)
-                self.assertEquals(True, gss_ctxt_status)
+                self.assertEqual(True, gss_ctxt_status)
                 # Establish the client context
                 c_token = gss_ctxt.step(s_token)
-                self.assertEquals(None, c_token)
+                self.assertEqual(None, c_token)
             else:
                 while not gss_ctxt.complete:
                     c_token = gss_ctxt.step(c_token)
@@ -177,7 +177,7 @@ class GSSAPITest(KerberosTestCase):
             if self.server_mode:
                 # Check MIC
                 status = gss_srv_ctxt.verify_signature(mic_msg, mic_token)
-                self.assertEquals(0, status)
+                self.assertEqual(0, status)
         else:
             gss_flags = (
                 sspicon.ISC_REQ_INTEGRITY
@@ -192,7 +192,7 @@ class GSSAPITest(KerberosTestCase):
             if self.server_mode:
                 error, token = gss_ctxt.authorize(c_token)
                 c_token = token[0].Buffer
-                self.assertEquals(0, error)
+                self.assertEqual(0, error)
                 # Accept a GSS-API context.
                 gss_srv_ctxt = sspi.ServerAuth("Kerberos", spn=target_name)
                 error, token = gss_srv_ctxt.authorize(c_token)
@@ -200,8 +200,8 @@ class GSSAPITest(KerberosTestCase):
                 # Establish the context.
                 error, token = gss_ctxt.authorize(s_token)
                 c_token = token[0].Buffer
-                self.assertEquals(None, c_token)
-                self.assertEquals(0, error)
+                self.assertEqual(None, c_token)
+                self.assertEqual(0, error)
                 # Build MIC
                 mic_token = gss_ctxt.sign(mic_msg)
                 # Check MIC

--- a/tests/test_gssapi.py
+++ b/tests/test_gssapi.py
@@ -112,7 +112,7 @@ class GSSAPITest(KerberosTestCase):
                 gss_srv_ctxt = gssapi.AcceptContext()
                 s_token = gss_srv_ctxt.step(c_token)
                 gss_ctxt_status = gss_srv_ctxt.established
-                self.assertNotEquals(None, s_token)
+                self.assertNotEqual(None, s_token)
                 self.assertEqual(True, gss_ctxt_status)
                 # Establish the client context
                 c_token = gss_ctxt.step(s_token)
@@ -120,7 +120,7 @@ class GSSAPITest(KerberosTestCase):
             else:
                 while not gss_ctxt.established:
                     c_token = gss_ctxt.step(c_token)
-                self.assertNotEquals(None, c_token)
+                self.assertNotEqual(None, c_token)
             # Build MIC
             mic_token = gss_ctxt.get_mic(mic_msg)
 
@@ -162,7 +162,7 @@ class GSSAPITest(KerberosTestCase):
                 gss_srv_ctxt = gssapi.SecurityContext(usage="accept")
                 s_token = gss_srv_ctxt.step(c_token)
                 gss_ctxt_status = gss_srv_ctxt.complete
-                self.assertNotEquals(None, s_token)
+                self.assertNotEqual(None, s_token)
                 self.assertEqual(True, gss_ctxt_status)
                 # Establish the client context
                 c_token = gss_ctxt.step(s_token)
@@ -170,7 +170,7 @@ class GSSAPITest(KerberosTestCase):
             else:
                 while not gss_ctxt.complete:
                     c_token = gss_ctxt.step(c_token)
-                self.assertNotEquals(None, c_token)
+                self.assertNotEqual(None, c_token)
             # Build MIC
             mic_token = gss_ctxt.get_signature(mic_msg)
 
@@ -209,7 +209,7 @@ class GSSAPITest(KerberosTestCase):
             else:
                 error, token = gss_ctxt.authorize(c_token)
                 c_token = token[0].Buffer
-                self.assertNotEquals(0, error)
+                self.assertNotEqual(0, error)
 
     def test_gssapi_sspi_client(self):
         """

--- a/tests/test_kex_gss.py
+++ b/tests/test_kex_gss.py
@@ -115,9 +115,9 @@ class GSSKexTest(KerberosTestCase):
         self.event.wait(1.0)
         self.assert_(self.event.is_set())
         self.assert_(self.ts.is_active())
-        self.assertEquals(self.username, self.ts.get_username())
-        self.assertEquals(True, self.ts.is_authenticated())
-        self.assertEquals(True, self.tc.get_transport().gss_kex_used)
+        self.assertEqual(self.username, self.ts.get_username())
+        self.assertEqual(True, self.ts.is_authenticated())
+        self.assertEqual(True, self.tc.get_transport().gss_kex_used)
 
         stdin, stdout, stderr = self.tc.exec_command("yes")
         schan = self.ts.accept(1.0)
@@ -128,10 +128,10 @@ class GSSKexTest(KerberosTestCase):
         schan.send_stderr("This is on stderr.\n")
         schan.close()
 
-        self.assertEquals("Hello there.\n", stdout.readline())
-        self.assertEquals("", stdout.readline())
-        self.assertEquals("This is on stderr.\n", stderr.readline())
-        self.assertEquals("", stderr.readline())
+        self.assertEqual("Hello there.\n", stdout.readline())
+        self.assertEqual("", stdout.readline())
+        self.assertEqual("This is on stderr.\n", stderr.readline())
+        self.assertEqual("", stderr.readline())
 
         stdin.close()
         stdout.close()

--- a/tests/test_ssh_gss.py
+++ b/tests/test_ssh_gss.py
@@ -120,8 +120,8 @@ class GSSAuthTest(KerberosTestCase):
         self.event.wait(1.0)
         self.assert_(self.event.is_set())
         self.assert_(self.ts.is_active())
-        self.assertEquals(self.username, self.ts.get_username())
-        self.assertEquals(True, self.ts.is_authenticated())
+        self.assertEqual(self.username, self.ts.get_username())
+        self.assertEqual(True, self.ts.is_authenticated())
 
         stdin, stdout, stderr = self.tc.exec_command("yes")
         schan = self.ts.accept(1.0)
@@ -130,10 +130,10 @@ class GSSAuthTest(KerberosTestCase):
         schan.send_stderr("This is on stderr.\n")
         schan.close()
 
-        self.assertEquals("Hello there.\n", stdout.readline())
-        self.assertEquals("", stdout.readline())
-        self.assertEquals("This is on stderr.\n", stderr.readline())
-        self.assertEquals("", stderr.readline())
+        self.assertEqual("Hello there.\n", stdout.readline())
+        self.assertEqual("", stdout.readline())
+        self.assertEqual("This is on stderr.\n", stderr.readline())
+        self.assertEqual("", stderr.readline())
 
         stdin.close()
         stdout.close()


### PR DESCRIPTION
https://docs.python.org/3.12/whatsnew/3.12.html#removed . This method was removed in Python 3.12