### PR TITLE
Drop `invoke` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ authors = [{name = "Jeff Forcier", email = "jeff@bitprophet.org"}]
 dependencies = [
     "bcrypt>=3.2",
     "cryptography>=3.3",
-    "invoke>=2.0",
     "pynacl>=1.5",
 ]
 optional-dependencies = {gssapi = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,7 @@ import os
 import shutil
 import threading
 from pathlib import Path
-
-from invoke.vendor.lexicon import Lexicon
+from types import SimpleNamespace
 
 import pytest
 from paramiko import (
@@ -150,7 +149,7 @@ def keys(request):
     - ``expected_fp``: the expected fingerprint of said key
     """
     short_type, key_type, key_class, fingerprint = request.param
-    bag = Lexicon()
+    bag = SimpleNamespace()
     bag.short_type = short_type
     bag.full_type = key_type
     bag.path = Path(_support(f"{short_type}.key"))


### PR DESCRIPTION
Alternate take for #2543 – shouldn't need a dependency just to see whether a process returns `1`.