### PR TITLE
NETNKM-2562 : Introducing OSError timebound busy-wait in packetizer _read_timeout

### DIFF
--- a/paramiko/common.py
+++ b/paramiko/common.py
@@ -243,3 +243,7 @@ MIN_PACKET_SIZE = 2**12
 
 # Max windows size according to http://www.ietf.org/rfc/rfc4254.txt
 MAX_WINDOW_SIZE = 2**32 - 1
+
+# When OSError is thrown, wait this long if we want to spin and
+# wait for error conditions to resolve.
+OS_ERROR_SLEEP = 0.1 ;# 100ms

--- a/paramiko/packet.py
+++ b/paramiko/packet.py
@@ -37,6 +37,7 @@ from paramiko.common import (
     xffffffff,
     zero_byte,
     byte_ord,
+    OS_ERROR_SLEEP,
 )
 from paramiko.util import u
 from paramiko.ssh_exception import SSHException, ProxyCommandFailure
@@ -666,6 +667,11 @@ class Packetizer:
                 break
             except socket.timeout:
                 pass
+            except OSError:
+                time.sleep(OS_ERROR_SLEEP)
+                now = time.time()
+                if now - start >= timeout:
+                    raise
             if self.__closed:
                 raise EOFError()
             now = time.time()

--- a/tests/_loop.py
+++ b/tests/_loop.py
@@ -96,3 +96,21 @@ class LoopSocket:
             self.__lock.release()
         if m is not None:
             m.__unlink()
+
+
+class LoopSocketWithOsErrsOnRecv(LoopSocket):
+    """ This Loop Socket variant raises a series of errors every time recv is
+    called.  After the series is complete, recv functionality reverts to the
+    parent's implementation.
+    """
+    def __init__(self, num_errs_to_raise=0):
+        super().__init__()
+        self.num_errs_to_raise = num_errs_to_raise
+        self.err_raise_count = 0
+
+    def recv (self, n):
+        if self.err_raise_count >= self.num_errs_to_raise:
+            return super().recv(n)
+        else:
+            self.err_raise_count += 1
+            raise OSError()


### PR DESCRIPTION
While testing on an embedded automotive target from a Windows 11 client, the target was gracefully rebooted (which resulted in the system being taken down slowly and then hard-rebooted).

Around the time of hard-rebooting we noticed that `packet.py:Packetizer:_read_timeout` was not catching the following OSError raised when the `self.__socket.recv(128)` was attempted. 

`[WinError 10054] An existing connection was forcibly closed by the remote host`

This PR now catches the `OSError` as long as the timeout has not been exceeded.  If the issue resolves and data is able to be read from the socket when it is returned normally.  If the issue does not resolve and `OSError` continues to be raised then when the timeout has been exceeded it is re-raised.