### PR TITLE
fix: handle password=None for servers with no password

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -802,7 +802,13 @@ class SSHClient(ClosingContextManager):
                 return
             except SSHException as e:
                 saved_exception = e
-        elif two_factor:
+        else:
+            try:
+                self._transport.auth_none(username)
+                return
+            except SSHException as e:
+                saved_exception = e
+        if two_factor:
             try:
                 self._transport.auth_interactive_dumb(username)
                 return


### PR DESCRIPTION
## Summary
Fixes #2530.
**Root cause:** Password authentication failed when connecting to a user with no password (`passwd -d`) because `password=None` was not handled correctly in the auth flow.
**Fix:** Added handling for `None` password in the authentication logic.
## Changes
- Updated password authentication to handle None password
## Testing
- Verified fix allows connection to servers with no password
- Change is minimal and follows existing auth patterns

Made with [Cursor](https://cursor.com)