### PR TITLE
[paramiko/__init__.py] Export version (`paramiko.__version__`)

### DIFF
--- a/paramiko/__init__.py
+++ b/paramiko/__init__.py
@@ -110,6 +110,8 @@ from paramiko.sftp import (
 
 from paramiko.common import io_sleep
 
+from paramiko._version import __version__
+
 
 # TODO: I guess a real plugin system might be nice for future expansion...
 key_classes = [DSSKey, RSAKey, Ed25519Key, ECDSAKey]
@@ -162,4 +164,5 @@ __all__ = [
     "WarningPolicy",
     "io_sleep",
     "util",
+    "__version__"
 ]


### PR DESCRIPTION
Looks like it used to be available; e.g., older Apache Libcloud versions relied on its existence