### PR TITLE
Fix some tests not closing all threads

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,8 +97,9 @@ def sftp_server():
     # Make & yield connection.
     tc.connect(username="slowdive", password="pygmalion")
     yield tc
-    # TODO: any need for shutdown? Why didn't old suite do so? Or was that the
-    # point of the "join all threads from threading module" crap in test.py?
+    # Shutdown both transports to prevent lingering threads.
+    tc.close()
+    ts.close()
 
 
 @pytest.fixture

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -333,6 +333,8 @@ class SSHClientTest(ClientTest):
                 key_filename=key_path,
                 public_blob=PublicBlob.from_file(f"{key_path}-cert.pub"),
             )
+            # Transport needs to be closed after each iteration.
+            self.tc.close()
 
     @requires_sha1_signing
     def test_certs_implicitly_loaded_alongside_key_filename_keys(self):
@@ -348,6 +350,8 @@ class SSHClientTest(ClientTest):
                 key_filename=key_path,
                 public_blob=PublicBlob.from_file(f"{key_path}-cert.pub"),
             )
+            # Transport needs to be closed after each iteration.
+            self.tc.close()
 
     def _cert_algo_test(self, ver, alg):
         # Issue #2017; see auth_handler.py


### PR DESCRIPTION
Some tests are not closing all Transports, resulting in tens of lingering threads when the test suite finishes.
