### PR TITLE
fix: remove unused imports in demo scripts

### DIFF
--- a/demos/demo.py
+++ b/demos/demo.py
@@ -19,14 +19,11 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA.
 
 
-import base64
 from binascii import hexlify
 import getpass
 import os
-import select
 import socket
 import sys
-import time
 import traceback
 from paramiko.py3compat import input
 

--- a/demos/demo_server.py
+++ b/demos/demo_server.py
@@ -18,16 +18,14 @@
 # along with Paramiko; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA.
 
-import base64
 from binascii import hexlify
-import os
 import socket
 import sys
 import threading
 import traceback
 
 import paramiko
-from paramiko.py3compat import b, u, decodebytes
+from paramiko.py3compat import u, decodebytes
 
 
 # setup logging

--- a/demos/demo_sftp.py
+++ b/demos/demo_sftp.py
@@ -20,7 +20,6 @@
 
 # based on code provided by raymond mosteller (thanks!)
 
-import base64
 import getpass
 import os
 import socket

--- a/demos/demo_simple.py
+++ b/demos/demo_simple.py
@@ -19,10 +19,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA.
 
 
-import base64
 import getpass
-import os
-import socket
 import sys
 import traceback
 from paramiko.py3compat import input

--- a/demos/forward.py
+++ b/demos/forward.py
@@ -27,8 +27,6 @@ connection to a destination reachable from the SSH server machine.
 """
 
 import getpass
-import os
-import socket
 import select
 
 try:

--- a/demos/rforward.py
+++ b/demos/rforward.py
@@ -27,7 +27,6 @@ connection to a destination reachable from the local machine.
 """
 
 import getpass
-import os
 import socket
 import select
 import sys

--- a/sites/docs/conf.py
+++ b/sites/docs/conf.py
@@ -1,5 +1,6 @@
 # Obtain shared config values
-import os, sys
+import os
+import sys
 from os.path import abspath, join, dirname
 
 sys.path.append(abspath(".."))


### PR DESCRIPTION
## Summary

Remove unused imports across 7 demo/docs files:

- `base64` from demo.py, demo_server.py, demo_sftp.py, demo_simple.py
- `os` from demo_server.py, rforward.py, demo_simple.py
- `socket` from forward.py, demo_simple.py
- `time` from demo.py
- `select` from demo.py
- `b` from demo_server.py (only `u` and `decodebytes` are used)
- Split compound `import os, sys` in docs/conf.py (E401)

All changes are in demo scripts and docs config — no library code touched. Zero behavior change.

Found by [ruff](https://docs.astral.sh/ruff/) (F401, E401) via [HUMMBL Arbiter](https://hummbl.io/audit).