### PR TITLE
Fix sha1 hash input in GSS Group1 client-side kex completion

### DIFF
--- a/paramiko/kex_gss.py
+++ b/paramiko/kex_gss.py
@@ -227,7 +227,7 @@ class KexGSSGroup1:
         hm.add_mpint(self.e)
         hm.add_mpint(self.f)
         hm.add_mpint(K)
-        H = sha1(str(hm)).digest()
+        H = sha1(hm.asbytes()).digest()
         self.transport._set_K_H(K, H)
         if srv_token is not None:
             self.kexgss.ssh_init_sec_context(


### PR DESCRIPTION
## Summary

Fix `KexGSSGroup1._parse_kexgss_complete()` to hash the exchange message bytes instead of its repr string.

## Problem

The client-side handler for `SSH_MSG_KEXGSS_COMPLETE` in `KexGSSGroup1` computes the exchange hash as:

```python
H = sha1(str(hm)).digest()
```

`hm` is a `Message` object (a `BytesIO` subclass). On Python 3, `str()` on a `BytesIO` returns its repr string — something like `"<_io.BytesIO object at 0x7f...>"` — not the actual buffer content. Then `sha1()` raises `TypeError` because `hashlib.sha1()` requires `bytes`, not `str`.

The server-side handler in the same class at line 269 already uses the correct form:

```python
H = sha1(hm.asbytes()).digest()
```

As do both handlers in `KexGSSGex` (lines 532 and 634).

## Impact

GSS-API Group1 key exchange (`gss-group1-sha1-*`) always fails in client mode on Python 3 with an unhandled `TypeError` during the kex completion step.

## Fix

Replace `sha1(str(hm))` with `sha1(hm.asbytes())`, consistent with every other hash computation in the same file.
