### PR TITLE
Fix duplicate auth methods in Transport docs

### DIFF
--- a/sites/docs/api/transport.rst
+++ b/sites/docs/api/transport.rst
@@ -3,3 +3,4 @@ Transport
 
 .. automodule:: paramiko.transport
     :member-order: bysource
+    :exclude-members: ServiceRequestingTransport


### PR DESCRIPTION
## Summary

Fixes #2556 — `auth_interactive()`, `auth_interactive_dumb()`, and other auth methods were appearing twice in the [Transport docs](https://docs.paramiko.org/en/stable/api/transport.html).

## Root Cause

The `paramiko.transport` module contains both `Transport` and its subclass `ServiceRequestingTransport`, which intentionally overrides several auth methods for internal refactoring (with `# TODO 4.0: merge to parent` comments). Since the docs use `automodule`, both classes are documented, causing the inherited/overridden methods to render twice.

## Fix

Added `:exclude-members: ServiceRequestingTransport` to the Sphinx `automodule` directive. This class is an internal implementation detail not intended for public API documentation.