### PR TITLE
Adding flexibility for weird SSH servers

### DIFF
--- a/paramiko/auth_handler.py
+++ b/paramiko/auth_handler.py
@@ -738,7 +738,11 @@ Error Message: {}
             self._log(INFO, "Authentication continues...")
             self._log(DEBUG, "Methods: " + str(authlist))
             self.transport.saved_exception = PartialAuthentication(authlist)
-        elif self.auth_method not in authlist:
+        # 'none' is never listed as supported, not the reason for the failure
+        elif (
+            self.auth_method not in authlist 
+            and self.auth_method is not "none" 
+        ):
             for msg in (
                 "Authentication type ({}) not permitted.".format(
                     self.auth_method

--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -238,6 +238,7 @@ class SSHClient(ClosingContextManager):
         passphrase=None,
         disabled_algorithms=None,
         transport_factory=None,
+        resend_service_requests=True,
     ):
         """
         Connect to an SSH server and authenticate to it.  The server's host key
@@ -323,6 +324,10 @@ class SSHClient(ClosingContextManager):
             functionality, and algorithm selection) and generates a
             `.Transport` instance to be used by this client. Defaults to
             `.Transport.__init__`.
+        :param bool resend_service_requests:
+            ``False`` if you want to prevent Paramiko from sending other
+            service requests after the server has already accepted one
+            for this service.
 
         :raises BadHostKeyException:
             if the server's host key could not be verified.
@@ -394,6 +399,7 @@ class SSHClient(ClosingContextManager):
             gss_kex=gss_kex,
             gss_deleg_creds=gss_deleg_creds,
             disabled_algorithms=disabled_algorithms,
+            resend_service_requests=resend_service_requests,
         )
         t.use_compression(compress=compress)
         t.set_gss_host(

--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -239,6 +239,7 @@ class SSHClient(ClosingContextManager):
         disabled_algorithms=None,
         transport_factory=None,
         resend_service_requests=True,
+        start_with_auth_none=False,
     ):
         """
         Connect to an SSH server and authenticate to it.  The server's host key
@@ -328,6 +329,9 @@ class SSHClient(ClosingContextManager):
             ``False`` if you want to prevent Paramiko from sending other
             service requests after the server has already accepted one
             for this service.
+        :param bool start_with_auth_none:
+            ```True`` if you want to send an authentication request with
+            the 'none' method before trying other authentication methods.
 
         :raises BadHostKeyException:
             if the server's host key could not be verified.
@@ -474,6 +478,7 @@ class SSHClient(ClosingContextManager):
             gss_deleg_creds,
             t.gss_host,
             passphrase,
+            start_with_auth_none,
         )
 
     def close(self):
@@ -642,10 +647,11 @@ class SSHClient(ClosingContextManager):
         gss_deleg_creds,
         gss_host,
         passphrase,
+        start_with_auth_none,
     ):
         """
         Try, in order:
-
+            - None method if start_with_auth_none is True
             - The key(s) passed in, if one was passed in.
             - Any key we can find through an SSH agent (if allowed).
             - Any "id_rsa", "id_dsa" or "id_ecdsa" key discoverable in ~/.ssh/
@@ -662,6 +668,13 @@ class SSHClient(ClosingContextManager):
         two_factor_types = {"keyboard-interactive", "password"}
         if passphrase is None and password is not None:
             passphrase = password
+
+        if start_with_auth_none:
+            try:
+                self._transport.auth_none(username)
+                return
+            except SSHException as e:
+                saved_exception = e
 
         # If GSS-API support and GSS-PI Key Exchange was performed, we attempt
         # authentication with gssapi-keyex.

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -332,6 +332,7 @@ class Transport(threading.Thread, ClosingContextManager):
         gss_deleg_creds=True,
         disabled_algorithms=None,
         server_sig_algs=True,
+        resend_service_requests=True,
     ):
         """
         Create a new SSH session over an existing socket, or socket-like
@@ -398,6 +399,10 @@ class Transport(threading.Thread, ClosingContextManager):
             Whether to send an extra message to compatible clients, in server
             mode, with a list of supported pubkey algorithms. Default:
             ``True``.
+        :param bool resend_service_requests:
+            ``False`` if you want to prevent Paramiko from sending other
+            service requests after the server has already accepted one
+            for this service.
 
         .. versionchanged:: 1.15
             Added the ``default_window_size`` and ``default_max_packet_size``
@@ -520,6 +525,9 @@ class Transport(threading.Thread, ClosingContextManager):
         self.channel_timeout = 60 * 60
         self.disabled_algorithms = disabled_algorithms or {}
         self.server_sig_algs = server_sig_algs
+        self.resend_service_requests = resend_service_requests
+        # which services have been accepted by the server
+        self.accepted_services = set()
 
         # server mode:
         self.server_mode = False

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -764,7 +764,7 @@ class SSHClientTest(ClientTest):
 
     @patch("paramiko.client.Transport")
     def test_transport_factory_defaults_to_Transport(self, Transport):
-        sock, kex, creds, algos = Mock(), Mock(), Mock(), Mock()
+        sock, kex, creds, algos, resend = Mock(), Mock(), Mock(), Mock(), Mock()
         SSHClient().connect(
             "host",
             sock=sock,
@@ -772,15 +772,16 @@ class SSHClientTest(ClientTest):
             gss_kex=kex,
             gss_deleg_creds=creds,
             disabled_algorithms=algos,
+            resend_service_requests=resend,
         )
         Transport.assert_called_once_with(
-            sock, gss_kex=kex, gss_deleg_creds=creds, disabled_algorithms=algos
+            sock, gss_kex=kex, gss_deleg_creds=creds, disabled_algorithms=algos, resend_service_requests=resend
         )
 
     @patch("paramiko.client.Transport")
     def test_transport_factory_may_be_specified(self, Transport):
         factory = Mock()
-        sock, kex, creds, algos = Mock(), Mock(), Mock(), Mock()
+        sock, kex, creds, algos, resend = Mock(), Mock(), Mock(), Mock(), Mock()
         SSHClient().connect(
             "host",
             sock=sock,
@@ -789,9 +790,10 @@ class SSHClientTest(ClientTest):
             gss_deleg_creds=creds,
             disabled_algorithms=algos,
             transport_factory=factory,
+            resend_service_requests=resend,
         )
         factory.assert_called_once_with(
-            sock, gss_kex=kex, gss_deleg_creds=creds, disabled_algorithms=algos
+            sock, gss_kex=kex, gss_deleg_creds=creds, disabled_algorithms=algos, resend_service_requests=resend
         )
         # Safety check
         assert not Transport.called


### PR DESCRIPTION
The purpose of this PR is to add flexibility through options for the client. I actually have a Nokia network device that needs these two new options to be compatible with Paramiko.

The `start_with_auth_none` option adds tolerance to SSH servers that consistently respond with an `SSH_MSG_USERAUTH_FAILURE` message on the first `SSH_MSG_USERAUTH_REQUEST` attempt.

The `resend_service_requests` option forces Paramiko not to resend service requests after it has already received an accept message from the server for that service. The RFCs are not precise on this point, and some SSH servers close the connection after receiving a second message for the same service.

These two options, if enabled, are very similar to the way the OpenSSH client works, which always sends a first authentication attempt `'none'` and does not send back a request to open a service if it has already been accepted.