### PR TITLE
Fixed logging messages for transport security options (#2310)

### DIFF
--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -3050,7 +3050,8 @@ class SecurityOptions:
         possible = list(getattr(self._transport, orig).keys())
         forbidden = [n for n in x if n not in possible]
         if len(forbidden) > 0:
-            raise ValueError("unknown cipher")
+            name_parsed = name.replace("_preferred_","")
+            raise ValueError("unknown {} name: {}, possible options: {}".format(name_parsed, x, possible))
         setattr(self._transport, name, x)
 
     @property

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -155,6 +155,18 @@ class TransportTest(unittest.TestCase):
         o.kex = o.kex
         o.compression = o.compression
 
+    def test_security_options_log_message(self):
+        """
+        Test proper logging user experience for security options
+        """
+        opts = self.tc.get_security_options()
+        # we use mapping to work with legacy attribute names
+        mapping = {'ciphers': 'ciphers', 'digests': 'macs', 'key_types': 'keys', 'kex': 'kex'}
+        for prop in mapping.keys():
+            with self.assertRaises(ValueError) as exc:
+                setattr(opts, prop, ['unknown'])
+            assert str(exc.exception).startswith('unknown {} name'.format(mapping[prop]))
+
     def test_compute_key(self):
         self.tc.K = 123281095979686581523377256114209720774539068973101330872763622971399429481072519713536292772709507296759612401802191955568143056534122385270077606457721553469730659233569339356140085284052436697480759510519672848743794433460113118986816826624865291116513647975790797391795651716378444844877749505443714557929  # noqa
         self.tc.H = b"\x0C\x83\x07\xCD\xE6\x85\x6F\xF3\x0B\xA9\x36\x84\xEB\x0F\x04\xC2\x52\x0E\x9E\xD3"  # noqa


### PR DESCRIPTION
```
import paramiko
import socket
s = socket.socket()
t = paramiko.Transport(s)
opts = t.get_security_options()

for prop in ('ciphers', 'digests', 'key_types', 'kex'):
    try:
        setattr(opts, prop, ['unknown'])
    except ValueError as e:
        print(e)
```

```
unknown ciphers name: ('unknown',), possible options: ['aes128-ctr', 'aes192-ctr', 'aes256-ctr', 'aes128-cbc', 'aes192-cbc', 'aes256-cbc', '3des-cbc']

unknown macs name: ('unknown',), possible options: ['hmac-sha1', 'hmac-sha1-96', 'hmac-sha2-256', 'hmac-sha2-256-etm@openssh.com', 'hmac-sha2-512', 'hmac-sha2-512-etm@openssh.com', 'hmac-md5', 'hmac-md5-96']

unknown keys name: ('unknown',), possible options: ['ssh-rsa', 'ssh-rsa-cert-v01@openssh.com', 'rsa-sha2-256', 'rsa-sha2-256-cert-v01@openssh.com', 'rsa-sha2-512', 'rsa-sha2-512-cert-v01@openssh.com', 'ssh-dss', 'ssh-dss-cert-v01@openssh.com', 'ecdsa-sha2-nistp256', 'ecdsa-sha2-nistp256-cert-v01@openssh.com', 'ecdsa-sha2-nistp384', 'ecdsa-sha2-nistp384-cert-v01@openssh.com', 'ecdsa-sha2-nistp521', 'ecdsa-sha2-nistp521-cert-v01@openssh.com', 'ssh-ed25519', 'ssh-ed25519-cert-v01@openssh.com']

unknown kex name: ('unknown',), possible options: ['diffie-hellman-group1-sha1', 'diffie-hellman-group14-sha1', 'diffie-hellman-group-exchange-sha1', 'diffie-hellman-group-exchange-sha256', 'diffie-hellman-group14-sha256', 'diffie-hellman-group16-sha512', 'gss-group1-sha1-toWM5Slw5Ew8Mqkay+al2g==', 'gss-group14-sha1-toWM5Slw5Ew8Mqkay+al2g==', 'gss-gex-sha1-toWM5Slw5Ew8Mqkay+al2g==', 'ecdh-sha2-nistp256', 'ecdh-sha2-nistp384', 'ecdh-sha2-nistp521', 'curve25519-sha256@libssh.org']

```