### PR TITLE
Modify cryptography dependency for Windows AMR64 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,10 @@ authors = [{ name = "Jeff Forcier", email = "jeff@bitprophet.org" }]
 
 dependencies = [
   "bcrypt>=3.2",
-  "cryptography>=3.3",
+  # Cryptography Windows ARM64 wheels are available only at 46.0.3
+  # See: https://github.com/pyca/cryptography/pull/14216
+  "cryptography>=3.3; platform_system != 'Windows' or platform_machine != 'ARM64'",
+  "cryptography==46.0.3; platform_system == 'Windows' and platform_machine == 'ARM64'",
   "invoke>=2.0",
   "pynacl>=1.5",
 ]


### PR DESCRIPTION
PR description:

- Installing Paramiko wheels on Windows ARM64 is failing due to the absence of Cryptography wheels.
- The Cryptography release for Windows ARM64 is currently on hold due to issues with Windows ARM64 GitHub Actions[See the [PR](https://github.com/pyca/cryptography/pull/14216)].
- To resolve this, pin Cryptography to version 46.0.3, which is available for Windows ARM64 to enable successful installation of Paramiko.