### PR TITLE
Remove codecov dependency

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -13,7 +13,6 @@ black>=22.8,<22.9
 codespell>=2.2,<2.3
 # Coverage!
 coverage>=6.2,<7
-codecov==2.1.12
 # Documentation tools
 alabaster==0.7.13
 releases>=2.1


### PR DESCRIPTION
They deleted their package from PyPI, see https://about.codecov.io/blog/message-regarding-the-pypi-package/. I don't see any actual usage of the package.