### PR TITLE
fix: use non-deprecated SPDX license identifier LGPL-2.1-only

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires-python = ">=3.9"
 version = "4.0.0"
 description = "SSH2 protocol library"
 readme = "README.rst"
-license = "LGPL-2.1"
+license = "LGPL-2.1-only"
 license-files = ["LICENSE"]
 authors = [{ name = "Jeff Forcier", email = "jeff@bitprophet.org" }]
 


### PR DESCRIPTION
## Summary

SPDX license identifier `LGPL-2.1` is [deprecated](https://spdx.dev/ids/#deprecated). The correct identifier `LGPL-2.1-only` unambiguously specifies the license without the "or later" clause, which matches the actual LICENSE file (LGPL-2.1, not LGPL-2.1+).

## Fix

One-line change in `pyproject.toml`:
- `license = "LGPL-2.1"` → `license = "LGPL-2.1-only"`

Fixes #2563