### PR TITLE
Add handling of ssh include paths

### DIFF
--- a/tests/configs/include-base
+++ b/tests/configs/include-base
@@ -1,0 +1,1 @@
+Include tests/configs/include-me

--- a/tests/configs/include-me
+++ b/tests/configs/include-me
@@ -1,0 +1,5 @@
+Host www.paramiko.org
+    User rando
+
+Match host www.paramiko.org
+    IdentityFile canonicalized.key

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -569,6 +569,25 @@ Host *
         )
         assert config.lookup("anything-else").as_int("port") == 3333
 
+    def test_include(self):
+        expected = [
+            {"host": ["*"], "config": {}},
+            {"config": {"user": "rando"}, "host": ["www.paramiko.org"]},
+            {
+                "config": {"identityfile": ["canonicalized.key"]},
+                "matches": [
+                    {
+                        "type": "host",
+                        "param": "www.paramiko.org",
+                        "negate": False,
+                    }
+                ],
+            },
+        ]
+        config = SSHConfig.from_path(_config("include-base"))
+        for context in config._config:
+            assert context in expected
+
 
 class TestHostnameCanonicalization:
     # NOTE: this class uses on-disk configs, and ones with real (at time of


### PR DESCRIPTION
This is a simple ssh include path handler for ssh config files that have Include keys to files or directories. Does not cover nested includes under host or match for instance. The user is responsible for any circular logic or pathing issues.