### PR TITLE
Add show-inheritance to autodoc config

### DIFF
--- a/sites/docs/conf.py
+++ b/sites/docs/conf.py
@@ -13,6 +13,7 @@ extensions.extend(["sphinx.ext.autodoc"])
 autodoc_default_options = {
     "members": True,
     "special-members": True,
+    "show-inheritance": True,
 }
 
 # Default is 'local' building, but reference the public www site when building


### PR DESCRIPTION
This PR fixes #2532 by adding `'show-inheritance': True` to the `autodoc_default_options` dictionary in `sites/docs/conf.py`.

This will display base classes in the class documentation signatures, making it easier to understand inheritance relationships. For example, the ChannelFile documentation will now show that it inherits from BufferedFile.

The change is minimal and follows Sphinx's recommended approach for enabling inheritance display across all autodoc-generated documentation.