### PR TITLE
Fix deprecated nose tests method and 'isSet()'

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -689,7 +689,7 @@ class SSHClientTest(ClientTest):
         )
 
         self.event.wait(1.0)
-        self.assertTrue(self.event.isSet())
+        self.assertTrue(self.event.is_set())
         self.assertTrue(self.ts.is_active())
 
     def test_update_environment(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -53,7 +53,7 @@ def load_config(name):
 
 
 class TestSSHConfig:
-    def setup(self):
+    def setup_method(self):
         self.config = load_config("robey")
 
     def test_init(self):


### PR DESCRIPTION
Fixes #2290 -- Changed the "setup(self)" method in TestSSHConfig to "setup_method(self)" as nose tests will be deprecated. This fixes over 20 warnings when running pytest. Additionally changed a remaining "isSet()" to "is_set()" within test_client.py.