### PR TITLE
Fix deprecated SPDX license identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires-python = ">=3.9"
 version = "4.0.0"
 description = "SSH2 protocol library"
 readme = "README.rst"
-license = "LGPL-2.1"
+license = "LGPL-2.1-only"
 license-files = ["LICENSE"]
 authors = [{ name = "Jeff Forcier", email = "jeff@bitprophet.org" }]
 


### PR DESCRIPTION
Update license metadata from deprecated `LGPL-2.1` to `LGPL-2.1-only` SPDX identifier.

The `LGPL-2.1` identifier is deprecated by SPDX and causes ambiguity. The correct identifier is `LGPL-2.1-only`.

Fixes #2563