### PR TITLE
transport.py: close socket when connection fails

### DIFF
--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -488,6 +488,7 @@ class Transport(threading.Thread, ClosingContextManager):
                         sock.connect((hostname, port))
                     except socket.error as e:
                         reason = str(e)
+                        sock.close()
                     else:
                         break
             else:


### PR DESCRIPTION
Noticing in some pytests of mine with `PytestUnraisableExceptionWarning` enabled that some sockets are dangling if the connection times out. Seems we need to close this here to handle.

What I saw locally before this change, with help from `PYTHONTRACEMALLOC`:
```
ResourceWarning: unclosed <socket.socket fd=11, family=2, type=1, proto=0, laddr=('0.0.0.0', #####)>

The above exception was the direct cause of the following exception:
...
pytest.PytestUnraisableExceptionWarning: Exception ignored in: <socket.socket fd=11, family=2, type=1, proto=0, laddr=('0.0.0.0', #####)>

Object allocated at:
  ... 
  <my code>
  ...
    self._xport = paramiko.Transport(
  File "<venv>/lib/python3.11/site-packages/paramiko/transport.py", line 491
    sock = socket.socket(af, socket.SOCK_STREAM)
```

Witnessed in paramiko 3.5.1 on py 3.11