### PR TITLE
fix issue #2078 prefering the use of ssh-rsa for old server

### DIFF
--- a/paramiko/auth_handler.py
+++ b/paramiko/auth_handler.py
@@ -295,7 +295,7 @@ class AuthHandler:
 
     def _choose_fallback_pubkey_algorithm(self, key_type, my_algos):
         # Fallback: first one in our (possibly tweaked by caller) list
-        pubkey_algo = my_algos[0]
+        pubkey_algo = my_algos[-1]
         msg = "Server did not send a server-sig-algs list; defaulting to our first preferred algo ({!r})"  # noqa
         self._log(DEBUG, msg.format(pubkey_algo))
         self._log(


### PR DESCRIPTION
This small change allow the use of ssh-rsa pubkey alg for old ssh server e.g redhat which don't handle rsa-sha2-256 or rsa-sha2-512. This is a workaround for #2078 to avoid disabling more modern pubkey alg.