### PR TITLE
Suppress superfluous exception reporting using PEP409

### DIFF
--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -2295,7 +2295,7 @@ class Transport(threading.Thread, ClosingContextManager):
             except Exception as e:
                 raise SSHException(
                     "Error reading SSH protocol banner" + str(e)
-                )
+                ) from None
             if buf[:4] == "SSH-":
                 break
             self._log(DEBUG, "Banner: " + buf)


### PR DESCRIPTION
I observed the following behavior when connecting to an embedded device. The SSH server is started but random other tasks slow down the whole system. Then the current behavior is:

    $ python3
    >>> import paramiko
    >>> s = paramiko.SSHClient()
    >>> s.set_missing_host_key_policy(paramiko.AutoAddPolicy())
    >>> s.connect("192.168.8.53", port=9000, username="root", password="superhero", timeout=2, allow_agent=False, look_for_keys=False)
    >>> Exception: Error reading SSH protocol banner
    Traceback (most recent call last):
      File "/usr/local/lib/python3.6/dist-packages/paramiko/transport.py", line 2044, in _check_banner
        buf = self.packetizer.readline(timeout)
      File "/usr/local/lib/python3.6/dist-packages/paramiko/packet.py", line 353, in readline
        buf += self._read_timeout(timeout)
      File "/usr/local/lib/python3.6/dist-packages/paramiko/packet.py", line 555, in _read_timeout
        raise socket.timeout()
    socket.timeout

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "/usr/local/lib/python3.6/dist-packages/paramiko/transport.py", line 1893, in run
        self._check_banner()
      File "/usr/local/lib/python3.6/dist-packages/paramiko/transport.py", line 2049, in _check_banner
        'Error reading SSH protocol banner' + str(e)
    paramiko.ssh_exception.SSHException: Error reading SSH protocol banner

Note: the code above triggers also a "No existing session" exception which I filtered out here to focus on my point.

The expected exception is SSHException("Error reading SSH protocol banner"). However, catching it in the calling program still prints the above to the console. In my eyes, reporting the socket.timeout stuff is not wanted since it is entirely covered by the "catchall" except clause and the intension is to replace all such exceptions with the new SSHException.
For this PEP409 [1] is implemented since Python 3.3 [2], so let's use it here.

After this fix, the same procedure looks like:

    >>> s.connect("192.168.8.53", port=9000, username="root", password="superhero", timeout=2, allow_agent=False, look_for_keys=False)
    >>> Exception: Error reading SSH protocol banner
    Traceback (most recent call last):
      File "/usr/local/lib/python3.6/dist-packages/paramiko/transport.py", line 1893, in run
        self._check_banner()
      File "/usr/local/lib/python3.6/dist-packages/paramiko/transport.py", line 2050, in _check_banner
        ) from None
    paramiko.ssh_exception.SSHException: Error reading SSH protocol banner

Now, the calling program can catch the exception without any printout to the console anymore.

[1] https://peps.python.org/pep-0409/
[2] https://docs.python.org/3/whatsnew/3.3.html