### PR TITLE
Fixed version parsing issue with OpenSSH 10.0

### DIFF
--- a/paramiko/auth_handler.py
+++ b/paramiko/auth_handler.py
@@ -321,7 +321,7 @@ class AuthHandler:
         # regarding server-sig-algs, it's impossible to fit this into the rest
         # of the logic here.
         if key_type.endswith("-cert-v01@openssh.com") and re.search(
-            r"-OpenSSH_(?:[1-6]|7\.[0-7])", self.transport.remote_version
+            r"-OpenSSH_(?:(?:[1-6]|7)\.[0-7])", self.transport.remote_version
         ):
             pubkey_algo = "ssh-rsa-cert-v01@openssh.com"
             self.transport._agreed_pubkey_algorithm = pubkey_algo


### PR DESCRIPTION
Regex matches now for Version 1..7 but not for 10.

After upgrading to OpenSSH 10.0 the log showed:
`Remote version/idstring: SSH-2.0-OpenSSH_10.0`
But afterwards the log shows:
`OpenSSH<7.8 + RSA cert = forcing ssh-rsa!`
the authentication afterwards failed