### PR TITLE
Fix Paramiko parsing of SSH certificate public_blob

### DIFF
--- a/paramiko/agent.py
+++ b/paramiko/agent.py
@@ -29,6 +29,7 @@ import time
 import tempfile
 import stat
 from logging import DEBUG
+from collections import namedtuple
 from select import select
 from paramiko.common import io_sleep, byte_chr
 
@@ -467,6 +468,15 @@ class AgentKey(PKey):
         if self.inner_key is not None:
             return self.inner_key.get_bits()
         return super().get_bits()
+
+    @property
+    def public_blob(self):
+        # If Paramiko managed to parse a real PKey object (RSA/Ed25519), use its blob
+        if self.inner_key is not None and hasattr(self.inner_key, 'public_blob'):
+            return self.inner_key.public_blob
+        # Otherwise, wrap the raw agent blob so AuthHandler can still see
+        # the key_type (self.name) and the raw bytes (self.blob)
+        return namedtuple('BlobWrapper', 'key_type key_blob')(self.name, self.blob)
 
     def __getattr__(self, name):
         """

--- a/paramiko/agent.py
+++ b/paramiko/agent.py
@@ -472,11 +472,15 @@ class AgentKey(PKey):
     @property
     def public_blob(self):
         # If Paramiko managed to parse a real PKey object (RSA/Ed25519), use its blob
-        if self.inner_key is not None and hasattr(self.inner_key, 'public_blob'):
+        if self.inner_key is not None and hasattr(
+            self.inner_key, 'public_blob'
+        ):
             return self.inner_key.public_blob
         # Otherwise, wrap the raw agent blob so AuthHandler can still see
         # the key_type (self.name) and the raw bytes (self.blob)
-        return namedtuple('BlobWrapper', 'key_type key_blob')(self.name, self.blob)
+        return namedtuple('BlobWrapper', 'key_type key_blob')(
+            self.name, self.blob
+        )
 
     def __getattr__(self, name):
         """

--- a/paramiko/agent.py
+++ b/paramiko/agent.py
@@ -471,14 +471,15 @@ class AgentKey(PKey):
 
     @property
     def public_blob(self):
-        # If Paramiko managed to parse a real PKey object (RSA/Ed25519), use its blob
+        # If Paramiko managed to parse a real
+        # PKey object (RSA/Ed25519), use its blob
         if self.inner_key is not None and hasattr(
-            self.inner_key, 'public_blob'
+            self.inner_key, "public_blob"
         ):
             return self.inner_key.public_blob
         # Otherwise, wrap the raw agent blob so AuthHandler can still see
         # the key_type (self.name) and the raw bytes (self.blob)
-        return namedtuple('BlobWrapper', 'key_type key_blob')(
+        return namedtuple("BlobWrapper", "key_type key_blob")(
             self.name, self.blob
         )
 

--- a/tests/agent.py
+++ b/tests/agent.py
@@ -149,3 +149,15 @@ class AgentKey_:
             assert msg.get_string() == expected_request_key_blob
             assert msg.get_string() == b"data-to-sign"
             assert msg.get_int() == expected_flag
+    def exposes_public_blob(self):
+            agent = Mock()
+            # Use a type that Paramiko doesn't have a specific class for.
+            # This prevents it from trying to parse 'some-signature-data' as RSA math.
+            msg = Message()
+            msg.add_string("unsupported-cert-type@example.com")
+            msg.add_bytes(b"some-signature-data")
+            fake_blob = bytes(msg)
+            key = AgentKey(agent=agent, blob=fake_blob)
+            # Verify our new property works even for types Paramiko can't parse internally
+            assert key.public_blob.key_type == "unsupported-cert-type@example.com"
+            assert key.public_blob.key_blob == fake_blob

--- a/tests/agent.py
+++ b/tests/agent.py
@@ -153,7 +153,8 @@ class AgentKey_:
     def exposes_public_blob(self):
         agent = Mock()
         # Use a type that Paramiko doesn't have a specific class for.
-        # This prevents it from trying to parse 'some-signature-data' as RSA math.
+        # This prevents it from trying to parse 'some-signature-data' as
+        # RSA math.
         msg = Message()
         msg.add_string("unsupported-cert-type@example.com")
         msg.add_bytes(b"some-signature-data")

--- a/tests/agent.py
+++ b/tests/agent.py
@@ -160,6 +160,7 @@ class AgentKey_:
         msg.add_bytes(b"some-signature-data")
         fake_blob = bytes(msg)
         key = AgentKey(agent=agent, blob=fake_blob)
-        # Verify our new property works even for types Paramiko can't parse internally
+        # Verify our new property works even for types Paramiko can't
+        # parse internally
         assert key.public_blob.key_type == "unsupported-cert-type@example.com"
         assert key.public_blob.key_blob == fake_blob

--- a/tests/agent.py
+++ b/tests/agent.py
@@ -149,15 +149,16 @@ class AgentKey_:
             assert msg.get_string() == expected_request_key_blob
             assert msg.get_string() == b"data-to-sign"
             assert msg.get_int() == expected_flag
+
     def exposes_public_blob(self):
-            agent = Mock()
-            # Use a type that Paramiko doesn't have a specific class for.
-            # This prevents it from trying to parse 'some-signature-data' as RSA math.
-            msg = Message()
-            msg.add_string("unsupported-cert-type@example.com")
-            msg.add_bytes(b"some-signature-data")
-            fake_blob = bytes(msg)
-            key = AgentKey(agent=agent, blob=fake_blob)
-            # Verify our new property works even for types Paramiko can't parse internally
-            assert key.public_blob.key_type == "unsupported-cert-type@example.com"
-            assert key.public_blob.key_blob == fake_blob
+        agent = Mock()
+        # Use a type that Paramiko doesn't have a specific class for.
+        # This prevents it from trying to parse 'some-signature-data' as RSA math.
+        msg = Message()
+        msg.add_string("unsupported-cert-type@example.com")
+        msg.add_bytes(b"some-signature-data")
+        fake_blob = bytes(msg)
+        key = AgentKey(agent=agent, blob=fake_blob)
+        # Verify our new property works even for types Paramiko can't parse internally
+        assert key.public_blob.key_type == "unsupported-cert-type@example.com"
+        assert key.public_blob.key_blob == fake_blob


### PR DESCRIPTION
When trying to use Paramiko with ssh certificates stored in the `ssh-agent`, we can observe failures to connect when using a simple connection script:

```
import paramiko
import os

def test_agent_cert_auth():
    client = paramiko.SSHClient()
    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())

    # This should ideally pick up the certificate from your running ssh-agent
    try:
        client.connect('localhost', username='calderonth', allow_agent=True)
        print("Authentication successful!")
    except Exception as e:
        print(f"Authentication failed: {e}")

if __name__ == "__main__":
    test_agent_cert_auth()
```
Running it produces the following stack trace:
```
sys-python test.py
Unknown exception: public_blob
Traceback (most recent call last):
  File ".../python3.11/site-packages/paramiko/transport.py", line 2262, in run
    handler(m)
  File ".../python3.11/site-packages/paramiko/auth_handler.py", line 394, in _parse_service_accept
    key_type, bits = self._get_key_type_and_bits(self.private_key)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../lib/python3.11/site-packages/paramiko/auth_handler.py", line 218, in _get_key_type_and_bits
    if key.public_blob:
       ^^^^^^^^^^^^^^^
  File ".../lib/python3.11/site-packages/paramiko/agent.py", line 476, in __getattr__
    raise AttributeError(name)
AttributeError: public_blob

Authentication failed: public_blob
```

Example content of the ssh-agent:
```
ssh-add -l
256 SHA256:E2MBaXQgjsV7KJo1sAO7REyu5WI0U1kU4X9ElT25Owo calderonth@example.com (ECDSA-CERT)
```

The following PR implements a `@property` in the AgentKey class that satisfies the interface expected by AuthHandler without breaking the existing proxy logic.

Changes in paramiko/agent.py:
  * Added a public_blob property to the AgentKey class.
  * The property returns the inner_key.public_blob if it exists (for standard keys).
  * For keys where the inner key is missing (like certificates the agent handles but Paramiko hasn't fully parsed), it returns a namedtuple containing key_type (from self.name) and key_blob (from self.blob).
  
Testing & Validation
Added regression test to tests/agent.py using the pytest-relaxed style familiar to the Paramiko codebase

Other issues this may help with #2462 #2320  #2299