### PR TITLE
Fix ProxyCommand.close() file descriptor leak

### DIFF
--- a/paramiko/proxy.py
+++ b/paramiko/proxy.py
@@ -19,7 +19,6 @@
 
 import os
 import shlex
-import signal
 from select import select
 import socket
 import time
@@ -119,7 +118,20 @@ class ProxyCommand(ClosingContextManager):
             raise ProxyCommandFailure(" ".join(self.cmd), e.strerror)
 
     def close(self):
-        os.kill(self.process.pid, signal.SIGTERM)
+        try:
+            self.process.terminate()
+            self.process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            self.process.kill()
+            self.process.wait()
+        finally:
+            for attr in ("stdin", "stdout", "stderr"):
+                pipe = getattr(self.process, attr, None)
+                if pipe is not None:
+                    try:
+                        pipe.close()
+                    except OSError:
+                        pass
 
     @property
     def closed(self):

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,7 +1,7 @@
-import signal
 import socket
+import subprocess
 
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock, call
 from pytest import raises
 
 from paramiko import ProxyCommand, ProxyCommandFailure
@@ -101,11 +101,76 @@ class TestProxyCommand:
         assert info.value.error == "whoops"
 
     @patch("paramiko.proxy.subprocess.Popen")
-    @patch("paramiko.proxy.os.kill")
-    def test_close_kills_subprocess(self, os_kill, Popen):
+    def test_close_terminates_and_waits_for_subprocess(self, Popen):
         proxy = ProxyCommand("hi")
         proxy.close()
-        os_kill.assert_called_once_with(Popen.return_value.pid, signal.SIGTERM)
+        Popen.return_value.terminate.assert_called_once()
+        Popen.return_value.wait.assert_called_once_with(timeout=5)
+
+    @patch("paramiko.proxy.subprocess.Popen")
+    def test_close_closes_all_pipes(self, Popen):
+        proxy = ProxyCommand("hi")
+        proxy.close()
+        Popen.return_value.stdin.close.assert_called_once()
+        Popen.return_value.stdout.close.assert_called_once()
+        Popen.return_value.stderr.close.assert_called_once()
+
+    @patch("paramiko.proxy.subprocess.Popen")
+    def test_close_force_kills_on_timeout(self, Popen):
+        Popen.return_value.wait.side_effect = [
+            subprocess.TimeoutExpired("hi", 5),
+            None,
+        ]
+        proxy = ProxyCommand("hi")
+        proxy.close()
+        Popen.return_value.terminate.assert_called_once()
+        Popen.return_value.kill.assert_called_once()
+        # wait called twice: once with timeout, once after kill
+        assert Popen.return_value.wait.call_count == 2
+
+    @patch("paramiko.proxy.subprocess.Popen")
+    def test_close_closes_pipes_even_after_force_kill(self, Popen):
+        Popen.return_value.wait.side_effect = [
+            subprocess.TimeoutExpired("hi", 5),
+            None,
+        ]
+        proxy = ProxyCommand("hi")
+        proxy.close()
+        # Pipes should still be closed in the finally block
+        Popen.return_value.stdin.close.assert_called_once()
+        Popen.return_value.stdout.close.assert_called_once()
+        Popen.return_value.stderr.close.assert_called_once()
+
+    def test_close_no_fd_leak_with_real_subprocess(self):
+        """Integration test: verify close() does not leak file descriptors."""
+        import os
+
+        def count_fds():
+            # macOS and Linux compatible
+            try:
+                return len(os.listdir(f"/proc/{os.getpid()}/fd"))
+            except FileNotFoundError:
+                # macOS: use lsof -p
+                import subprocess as sp
+                result = sp.run(
+                    ["lsof", "-p", str(os.getpid())],
+                    capture_output=True, text=True,
+                )
+                return len(result.stdout.strip().splitlines()) - 1
+
+        initial_fds = count_fds()
+
+        for _ in range(20):
+            proxy = ProxyCommand("cat")
+            proxy.close()
+
+        final_fds = count_fds()
+        # Allow a small margin (e.g., 3 FDs) for interpreter internals,
+        # but definitely not 60 (which would be 3 per iteration leaked).
+        assert final_fds - initial_fds < 10, (
+            f"FD leak detected: started with {initial_fds}, "
+            f"ended with {final_fds} (leaked {final_fds - initial_fds})"
+        )
 
     @patch("paramiko.proxy.subprocess.Popen")
     def test_closed_exposes_whether_subprocess_has_exited(self, Popen):

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,7 +1,7 @@
 import socket
 import subprocess
 
-from unittest.mock import patch, MagicMock, call
+from unittest.mock import patch
 from pytest import raises
 
 from paramiko import ProxyCommand, ProxyCommandFailure
@@ -152,9 +152,11 @@ class TestProxyCommand:
             except FileNotFoundError:
                 # macOS: use lsof -p
                 import subprocess as sp
+
                 result = sp.run(
                     ["lsof", "-p", str(os.getpid())],
-                    capture_output=True, text=True,
+                    capture_output=True,
+                    text=True,
                 )
                 return len(result.stdout.strip().splitlines()) - 1
 


### PR DESCRIPTION
`ProxyCommand.close()` only sends `SIGTERM` to the child process but never closes the `stdin`/`stdout`/`stderr` pipes or waits for the process to exit. This leaks 3 file descriptors per `ProxyCommand` lifecycle, which adds up in long-running applications that create many SSH connections (test suites, monitoring tools, orchestration systems, etc.) until hitting the `select()` `FD_SETSIZE` limit of 1024.

### Changes

- Replace raw `os.kill(pid, SIGTERM)` with `process.terminate()` + `process.wait(timeout=5)`, falling back to `process.kill()` + `process.wait()` if the process doesn't exit in time
- Close all three pipe file descriptors (`stdin`, `stdout`, `stderr`) in a `finally` block so they're released even if termination/kill raises
- Remove the now-unused `signal` import

### Testing

- Updated the existing `test_close_kills_subprocess` to verify `terminate()` and `wait()` are called
- Added `test_close_closes_all_pipes` to verify all pipe FDs are closed
- Added `test_close_force_kills_on_timeout` to cover the `TimeoutExpired` -> `kill()` path
- Added `test_close_closes_pipes_even_after_force_kill` to verify pipes are closed in the force-kill path
- Added integration test `test_close_no_fd_leak_with_real_subprocess` that creates 20 real `cat` subprocesses and verifies FD count stays stable

```
$ python3 -m pytest tests/test_proxy.py -v
15 passed in 0.63s
```

Manual verification with 50 iterations confirmed zero leaked FDs:
```
Initial FDs: 43
Final FDs: 43
Leaked: 0
```

Fixes #2568