### PR TITLE
Find connectable address using sockaddr (resolved IP) instead of host

### DIFF
--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -490,7 +490,7 @@ class Transport(threading.Thread, ClosingContextManager):
                     # addr = sockaddr
                     sock = socket.socket(af, socket.SOCK_STREAM)
                     try:
-                        sock.connect((hostname, port))
+                        sock.connect(sockaddr)
                     except socket.error as e:
                         reason = str(e)
                     else:


### PR DESCRIPTION
Many systems receive a list of matching addresses from the `getaddressinfo` function. These addresses should be tried until a connection succeeds. Current implementaion only test connection using the default "hostname" without testing other addesses.

Quoted python documentation on socket library (https://docs.python.org/3/library/socket.html#socket.getaddrinfo)
"""
sockaddr is a tuple describing a socket address, whose format depends on the returned family (a (address, port) 2-tuple for [AF_INET](https://docs.python.org/3/library/socket.html#socket.AF_INET), a (address, port, flowinfo, scope_id) 4-tuple for [AF_INET6](https://docs.python.org/3/library/socket.html#socket.AF_INET6)), and is meant to be passed to the [socket.connect()](https://docs.python.org/3/library/socket.html#socket.socket.connect) method.
"""