### PR TITLE
Fixed transport join, moved host keys subdict, reduced tuple deep copying

### DIFF
--- a/paramiko/hostkeys.py
+++ b/paramiko/hostkeys.py
@@ -32,6 +32,51 @@ from paramiko.util import get_logger, constant_time_bytes_eq, b, u
 from paramiko.ssh_exception import SSHException
 
 
+class _SubDict(MutableMapping):
+    def __init__(self, hostname, entries, hostkeys):
+        self._hostname = hostname
+        self._entries = entries
+        self._hostkeys = hostkeys
+
+    def __iter__(self):
+        for k in self.keys():
+            yield k
+
+    def __len__(self):
+        return len(self.keys())
+
+    def __delitem__(self, key):
+        for e in list(self._entries):
+            if e.key.get_name() == key:
+                self._entries.remove(e)
+                break
+        else:
+            raise KeyError(key)
+
+    def __getitem__(self, key):
+        for e in self._entries:
+            if e.key.get_name() == key:
+                return e.key
+        raise KeyError(key)
+
+    def __setitem__(self, key, val):
+        for e in self._entries:
+            if e.key is None:
+                continue
+            if e.key.get_name() == key:
+                # replace
+                e.key = val
+                break
+        else:
+            # add a new one
+            e = HostKeyEntry([self._hostname], val)
+            self._entries.append(e)
+            self._hostkeys._entries.append(e)
+
+    def keys(self):
+        return [e.key.get_name() for e in self._entries if e.key is not None]
+
+
 class HostKeys(MutableMapping):
     """
     Representation of an OpenSSH-style "known hosts" file.  Host keys can be
@@ -132,62 +177,13 @@ class HostKeys(MutableMapping):
         :return: dict of `str` -> `.PKey` keys associated with this host
             (or ``None``)
         """
-
-        class SubDict(MutableMapping):
-            def __init__(self, hostname, entries, hostkeys):
-                self._hostname = hostname
-                self._entries = entries
-                self._hostkeys = hostkeys
-
-            def __iter__(self):
-                for k in self.keys():
-                    yield k
-
-            def __len__(self):
-                return len(self.keys())
-
-            def __delitem__(self, key):
-                for e in list(self._entries):
-                    if e.key.get_name() == key:
-                        self._entries.remove(e)
-                        break
-                else:
-                    raise KeyError(key)
-
-            def __getitem__(self, key):
-                for e in self._entries:
-                    if e.key.get_name() == key:
-                        return e.key
-                raise KeyError(key)
-
-            def __setitem__(self, key, val):
-                for e in self._entries:
-                    if e.key is None:
-                        continue
-                    if e.key.get_name() == key:
-                        # replace
-                        e.key = val
-                        break
-                else:
-                    # add a new one
-                    e = HostKeyEntry([hostname], val)
-                    self._entries.append(e)
-                    self._hostkeys._entries.append(e)
-
-            def keys(self):
-                return [
-                    e.key.get_name()
-                    for e in self._entries
-                    if e.key is not None
-                ]
-
         entries = []
         for e in self._entries:
             if self._hostname_matches(hostname, e):
                 entries.append(e)
         if len(entries) == 0:
             return None
-        return SubDict(hostname, entries, self)
+        return _SubDict(hostname, entries, self)
 
     def _hostname_matches(self, hostname, entry):
         """

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -595,6 +595,9 @@ class Transport(threading.Thread, ClosingContextManager):
 
     def _filter_algorithm(self, type_):
         default = getattr(self, "_preferred_{}".format(type_))
+        disabled = self.disabled_algorithms.get(type_, [])
+        if not disabled:
+            return default
         return tuple(
             x
             for x in default
@@ -929,6 +932,7 @@ class Transport(threading.Thread, ClosingContextManager):
         for chan in list(self._channels.values()):
             chan._unlink()
         self.sock.close()
+        self.join()
 
     def get_remote_server_key(self):
         """
@@ -1397,13 +1401,13 @@ class Transport(threading.Thread, ClosingContextManager):
             # for its nameS plural, and just use that.
             # TODO: that could be used in a bunch of other spots too
             if isinstance(hostkey, RSAKey):
-                self._preferred_keys = [
+                self._preferred_keys = (
                     "rsa-sha2-512",
                     "rsa-sha2-256",
                     "ssh-rsa",
-                ]
+                )
             else:
-                self._preferred_keys = [hostkey.get_name()]
+                self._preferred_keys = (hostkey.get_name(),)
 
         self.set_gss_host(
             gss_host=gss_host,
@@ -1922,7 +1926,6 @@ class Transport(threading.Thread, ClosingContextManager):
             self.is_alive()
             and self is not threading.current_thread()
             and not self.sock._closed
-            and not self.packetizer.closed
         ):
             self.join(0.1)
 
@@ -2298,6 +2301,7 @@ class Transport(threading.Thread, ClosingContextManager):
                 self._log(ERROR, "Unknown exception: " + str(e))
                 self._log(ERROR, util.tb_strings())
                 self.saved_exception = e
+            self._handler_table.clear()
             _active_threads.remove(self)
             for chan in list(self._channels.values()):
                 chan._unlink()


### PR DESCRIPTION
SSHClients do not release all their memory after close. This patch helps Python realize objects are not referenced and can be freed.

Transport `stop_thread()`: `packetizer.close()` is called which sets `packetizer.closed` to `True` and prevents the following while loop from every evaluating. I removed `packetizer.closed` clause from while loop

Transport `_handler_table`: Python got confused with a dict of function pointers and didn't automatically free them. I cleared `_handler_table` when complete.

Transport `_filter_algorithms()`: It would deep copy the algorithms every time regardless of if filtering was necessary. I added a check to return the unfiltered tuple if able.

HostKeys `lookup()`: The anonymous class `SubDict` had a reference to `hostname` which led it to be unique for each call and require unique allocation. I moved the class outside of the function call and repaired the `hostname` reference.