### PR TITLE
Fix file offset calculation in SFTP check-file hash computation

### DIFF
--- a/paramiko/sftp_server.py
+++ b/paramiko/sftp_server.py
@@ -345,7 +345,7 @@ class SFTPServer(BaseSFTP, SubsystemHandler):
                     return
                 hash_obj.update(data)
                 count += len(data)
-                offset += count
+                offset += len(data)
             sum_out += hash_obj.digest()
 
         msg = Message()


### PR DESCRIPTION
## Summary

Fix a file offset computation error in `_check_file()` that causes the SFTP `check-file` extension to produce incorrect block hashes for files larger than one chunk (~64KB).

## Problem

In the inner loop of `_check_file()`, the file offset is advanced by `count` (the cumulative total of bytes read so far for the current block) instead of `len(data)` (the number of bytes read in the current iteration):

```python
while count < blocklen:
    data = f.read(offset, chunklen)
    hash_obj.update(data)
    count += len(data)
    offset += count       # Bug: count is cumulative, not incremental
```

Since `count` accumulates across iterations, the offset grows quadratically:

| Iteration | len(data) | count | offset += | Should be |
|-----------|-----------|-------|-----------|-----------|
| 1         | 1000      | 1000  | 1000      | 1000 ✓    |
| 2         | 1000      | 2000  | **2000**  | 1000 ✗    |
| 3         | 1000      | 3000  | **3000**  | 1000 ✗    |

This skips increasingly large sections of the file between reads.

## Impact

Block hashes are computed over non-contiguous, incomplete data. Any SFTP client using the `check-file` extension for integrity verification or differential sync gets incorrect results when blocks span more than one 64KB chunk.

## Fix

Change `offset += count` to `offset += len(data)` so the offset advances by exactly the number of bytes read in each iteration.
