### PR TITLE
Fix CVE-2025-69277

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
   "bcrypt>=3.2",
   "cryptography>=3.3",
   "invoke>=2.0",
-  "pynacl>=1.5",
+  "pynacl>=1.6.2",
 ]
 optional-dependencies = { gssapi = [
   "pyasn1>=0.1.7",


### PR DESCRIPTION
https://00f.net/2025/12/30/libsodium-vulnerability/ pynacl is also impacted.