### PR TITLE
fix: use `except Exception:` instead of bare `except:` in Channel.__del__

### DIFF
--- a/paramiko/channel.py
+++ b/paramiko/channel.py
@@ -6,7 +6,7 @@
 # terms of the GNU Lesser General Public License as published by the Free
 # Software Foundation; either version 2.1 of the License, or (at your option)
 # any later version.
-#
+
 # Paramiko is distributed in the hope that it will be useful, but WITHOUT ANY
 # WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
 # A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
@@ -136,7 +136,7 @@ class Channel(ClosingContextManager):
     def __del__(self):
         try:
             self.close()
-        except:
+        except Exception:
             pass
 
     def __repr__(self):

--- a/paramiko/channel.py
+++ b/paramiko/channel.py
@@ -6,7 +6,7 @@
 # terms of the GNU Lesser General Public License as published by the Free
 # Software Foundation; either version 2.1 of the License, or (at your option)
 # any later version.
-
+#
 # Paramiko is distributed in the hope that it will be useful, but WITHOUT ANY
 # WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
 # A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more


### PR DESCRIPTION
## Summary

Replace bare `except:` clause with `except Exception:` in `Channel.__del__`.

**Change:**
```python
# Before
except:
    pass

# After
except Exception:
    pass
```

## Rationale

Bare `except:` clauses catch all exceptions including `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit`, which should generally propagate. Using `except Exception:` follows PEP 8 (E722) and is safer — especially in `__del__` methods where we only want to suppress cleanup errors, not mask critical interpreter signals.

## Testing

No behavior change for normal operation — this is a correctness/style fix only.