### PR TITLE
Add tox.ini

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include LICENSE setup_helper.py pytest.ini
+include LICENSE setup_helper.py pytest.ini dev-requirements.txt tox.ini
 recursive-include docs *
 recursive-include tests *.py *.key *.pub
 recursive-include tests/configs *

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,5 @@
+[testenv]
+deps =
+    -rdev-requirements.txt
+commands =
+    python -m pytest {posargs}


### PR DESCRIPTION
A minimal `tox.ini` file.  It will allow fully automatic packaging and testing of `paramiko` package for OpenIndiana.

Closes #2246
Closes #2286

Thank you.