### PR TITLE
Fix typos in transport.py's open_channel method docstring

### DIFF
--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -364,7 +364,7 @@ class Transport(threading.Thread, ClosingContextManager):
         call may be thrown in this case.
 
         .. note::
-            Modifying the the window and packet sizes might have adverse
+            Modifying the window and packet sizes might have adverse
             effects on your channels created from this transport. The default
             values are the same as in the OpenSSH code base and have been
             battle tested.
@@ -936,7 +936,7 @@ class Transport(threading.Thread, ClosingContextManager):
         just an alias for calling `open_channel` with an argument of
         ``"session"``.
 
-        .. note:: Modifying the the window and packet sizes might have adverse
+        .. note:: Modifying the window and packet sizes might have adverse
             effects on the session created. The default values are the same
             as in the OpenSSH code base and have been battle tested.
 
@@ -1020,7 +1020,7 @@ class Transport(threading.Thread, ClosingContextManager):
         session. You may only request a channel after negotiating encryption
         (using `connect` or `start_client`) and authenticating.
 
-        .. note:: Modifying the the window and packet sizes might have adverse
+        .. note:: Modifying the window and packet sizes might have adverse
             effects on the channel created. The default values are the same
             as in the OpenSSH code base and have been battle tested.
 


### PR DESCRIPTION
Title: Fix typos in transport.py's __init__, open_session, open_channel method docstring

Description:
### Changes
This PR corrects repeated words in the `transport.py` file. Specifically, instances of "the the window" have been corrected to "the window".

### Details
- The typos were found in the docstring of the `__init__`, `open_session`, `open_channel` method.
- Each instance of the typo appeared in the explanation of window and packet sizes, which could potentially confuse readers or developers trying to understand the method's functionality.

### Impact
- These changes improve the readability of the documentation and ensure that the information is clearly conveyed.
- No functional changes were made; this PR only involves documentation.

### References
- This PR addresses the issue reported in issue #2386 

### Tests
- No code was altered; thus, no new tests are required.
- Documentation changes do not affect the execution of the code.

### Notes
- All modifications are confined to comments and docstrings; thus, they do not impact the functional aspects of the module.