### PR TITLE
Add option to skip host key verification

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -233,6 +233,7 @@ class SSHClient(ClosingContextManager):
         disabled_algorithms=None,
         transport_factory=None,
         auth_strategy=None,
+        skip_host_key_verification=False,
     ):
         """
         Connect to an SSH server and authenticate to it.  The server's host key
@@ -300,6 +301,9 @@ class SSHClient(ClosingContextManager):
         :param dict disabled_algorithms:
             an optional dict passed directly to `.Transport` and its keyword
             argument of the same name.
+        :param bool skip_host_key_verification:
+            whether or not to skip host key verification (not recommended,
+            default ``False``)
         :param transport_factory:
             an optional callable which is handed a subset of the constructor
             arguments (primarily those related to the socket and algorithm
@@ -393,6 +397,7 @@ class SSHClient(ClosingContextManager):
             disabled_algorithms=disabled_algorithms,
         )
         t.use_compression(compress=compress)
+        t.set_skip_host_key_verification(skip_host_key_verification)
         if self._log_channel is not None:
             t.set_log_channel(self._log_channel)
         if banner_timeout is not None:

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -342,6 +342,7 @@ class Transport(threading.Thread, ClosingContextManager):
 
     _modulus_pack = None
     _active_check_timeout = 0.1
+    _skip_host_key_verification = False
 
     def __init__(
         self,
@@ -646,6 +647,27 @@ class Transport(threading.Thread, ClosingContextManager):
         of preference for them.
         """
         return SecurityOptions(self)
+
+    def set_skip_host_key_verification(self, skip_host_key_verification):
+        """
+        Skipping host key verification might be useful in very rare cases
+        where it is not possible to verify the target's key, for example if
+        it uses a legacy signature algorithm that is no longer supported by
+        the client.
+
+        This option should be avoided if possible because host key
+        verification protects against issues like MITM attacks and replacement
+        of a server by a malicious actor that might perhaps use it to log
+        usernames and passwords with which to access the client system later.
+
+        :param bool skip_host_key_verification:
+            Whether of not to skip host key verification
+            (Defaults to False.)
+        :returns: ``None``.
+
+        .. versionadded:: 5.0.1
+        """
+        self._skip_host_key_verification = skip_host_key_verification
 
     def start_client(self, event=None, timeout=None):
         """
@@ -1852,7 +1874,9 @@ class Transport(threading.Thread, ClosingContextManager):
             raise SSHException("Unknown host key type")
         # TODO: like, here, can a host offer "ssh-rsa" but request SHA2, or are
         # those baked in?
-        if not key.verify_ssh_sig(self.H, Message(sig)):
+        if not self._skip_host_key_verification and not key.verify_ssh_sig(
+            self.H, Message(sig)
+        ):
             raise SSHException(
                 "Signature verification ({}) failed.".format(
                     self.host_key_type

--- a/tests/pkey.py
+++ b/tests/pkey.py
@@ -307,5 +307,5 @@ class Ed25519Key_:
         # will effectively be that of an 'empty' key bytes)
         assert (
             repr(info.traceback[1].locals["self"])
-            == "PKey(alg=ED25519, bits=256, fp=SHA256:UsIasxMWEd9VFEwjARWWtGJ08DgHp1eib3gSBLed54U)"
+            == "PKey(alg=ED25519, bits=256, fp=SHA256:UsIasxMWEd9VFEwjARWWtGJ08DgHp1eib3gSBLed54U)"  # noqa
         )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -42,6 +42,9 @@ from paramiko.ssh_exception import AuthenticationException, SSHException
 
 from ._util import _support, slow
 
+from cryptography.exceptions import UnsupportedAlgorithm
+
+
 FINGERPRINTS = {
     # TODO: this should still be ok as it's specifically re: key
     # type/identity.
@@ -476,6 +479,54 @@ class SSHClientTest(ClientTest):
             self.assertTrue(self.tc._transport is not None)
 
         self.assertTrue(self.tc._transport is None)
+
+    def test_host_key_verification_with_bad_key(self):
+        """
+        verify that host key verification raises an exception on failure
+        """
+        # Note that _test_connection uses an RSA host key,
+        # so that's what we mock
+        with patch.object(paramiko.RSAKey, "verify_ssh_sig") as verifier:
+            verifier.return_value = False
+            with self.assertRaises(SSHException) as cm:
+                self._test_connection(key_filename=_support("ed25519.key"))
+            self.assertEqual(
+                str(cm.exception),
+                "Signature verification (rsa-sha2-512) failed.",
+            )
+
+    def test_host_key_verification_with_unsupported_key(self):
+        """
+        verify that host key verification raises an exception on
+        getting a host key with an unsupported algorithm
+        """
+        with patch.object(paramiko.RSAKey, "verify_ssh_sig") as verifier:
+            verifier.side_effect = UnsupportedAlgorithm("oops")
+            with self.assertRaises(UnsupportedAlgorithm) as cm:
+                self._test_connection(key_filename=_support("ed25519.key"))
+            self.assertEqual(str(cm.exception), "oops")
+
+    def test_skip_host_key_verification_with_bad_key(self):
+        """
+        verify that a bad host key can be ignored
+        """
+        with patch.object(paramiko.RSAKey, "verify_ssh_sig") as verifier:
+            verifier.return_value = False
+            self._test_connection(
+                key_filename=_support("ed25519.key"),
+                skip_host_key_verification=True,
+            )
+
+    def test_skip_host_key_verification_with_unsupported_key(self):
+        """
+        verify that an unsupported host key can be ignored
+        """
+        with patch.object(paramiko.RSAKey, "verify_ssh_sig") as verifier:
+            verifier.side_effect = UnsupportedAlgorithm("oops")
+            self._test_connection(
+                key_filename=_support("ed25519.key"),
+                skip_host_key_verification=True,
+            )
 
     def test_banner_timeout(self):
         """


### PR DESCRIPTION
Skipping host key verification might be useful in very rare cases where it is not possible to verify the target's key, for example if it uses a legacy signature algorithm that is no longer supported by the client, e.g. this fixes #2259.