### PR TITLE
Switch debug logging in `client.py` to use `key.fingerprint`

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -640,7 +640,7 @@ class SSHClient(ClosingContextManager):
         # when #387 is released, since this is a critical log message users are
         # likely testing/filtering for (bah.)
         msg = "Trying discovered key {} in {}".format(
-            hexlify(key.get_fingerprint()), key_path
+            hexlify(key.fingerprint), key_path
         )
         self._log(DEBUG, msg)
         # Attempt to load cert if it exists.
@@ -709,7 +709,7 @@ class SSHClient(ClosingContextManager):
                 self._log(
                     DEBUG,
                     "Trying SSH key {}".format(
-                        hexlify(pkey.get_fingerprint())
+                        hexlify(pkey.fingerprint)
                     ),
                 )
                 allowed_types = set(
@@ -746,7 +746,7 @@ class SSHClient(ClosingContextManager):
 
             for key in self._agent.get_keys():
                 try:
-                    id_ = hexlify(key.get_fingerprint())
+                    id_ = hexlify(key.fingerprint)
                     self._log(DEBUG, "Trying SSH agent key {}".format(id_))
                     # for 2-factor auth a successfully auth'd key password
                     # will return an allowed 2fac auth method
@@ -856,7 +856,7 @@ class AutoAddPolicy(MissingHostKeyPolicy):
         client._log(
             DEBUG,
             "Adding {} host key for {}: {}".format(
-                key.get_name(), hostname, hexlify(key.get_fingerprint())
+                key.get_name(), hostname, hexlify(key.fingerprint)
             ),
         )
 
@@ -871,7 +871,7 @@ class RejectPolicy(MissingHostKeyPolicy):
         client._log(
             DEBUG,
             "Rejecting {} host key for {}: {}".format(
-                key.get_name(), hostname, hexlify(key.get_fingerprint())
+                key.get_name(), hostname, hexlify(key.fingerprint)
             ),
         )
         raise SSHException(
@@ -888,6 +888,6 @@ class WarningPolicy(MissingHostKeyPolicy):
     def missing_host_key(self, client, hostname, key):
         warnings.warn(
             "Unknown {} host key for {}: {}".format(
-                key.get_name(), hostname, hexlify(key.get_fingerprint())
+                key.get_name(), hostname, hexlify(key.fingerprint)
             )
         )


### PR DESCRIPTION
Per #396, FIPS mode rejects .get_fingerprint() because it uses MD5.

The .fingerprint property uses SHA256, which is FIPS-compatible.

This addresses the latest FIPS problem reported in #396. We'll see if it solves all the FIPS problems.