### PR TITLE
Do not keep ImportError as global var

### DIFF
--- a/paramiko/config.py
+++ b/paramiko/config.py
@@ -31,7 +31,7 @@ from hashlib import sha1
 from io import StringIO
 from functools import partial
 
-invoke, invoke_import_error_msg = None
+invoke, invoke_import_error_msg = None, None
 try:
     import invoke
 except ImportError as e:

--- a/paramiko/proxy.py
+++ b/paramiko/proxy.py
@@ -26,7 +26,7 @@ import time
 
 # Try-and-ignore import so platforms w/o subprocess (eg Google App Engine) can
 # still import paramiko.
-subprocess, subprocess_import_error_msg = None
+subprocess, subprocess_import_error_msg = None, None
 try:
     import subprocess
 except ImportError as e:


### PR DESCRIPTION
Keeping the exception as global var forever is not a good idea.

Consider the following code:

- foo.py:

```python
import_error = None

try:
    import non_exists
except ImportError as e:
    import_error = e
```

- main.py:

```python
import time

class S:
    def __init__(self):
        print(f"created {id(self)}")
    def __del__(self):
        print(f"destroyed {id(self)}")

def main():
    import foo
    s = S()

if __name__ == '__main__':
    main()
    time.sleep(1000)
```

Run `python main.py`, it turns out that `s` object would not be destroyed after `main()` exits, because `import_error` references the frame object of the `main()` function call.

This can lead to unexpected memory leak when 1. users imports `paramiko` (even indirectly) inside a function local scope 2. the function creates some temporary resource intensive object. It's also very hard to diagnose once happened. In my case at work, this issues resulted memory leak of 100+GB  :(