### PR TITLE
new optional paramiko host policy: prompt

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -861,6 +861,34 @@ class AutoAddPolicy(MissingHostKeyPolicy):
         )
 
 
+def no_yes(prompt: str) -> bool:
+    """ask a yes/no question, defaulting to no. Return False on no, True on yes"""
+    while True:
+        res = input(prompt + "\a [No/yes] ").lower()
+        if res and res not in ("yes", "no"):
+            print("invalid response, must be one of yes or no")
+            continue
+        if not res or res != "yes":
+            return False
+        break
+    return True
+
+
+class PromptAddPolicy(MissingHostKeyPolicy):
+    """
+    Policy for automatically adding the hostname and new host key to the
+    local `.HostKeys` object, and saving it.  This is used by `.SSHClient`.
+    """
+
+    def missing_host_key(self, client, hostname, key):
+        WarningPolicy.missing_host_key(self, client, hostname, key)
+        if not no_yes("Are you sure you want to continue connecting?"):
+            raise SSHException(
+                "Server {!r} not found in known_hosts".format(hostname)
+            )
+        AutoAddPolicy.missing_host_key(self, client, hostname, key)
+
+
 class RejectPolicy(MissingHostKeyPolicy):
     """
     Policy for automatically rejecting the unknown hostname & key.  This is


### PR DESCRIPTION
This policy tries to match a little closer what a "normal" SSH client does which is "trust on first use" (TOFU).

We do not actually set it as default, as I want to leave room for discussion and maximize the possibility of this being merged.

This is part of repeated attempts I have made at improving host key policy handling in Fabric, see:

https://github.com/fabric/fabric/pull/2076
https://github.com/paramiko/paramiko/pull/1647

To have this useful in Fabric, the former would be necessary.

Hopefully one of those will stick...