### PR TITLE
Clean up threads in sftp_server fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,9 +95,13 @@ def sftp_server():
     event.wait(1.0)
     # Make & yield connection.
     tc.connect(username="slowdive", password="pygmalion")
-    yield tc
-    # TODO: any need for shutdown? Why didn't old suite do so? Or was that the
-    # point of the "join all threads from threading module" crap in test.py?
+    try:
+        yield tc
+    finally:
+        tc.close()
+        ts.close()
+        socks.close()
+        sockc.close()
 
 
 @pytest.fixture


### PR DESCRIPTION
The `sftp_server` fixture never cleaned up the server thread; this was easily visible by watching `htop` while running the test suite.

On some underpowered architectures this could eventually result in `RuntimeError: can't start new thread`.  This was the root cause of https://bugs.debian.org/1127663.

Fixes: #2567