### PR TITLE
check for TimeoutError in BufferedFile

### DIFF
--- a/paramiko/file.py
+++ b/paramiko/file.py
@@ -201,6 +201,11 @@ class BufferedFile(ClosingContextManager):
                 read_size = max(self._bufsize, read_size)
             try:
                 new_data = self._read(read_size)
+            except TimeoutError:
+                if not self._rbuffer:
+                    raise
+                else:
+                    new_data = b""
             except EOFError:
                 new_data = None
             if (new_data is None) or (len(new_data) == 0):


### PR DESCRIPTION
Check for TimeoutError in BufferedFile so that data does not languish in the buffer after a timeout occurs.

Fixes: #2440