### PR TITLE
Add and remove keys agent keys

### DIFF
--- a/paramiko/agent.py
+++ b/paramiko/agent.py
@@ -37,7 +37,7 @@ from paramiko.message import Message
 from paramiko.pkey import PKey, UnknownKeyType
 from paramiko.util import asbytes, get_logger
 
-SSH_AGENT_SUCCESS = byte_chr(6)
+SSH_AGENT_SUCCESS = 6
 cSSH2_AGENTC_REQUEST_IDENTITIES = byte_chr(11)
 SSH2_AGENT_IDENTITIES_ANSWER = 12
 cSSH2_AGENTC_SIGN_REQUEST = byte_chr(13)
@@ -47,8 +47,8 @@ cSSH2_AGENTC_ADD_ID_CONSTRAINTED = byte_chr(25)
 SSH2_AGENT_CONSTRAIN_LIFETIME = byte_chr(1)
 SSH2_AGENT_CONSTRAIN_CONFIRM = byte_chr(2)
 SSH2_AGENT_SUCCESS = 6
-SSH_AGENTC_REMOVE_IDENTITY = 18
-SSH_AGENTC_REMOVE_ALL_IDENTITIES = 19
+SSH_AGENTC_REMOVE_IDENTITY = byte_chr(18)
+SSH_AGENTC_REMOVE_ALL_IDENTITIES = byte_chr(19)
 
 SSH_AGENT_RSA_SHA2_256 = 2
 SSH_AGENT_RSA_SHA2_512 = 4
@@ -153,8 +153,8 @@ class AgentSSH:
     def _remove_key(self, key):
         msg = Message()
         msg.add_byte(SSH_AGENTC_REMOVE_IDENTITY)
-        msg.add_string(key.as_bytes())
-        ptype, result = self.agent._send_message(msg)
+        msg.add_string(key.asbytes())
+        ptype, result = self._send_message(msg)
         if ptype != SSH_AGENT_SUCCESS:
             raise SSHException("Unable to remove key from agent")
         key_list = list(self._keys)
@@ -167,8 +167,7 @@ class AgentSSH:
         """
         msg = Message()
         msg.add_byte(SSH_AGENTC_REMOVE_ALL_IDENTITIES)
-        msg.add_string(key.as_bytes())
-        ptype, result = self.agent._send_message(msg)
+        ptype, result = self._send_message(msg)
         if ptype != SSH_AGENT_SUCCESS:
             raise SSHException("Unable to remove key from agent")
         self._connect(self._conn)

--- a/paramiko/dsskey.py
+++ b/paramiko/dsskey.py
@@ -162,6 +162,14 @@ class DSSKey(PKey):
         else:
             return True
 
+    def append_add_agent_parameters(self, m):
+        # All mpint's p, q, g, y, x (private)
+        m.add_mpint(self.p)
+        m.add_mpint(self.q)
+        m.add_mpint(self.g)
+        m.add_mpint(self.y)
+        m.add_mpint(self.x)
+
     def write_private_key_file(self, filename, password=None):
         key = dsa.DSAPrivateNumbers(
             x=self.x,

--- a/paramiko/ecdsakey.py
+++ b/paramiko/ecdsakey.py
@@ -243,6 +243,24 @@ class ECDSAKey(PKey):
         else:
             return True
 
+    def append_add_agent_parameters(self, m):
+        # Curve_name, public_key, private
+        m.add_string(self.ecdsa_curve.nist_name)
+
+        numbers = self.verifying_key.public_numbers()
+
+        key_size_bytes = (self.verifying_key.curve.key_size + 7) // 8
+
+        x_bytes = deflate_long(numbers.x, add_sign_padding=False)
+        x_bytes = b'\x00' * (key_size_bytes - len(x_bytes)) + x_bytes
+
+        y_bytes = deflate_long(numbers.y, add_sign_padding=False)
+        y_bytes = b'\x00' * (key_size_bytes - len(y_bytes)) + y_bytes
+
+        point_str = four_byte + x_bytes + y_bytes
+        m.add_string(point_str)
+        m.add_mpint(self.signing_key.private_numbers().private_value)
+
     def write_private_key_file(self, filename, password=None):
         self._write_private_key_file(
             filename,

--- a/paramiko/ed25519key.py
+++ b/paramiko/ed25519key.py
@@ -210,3 +210,10 @@ class Ed25519Key(PKey):
             return False
         else:
             return True
+
+    def append_add_agent_parameters(self, m):
+        # Public[ENC(A)] , Private[k+ENC(A)]
+        # Using _key and _seed instead of __bytes__()
+        m.add_string(self._signing_key.verify_key._key)
+        m.add_string(self._signing_key._seed +
+            self._signing_key.verify_key._key)

--- a/paramiko/pkey.py
+++ b/paramiko/pkey.py
@@ -411,6 +411,15 @@ class PKey:
         """
         return False
 
+    def append_add_agent_parameters(self, m):
+        """
+        For use with Agent.add_key_to_agent()
+        Append Message with public/private key info that varies
+        based on key (or certificate) type.
+        """
+        raise Exception('Not implemented in PKey')
+
+
     @classmethod
     def from_private_key_file(cls, filename, password=None):
         """

--- a/paramiko/rsakey.py
+++ b/paramiko/rsakey.py
@@ -159,6 +159,15 @@ class RSAKey(PKey):
         else:
             return True
 
+    def append_add_agent_parameters(self, m):
+        # All mpint's n, e, d, iqmp, p, q
+        m.add_mpint(self.public_numbers.n)
+        m.add_mpint(self.public_numbers.e)
+        m.add_mpint(self.key.private_numbers().d)
+        m.add_mpint(self.key.private_numbers().iqmp)
+        m.add_mpint(self.key.private_numbers().p)
+        m.add_mpint(self.key.private_numbers().q)
+
     def write_private_key_file(self, filename, password=None):
         self._write_private_key_file(
             filename,


### PR DESCRIPTION
Add the ability to load private keys into the ssh agent and also remove them.
This PR tries to re-implement some of the functionality of ssh-add.
The implementation of the loading of new keys is taken from https://github.com/radssh/paramiko/tree/AddKeyToAgent, while the removal of keys is implemented by myself.