### PR TITLE
fixed add in paramiko/hostkeys.py

### DIFF
--- a/paramiko/hostkeys.py
+++ b/paramiko/hostkeys.py
@@ -66,7 +66,7 @@ class HostKeys(MutableMapping):
         :param .PKey key: the key to add
         """
         for e in self._entries:
-            if (hostname in e.hostnames) and (e.key.get_name() == keytype):
+            if self._hostname_matches(hostname, e) and (e.key.get_name() == keytype):
                 e.key = key
                 return
         self._entries.append(HostKeyEntry([hostname], key))


### PR DESCRIPTION
This change resolve #2355 by comparing hostname literally and with hashed hostname
Instead of adding key blindly if hostname is not found
I added a check of _hostname_matches, which will match the hashed hostname also