### PR TITLE
Make `invoke` an optional dependency again

### DIFF
--- a/paramiko/config.py
+++ b/paramiko/config.py
@@ -31,12 +31,6 @@ from hashlib import sha1
 from io import StringIO
 from functools import partial
 
-invoke, invoke_import_error = None, None
-try:
-    import invoke
-except ImportError as e:
-    invoke_import_error = e
-
 from .ssh_exception import CouldNotCanonicalize, ConfigParseError
 
 
@@ -391,10 +385,8 @@ class SSHConfig:
                 exec_cmd = self._tokenize(
                     options, target_hostname, "match-exec", param
                 )
-                # This is the laziest spot in which we can get mad about an
-                # inability to import Invoke.
-                if invoke is None:
-                    raise invoke_import_error
+                import invoke
+
                 # Like OpenSSH, we 'redirect' stdout but let stderr bubble up
                 passed = invoke.run(exec_cmd, hide="stdout", warn=True).ok
             # Tackle any 'passed, but was negated' results from above

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,14 +11,8 @@ authors = [{name = "Jeff Forcier", email = "jeff@bitprophet.org"}]
 dependencies = [
     "bcrypt>=3.2",
     "cryptography>=3.3",
-    "invoke>=2.0",
     "pynacl>=1.5",
 ]
-optional-dependencies = {gssapi = [
-    "pyasn1>=0.1.7",
-    'gssapi>=1.4.1;platform_system!="Windows"',
-    'pywin32>=2.1.8;platform_system=="Windows"',
-]}
 
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -36,6 +30,14 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 
+[project.optional-dependencies]
+gssapi = [
+    "pyasn1>=0.1.7",
+    'gssapi>=1.4.1;platform_system!="Windows"',
+    'pywin32>=2.1.8;platform_system=="Windows"',
+]
+
+invoke = ["invoke>=2.0"]
 
 [project.urls]
 Docs = "https://docs.paramiko.org"


### PR DESCRIPTION
I was doing a routine dependency upgrade on a project and noticed `invoke` started getting pulled in by paramiko 4.0.0. I'm allergic to extra dependencies being pulled in, so I decided to investigate.

https://github.com/paramiko/paramiko/commit/dbfd52c50594164ed0cb884d90b1009bf48fccc6 (inadvertently? The commit message doesn't make a note of the change?) made `invoke`, only needed for `exec` credential helpers a non-optional dependency.

This pulls it back to a dependency group – and while at it, moves importing it to a very late stage, so no extra time is being spent importing it if exec credentials aren't used. This also simplifies the code a bit.