### PR TITLE
Fix detection of SHA1 signing support

### DIFF
--- a/tests/_util.py
+++ b/tests/_util.py
@@ -188,7 +188,7 @@ def sha1_signing_unsupported():
         )
         return False
     except UnsupportedAlgorithm as e:
-        return e._reason is _Reasons.UNSUPPORTED_HASH
+        return e._reason == _Reasons.UNSUPPORTED_HASH
 
 
 requires_sha1_signing = unittest.skipIf(


### PR DESCRIPTION
`e._reason` is an enum from `cryptography.exceptions._Reasons` so `is` should be the correct comparison, but it doesn't always work. This is apparently triggered by `_Reasons` moving to the part of `cryptography` that is implemented in rust, which doesn't yet implement enums as singletons.

https://github.com/pyca/cryptography/issues/11332
https://github.com/PyO3/pyo3/issues/3059