### PR TITLE
fix(config): handle key=value syntax in Match directives

### DIFF
--- a/paramiko/config.py
+++ b/paramiko/config.py
@@ -526,16 +526,25 @@ class SSHConfig:
             if type_.startswith("!"):
                 match["negate"] = True
                 type_ = type_[1:]
+            # Handle key=value syntax (e.g. "host=pattern") in
+            # addition to key value; OpenSSH accepts both forms.
+            if "=" in type_:
+                type_, param = type_.split("=", 1)
+            else:
+                param = None
             match["type"] = type_
             # all/canonical have no params (everything else does)
             if type_ in ("all", "canonical", "final"):
                 matches.append(match)
                 continue
-            if not tokens:
+            if param is not None:
+                match["param"] = param
+            elif tokens:
+                match["param"] = tokens.pop(0)
+            else:
                 raise ConfigParseError(
                     "Missing parameter to Match '{}' keyword".format(type_)
                 )
-            match["param"] = tokens.pop(0)
             matches.append(match)
         # Perform some (easier to do now than in the middle) validation that is
         # better handled here than at lookup time.

--- a/tests/configs/match-host-equals
+++ b/tests/configs/match-host-equals
@@ -1,0 +1,2 @@
+Match host=target
+    User rand

--- a/tests/configs/match-host-equals-glob
+++ b/tests/configs/match-host-equals-glob
@@ -1,0 +1,2 @@
+Match host=*ever
+    User matrim

--- a/tests/configs/match-host-equals-negated
+++ b/tests/configs/match-host-equals-negated
@@ -1,0 +1,2 @@
+Match !host=www
+    User jeff

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -874,6 +874,27 @@ class TestMatchHost:
         with raises(ConfigParseError):
             load_config("match-host-no-arg")
 
+    def test_equals_syntax(self):
+        """Match host=pattern works like Match host pattern.
+
+        Regression test for https://github.com/paramiko/paramiko/issues/2522
+        """
+        result = load_config("match-host-equals").lookup("target")
+        assert result["user"] == "rand"
+
+    def test_equals_syntax_with_glob(self):
+        result = load_config("match-host-equals-glob").lookup("whatever")
+        assert result["user"] == "matrim"
+
+    def test_equals_syntax_non_match(self):
+        result = load_config("match-host-equals").lookup("other")
+        assert "user" not in result
+
+    def test_equals_syntax_with_negation(self):
+        conf = load_config("match-host-equals-negated")
+        assert conf.lookup("docs")["user"] == "jeff"
+        assert "user" not in conf.lookup("www")
+
 
 class TestMatchOriginalHost:
     def test_matches_target_host_not_hostname(self):


### PR DESCRIPTION
## Summary

- Fix `ConfigParseError` when ssh_config uses `Match host=pattern` syntax (equals sign instead of space separator)
- `_get_matches` now splits tokens on the first `=` to extract keyword and parameter, matching OpenSSH's accepted syntax
- Added 4 regression tests covering exact match, glob match, non-match, and negation with equals syntax

Closes #2522

## Test plan

- [x] Existing 110+ config tests pass (117 passed, 7 skipped)
- [x] New `test_equals_syntax` — verifies `Match host=target` matches correctly
- [x] New `test_equals_syntax_with_glob` — verifies `Match host=*ever` glob matching
- [x] New `test_equals_syntax_non_match` — verifies non-matching host is excluded
- [x] New `test_equals_syntax_with_negation` — verifies `Match !host=www` negation works
- [x] `black` formatting applied
- [x] `flake8` clean (no new issues)

Generated with [Dhiman's Agentic Suite](https://github.com/Dhi13man)