### PR TITLE
fix: Update the import path for TripleDES Cipher

### DIFF
--- a/paramiko/pkey.py
+++ b/paramiko/pkey.py
@@ -43,6 +43,20 @@ from paramiko.ssh_exception import SSHException, PasswordRequiredException
 from paramiko.message import Message
 
 
+# TripleDES is moving from `cryptography.hazmat.primitives.ciphers.algorithms`
+# in cryptography>=43.0.0 to `cryptography.hazmat.decrepit.ciphers.algorithms`
+# It will be removed from `cryptography.hazmat.primitives.ciphers.algorithms`
+# in cryptography==48.0.0.
+#
+# Source References:
+# - https://github.com/pyca/cryptography/commit/722a6393e61b3ac
+# - https://github.com/pyca/cryptography/pull/11407/files
+try:
+    from cryptography.hazmat.decrepit.ciphers.algorithms import TripleDES
+except ImportError:
+    from cryptography.hazmat.primitives.ciphers.algorithms import TripleDES
+
+
 OPENSSH_AUTH_MAGIC = b"openssh-key-v1\x00"
 
 
@@ -97,7 +111,7 @@ class PKey:
             "mode": modes.CBC,
         },
         "DES-EDE3-CBC": {
-            "cipher": algorithms.TripleDES,
+            "cipher": TripleDES,
             "keysize": 24,
             "blocksize": 8,
             "mode": modes.CBC,

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -121,6 +121,20 @@ from paramiko.util import (
 )
 
 
+# TripleDES is moving from `cryptography.hazmat.primitives.ciphers.algorithms`
+# in cryptography>=43.0.0 to `cryptography.hazmat.decrepit.ciphers.algorithms`
+# It will be removed from `cryptography.hazmat.primitives.ciphers.algorithms`
+# in cryptography==48.0.0.
+#
+# Source References:
+# - https://github.com/pyca/cryptography/commit/722a6393e61b3ac
+# - https://github.com/pyca/cryptography/pull/11407/files
+try:
+    from cryptography.hazmat.decrepit.ciphers.algorithms import TripleDES
+except ImportError:
+    from cryptography.hazmat.primitives.ciphers.algorithms import TripleDES
+
+
 # for thread cleanup
 _active_threads = []
 
@@ -256,7 +270,7 @@ class Transport(threading.Thread, ClosingContextManager):
             "key-size": 32,
         },
         "3des-cbc": {
-            "class": algorithms.TripleDES,
+            "class": TripleDES,
             "mode": modes.CBC,
             "block-size": 8,
             "key-size": 24,


### PR DESCRIPTION
### Changelog
- A new major version of cryptography was released a few days ago and with it, the TripleDES cipher was moved from  the `primitives` to the `decrepit` ciphers as shown below

```python
# Old Import Path
from cryptography.hazmat.primitives.ciphers.algorithms import TripleDES

# New Import Path
from cryptography.hazmat.decrepit.ciphers.algorithms import TripleDES
```
- Addresses https://github.com/paramiko/paramiko/issues/2419 by adding a conditional import so `paramiko` remains compatible with either version of `cryptography`. 
- Paramiko seems to only have two references to the cipher in `transport.py` <sup>[1](https://github.com/paramiko/paramiko/blob/main/paramiko/pkey.py#L99-L103)</sup> and `pkey.py` <sup>[2](https://github.com/paramiko/paramiko/blob/main/paramiko/transport.py#L258-L263)</sup> which the conditional import caters to. Considered [bumping `cryptography>=43.0.0`](https://github.com/paramiko/paramiko/blob/main/setup.py#L91) <sup>[3](https://github.com/paramiko/paramiko/blob/main/setup.py#L91)</sup> but that would likely limit the range of supported clients which I have no insight on

### Breaking Change
- cryptography moving TripleDES from `primitives` to `decrepit` as it should https://github.com/pyca/cryptography/commit/722a6393e61b3acb569f404218f213fe08478a96

### Links
1. https://github.com/paramiko/paramiko/blob/main/paramiko/pkey.py#L99-L103
2. https://github.com/paramiko/paramiko/blob/main/paramiko/transport.py#L258-L263
3. https://github.com/paramiko/paramiko/blob/main/setup.py#L91

### Alternatives
- In the interim, one can pin `cryptography<43` in projects that depend on paramiko until a formal way forward is decided
