### PR TITLE
Fix FSETSTAT invalid handle to send CMD_STATUS instead of raw _response

### DIFF
--- a/paramiko/sftp_server.py
+++ b/paramiko/sftp_server.py
@@ -488,7 +488,7 @@ class SFTPServer(BaseSFTP, SubsystemHandler):
             handle = msg.get_binary()
             attr = SFTPAttributes._from_msg(msg)
             if handle not in self.file_table:
-                self._response(
+                self._send_status(
                     request_number, SFTP_BAD_MESSAGE, "Invalid handle"
                 )
                 return


### PR DESCRIPTION
## Summary

Fix the `CMD_FSETSTAT` invalid-handle error path to use `_send_status()` instead of `_response()`.

## Problem

When a client sends `CMD_FSETSTAT` with an unknown handle, the error path calls:
```python
self._response(request_number, SFTP_BAD_MESSAGE, "Invalid handle")
```

`_response()` uses its second argument as the **SFTP packet type**. `SFTP_BAD_MESSAGE` has value `5`, which is also the value of `CMD_WRITE`. So the server sends a response with packet type 5 (`SSH_FXP_WRITE`) containing the error code and message.

SFTP clients expect a `CMD_STATUS` (type 101 / `SSH_FXP_STATUS`) response for error conditions. Receiving an unexpected `SSH_FXP_WRITE` packet as a response to `SSH_FXP_FSETSTAT` will cause client-side parsing errors.

## Context

Every other invalid-handle branch in `_process()` correctly uses `_send_status()`:
- `CMD_CLOSE` → `_send_status()`
- `CMD_READ` → `_send_status()`
- `CMD_WRITE` → `_send_status()`
- `CMD_FSTAT` → `_send_status()`
- **`CMD_FSETSTAT` → `_response()`** ← the one that's wrong

## Fix

Replace the `_response()` call with `_send_status()`, which wraps the error code inside a proper `CMD_STATUS` packet — consistent with all other handlers.
