### PR TITLE
Fix and improve demo programs

### DIFF
--- a/demos/demo_keygen.py
+++ b/demos/demo_keygen.py
@@ -18,6 +18,9 @@
 # along with Paramiko; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA.
 
+"""
+Demonstrates Paramiko's native keygen capabilities.
+"""
 import sys
 
 from binascii import hexlify
@@ -26,7 +29,7 @@ from optparse import OptionParser
 from paramiko import DSSKey
 from paramiko import RSAKey
 from paramiko.ssh_exception import SSHException
-from paramiko.py3compat import u
+from paramiko.util import u
 
 usage = """
 %prog [-v] [-b bits] -t type [-N new_passphrase] [-f output_keyfile]"""
@@ -167,7 +170,7 @@ if __name__ == "__main__":
         "Fingerprint: %d %s %s.pub (%s)"
         % (
             bits,
-            ":".join([hash[i : 2 + i] for i in range(0, len(hash), 2)]),
+            ":".join([hash[i: 2 + i] for i in range(0, len(hash), 2)]),
             filename,
             ktype.upper(),
         )

--- a/demos/demo_server.py
+++ b/demos/demo_server.py
@@ -18,17 +18,23 @@
 # along with Paramiko; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA.
 
-import base64
+"""
+Demonstrates implementation of an SSHv2 server with the ServerInterface
+and Transport primitives.
+
+Listens on port 2200. Accepts connection from username "robey" and either
+password "foo" or user_rsa_key.
+"""
+
+from base64 import decodebytes
 from binascii import hexlify
-import os
 import socket
 import sys
 import threading
 import traceback
 
 import paramiko
-from paramiko.py3compat import b, u, decodebytes
-
+from paramiko.util import u
 
 # setup logging
 paramiko.util.log_to_file("demo_server.log")
@@ -113,7 +119,9 @@ class Server(paramiko.ServerInterface):
         return True
 
 
-DoGSSAPIKeyExchange = True
+DoGSSAPIKeyExchange = (
+    paramiko.GSS_AUTH_AVAILABLE
+)  # enable "gssapi-kex" key exchange, if supported by your python installation
 
 # now connect
 try:

--- a/demos/demo_sftp.py
+++ b/demos/demo_sftp.py
@@ -20,7 +20,10 @@
 
 # based on code provided by raymond mosteller (thanks!)
 
-import base64
+"""
+Demonstrates basic SFTP transfer across a connection.
+"""
+
 import getpass
 import os
 import socket
@@ -28,15 +31,16 @@ import sys
 import traceback
 
 import paramiko
-from paramiko.py3compat import input
-
-
 # setup logging
 paramiko.util.log_to_file("demo_sftp.log")
 
 # Paramiko client configuration
-UseGSSAPI = True  # enable GSS-API / SSPI authentication
-DoGSSAPIKeyExchange = True
+UseGSSAPI = (
+    paramiko.GSS_AUTH_AVAILABLE
+)  # enable "gssapi-with-mic" authentication, if supported by your python installation
+DoGSSAPIKeyExchange = (
+    paramiko.GSS_AUTH_AVAILABLE
+)  # enable "gssapi-kex" key exchange, if supported by your python installation
 Port = 22
 
 # get hostname

--- a/demos/demo_simple.py
+++ b/demos/demo_simple.py
@@ -18,14 +18,14 @@
 # along with Paramiko; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA.
 
+"""
+Demonstrates how to open a shell at an SSH server, using basic password
+authentication or GSSAPI.
+"""
 
-import base64
 import getpass
-import os
-import socket
 import sys
 import traceback
-from paramiko.py3compat import input
 
 import paramiko
 
@@ -44,8 +44,6 @@ UseGSSAPI = (
 DoGSSAPIKeyExchange = (
     paramiko.GSS_AUTH_AVAILABLE
 )  # enable "gssapi-kex" key exchange, if supported by your python installation
-# UseGSSAPI = False
-# DoGSSAPIKeyExchange = False
 port = 22
 
 # get hostname
@@ -93,7 +91,7 @@ try:
                 gss_kex=DoGSSAPIKeyExchange,
             )
         except Exception:
-            # traceback.print_exc()
+            traceback.print_exc()
             password = getpass.getpass(
                 "Password for %s@%s: " % (username, hostname)
             )

--- a/demos/forward.py
+++ b/demos/forward.py
@@ -27,8 +27,6 @@ connection to a destination reachable from the SSH server machine.
 """
 
 import getpass
-import os
-import socket
 import select
 
 try:

--- a/demos/interactive.py
+++ b/demos/interactive.py
@@ -19,7 +19,7 @@
 
 import socket
 import sys
-from paramiko.py3compat import u
+from paramiko.util import u
 
 # windows does not have termios...
 try:

--- a/demos/rforward.py
+++ b/demos/rforward.py
@@ -27,7 +27,6 @@ connection to a destination reachable from the local machine.
 """
 
 import getpass
-import os
 import socket
 import select
 import sys


### PR DESCRIPTION
This commit does a few things that make the demos more usable.

Imports from paramiko.py3compat have been removed as that module was
removed in commit 5c4b311b (2023-01-09), making it possible to run these
demos with modern versions of the library.

GSS support was made system-conditional in all demo files, as it was
previously in demo_simple.py.

Unused imports were removed.

Docstrings were added to files that did not have them.
