### PR TITLE
Raise exception if timeout occurs when starting the ssh client.

### DIFF
--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -721,10 +721,10 @@ class Transport(threading.Thread, ClosingContextManager):
                 if e is not None:
                     raise e
                 raise SSHException("Negotiation failed.")
-            if event.is_set() or (
-                timeout is not None and time.time() >= max_time
-            ):
+            if event.is_set():
                 break
+            elif timeout is not None and time.time() >= max_time:
+                raise SSHException("Timeout starting client.")
 
     def start_server(self, event=None, server=None):
         """


### PR DESCRIPTION
### Issue
If the ssh client is not started within the timeout the `start_client` function exits without an error and without a client.
This leads later to a ` SSHException("No existing session")` which does not allow any conclusions to be drawn about the cause. 

### Fix
On timeout raise a `SSHException` with a proper error message like it is [already done](https://github.com/paramiko/paramiko/blob/main/paramiko/transport.py#L1075) in the `open_channel` function.