### PR TITLE
remove traceback for SSHException

### DIFF
--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -2243,7 +2243,6 @@ class Transport(threading.Thread, ClosingContextManager):
                         "server" if self.server_mode else "client", e
                     ),
                 )
-                self._log(ERROR, util.tb_strings())
                 self.saved_exception = e
             except EOFError as e:
                 self._log(DEBUG, "EOF in transport thread")


### PR DESCRIPTION
While running a transport, if an `SSHException` is encountered, a full traceback is printed to the error log (via `util.tb_strings()`). This is a less-than-ideal behavior, as we can't prevent this Python traceback from surfacing to the user (even when the actual error was handled gracefully). Looking at the rest of the codebase, it looks like the only other places `util.tb_strings()` is used is when catching a generic Exception (which makes sense, as this is by definition an unexpected failure and needs to be debugged). I propose removing the traceback log for SSHException.