### PR TITLE
ProxyCommand.close: close pipes, reap process, and handle already-exited child

### DIFF
--- a/paramiko/proxy.py
+++ b/paramiko/proxy.py
@@ -19,7 +19,6 @@
 
 import os
 import shlex
-import signal
 from select import select
 import socket
 import time
@@ -119,7 +118,32 @@ class ProxyCommand(ClosingContextManager):
             raise ProxyCommandFailure(" ".join(self.cmd), e.strerror)
 
     def close(self):
-        os.kill(self.process.pid, signal.SIGTERM)
+        try:
+            self.process.terminate()
+        except ProcessLookupError:
+            pass
+        try:
+            self.process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            try:
+                self.process.kill()
+            except ProcessLookupError:
+                pass
+            self.process.wait()
+        except ChildProcessError:
+            pass
+        finally:
+            for pipe in (
+                self.process.stdin,
+                self.process.stdout,
+                self.process.stderr,
+            ):
+                if pipe is None:
+                    continue
+                try:
+                    pipe.close()
+                except OSError:
+                    pass
 
     @property
     def closed(self):

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,7 +1,7 @@
-import signal
 import socket
+import subprocess
 
-from unittest.mock import patch
+from unittest.mock import call, patch
 from pytest import raises
 
 from paramiko import ProxyCommand, ProxyCommandFailure
@@ -101,11 +101,52 @@ class TestProxyCommand:
         assert info.value.error == "whoops"
 
     @patch("paramiko.proxy.subprocess.Popen")
-    @patch("paramiko.proxy.os.kill")
-    def test_close_kills_subprocess(self, os_kill, Popen):
+    def test_close_terminates_waits_and_closes_pipes(self, Popen):
         proxy = ProxyCommand("hi")
         proxy.close()
-        os_kill.assert_called_once_with(Popen.return_value.pid, signal.SIGTERM)
+        process = Popen.return_value
+        process.terminate.assert_called_once_with()
+        process.wait.assert_called_once_with(timeout=5)
+        process.stdin.close.assert_called_once_with()
+        process.stdout.close.assert_called_once_with()
+        process.stderr.close.assert_called_once_with()
+
+    @patch("paramiko.proxy.subprocess.Popen")
+    def test_close_kills_process_when_wait_times_out(self, Popen):
+        process = Popen.return_value
+        process.wait.side_effect = [subprocess.TimeoutExpired("hi", 5), None]
+        proxy = ProxyCommand("hi")
+        proxy.close()
+        process.terminate.assert_called_once_with()
+        process.kill.assert_called_once_with()
+        assert process.wait.call_args_list == [call(timeout=5), call()]
+
+    @patch("paramiko.proxy.subprocess.Popen")
+    def test_close_handles_missing_process_and_still_closes_pipes(self, Popen):
+        process = Popen.return_value
+        process.terminate.side_effect = ProcessLookupError()
+        proxy = ProxyCommand("hi")
+        proxy.close()
+        process.wait.assert_called_once_with(timeout=5)
+        process.kill.assert_not_called()
+        process.stdin.close.assert_called_once_with()
+        process.stdout.close.assert_called_once_with()
+        process.stderr.close.assert_called_once_with()
+
+    @patch("paramiko.proxy.subprocess.Popen")
+    def test_close_is_idempotent(self, Popen):
+        process = Popen.return_value
+        process.terminate.side_effect = [None, ProcessLookupError()]
+        proxy = ProxyCommand("hi")
+        proxy.close()
+        proxy.close()
+        assert process.wait.call_args_list == [
+            call(timeout=5),
+            call(timeout=5),
+        ]
+        assert process.stdin.close.call_count == 2
+        assert process.stdout.close.call_count == 2
+        assert process.stderr.close.call_count == 2
 
     @patch("paramiko.proxy.subprocess.Popen")
     def test_closed_exposes_whether_subprocess_has_exited(self, Popen):


### PR DESCRIPTION
Fixes #2568.

`ProxyCommand.close()` previously only sent `SIGTERM`, which could leave pipe FDs open and could also raise when the subprocess had already exited. This patch updates `close()` to:

- call `terminate()` and `wait(timeout=5)` to reap the child process
- fall back to `kill()` + `wait()` on timeout
- gracefully handle `ProcessLookupError` / `ChildProcessError`
- always close `stdin`/`stdout`/`stderr` pipes in a `finally` block

Tests added/updated in `tests/test_proxy.py`:

- close terminates, waits, and closes all pipes
- timeout path kills then waits
- already-exited process path is handled cleanly while still closing pipes
- close is idempotent

Validation:

- `python -m pytest tests/test_proxy.py -q`
- `python -m flake8 paramiko/proxy.py tests/test_proxy.py`
