### PR TITLE
fix for transport::join_lingering_threads() not stopping all threads and join thread never get executed in transport::stop_thread() #2406

### DIFF
--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -126,7 +126,8 @@ _active_threads = []
 
 
 def _join_lingering_threads():
-    for thr in _active_threads:
+    active_threads = [thr for thr in _active_threads]
+    for thr in active_threads:
         thr.stop_thread()
 
 
@@ -1892,8 +1893,6 @@ class Transport(threading.Thread, ClosingContextManager):
         while (
             self.is_alive()
             and self is not threading.current_thread()
-            and not self.sock._closed
-            and not self.packetizer.closed
         ):
             self.join(0.1)
 


### PR DESCRIPTION
PR for issue https://github.com/paramiko/paramiko/issues/2406
Fix : keep a deep copy of active thread list and iterated stop_threads() over it. And removed the conditions which are blocking to join the threads.