### PR TITLE
fix: [BUG] wrong documentation on how known hosts are merged

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -82,8 +82,8 @@ class SSHClient(ClosingContextManager):
         this method will not be saved back by `save_host_keys`.
 
         This method can be called multiple times.  Each new set of host keys
-        will be merged with the existing set (new replacing old if there are
-        conflicts).
+        will be merged with the existing set (existing entries are kept if
+        there are conflicts).
 
         If ``filename`` is left as ``None``, an attempt will be made to read
         keys from the user's local "known hosts" file, as used by OpenSSH,
@@ -114,8 +114,9 @@ class SSHClient(ClosingContextManager):
         saves them, when connecting to a previously-unknown server.
 
         This method can be called multiple times.  Each new set of host keys
-        will be merged with the existing set (new replacing old if there are
-        conflicts).  When automatically saving, the last hostname is used.
+        will be merged with the existing set (existing entries are kept if
+        there are conflicts).  When automatically saving, the last hostname
+        is used.
 
         :param str filename: the filename to read
 

--- a/paramiko/hostkeys.py
+++ b/paramiko/hostkeys.py
@@ -79,8 +79,8 @@ class HostKeys(MutableMapping):
         ``os.path.expanduser("~/.ssh/known_hosts")``.
 
         If this method is called multiple times, the host keys are merged,
-        not cleared.  So multiple calls to `load` will just call `add`,
-        replacing any existing entries and adding new ones.
+        not cleared.  So multiple calls to `load` will add new entries,
+        skipping any existing entries for the same hostname and key type.
 
         :param str filename: name of the file to read host keys from
 


### PR DESCRIPTION
Fixes #2572

The docstrings in `paramiko/client.py` (`load_host_keys`, `load_system_host_keys`) and `paramiko/hostkeys.py` (`HostKeys.load`) incorrectly stated that new entries replace existing ones during a merge conflict. The actual behavior preserves existing entries when a conflict is detected -- the documentation was simply wrong relative to the implementation. Updates the affected docstrings in all three locations to accurately describe the skip-on-conflict behavior. Verified by inspecting the merge logic directly against the corrected documentation.