### PR TITLE
Spelling error change from "Sesch" to "Secsh". Issue #2146

### DIFF
--- a/paramiko/channel.py
+++ b/paramiko/channel.py
@@ -1021,7 +1021,7 @@ class Channel(ClosingContextManager):
         )
 
     def _request_success(self, m):
-        self._log(DEBUG, "Sesch channel {} request ok".format(self.chanid))
+        self._log(DEBUG, "Secsh channel {} request ok".format(self.chanid))
         self.event_ready = True
         self.event.set()
         return


### PR DESCRIPTION
After looking around on stack overflow and through the rest of the Paramiko source code I was able to find that Secure Shell Channel is being referred to as 'Secsh' not 'Sesch'. 