### PR TITLE
Raise SSHException when channel-opening methods are called on an unconnected client (#2600)

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -505,6 +505,20 @@ class SSHClient(ClosingContextManager):
             self._agent.close()
             self._agent = None
 
+    def _ensure_connected(self):
+        """
+        Raise `.SSHException` if this client has no active transport.
+
+        Guards the channel-opening methods (`.exec_command`, `.invoke_shell`,
+        `.open_sftp`) against being called on a client which hasn't been
+        `.connect`-ed yet or which has been `.close`-d, producing a useful
+        error instead of a bare ``AttributeError`` on ``NoneType``.
+        """
+        if self._transport is None:
+            raise SSHException(
+                "SSHClient is not connected; call .connect() first"
+            )
+
     def exec_command(
         self,
         command,
@@ -545,6 +559,7 @@ class SSHClient(ClosingContextManager):
         .. versionchanged:: 1.10
             Added the ``get_pty`` kwarg.
         """
+        self._ensure_connected()
         chan = self._transport.open_session(timeout=timeout)
         if get_pty:
             chan.get_pty()
@@ -582,6 +597,7 @@ class SSHClient(ClosingContextManager):
 
         :raises: `.SSHException` -- if the server fails to invoke a shell
         """
+        self._ensure_connected()
         chan = self._transport.open_session()
         chan.get_pty(term, width, height, width_pixels, height_pixels)
         chan.invoke_shell()
@@ -593,6 +609,7 @@ class SSHClient(ClosingContextManager):
 
         :return: a new `.SFTPClient` session object
         """
+        self._ensure_connected()
         return self._transport.open_sftp_client()
 
     def get_transport(self):

--- a/tests/test_client_unconnected.py
+++ b/tests/test_client_unconnected.py
@@ -1,8 +1,4 @@
-# Regression test for paramiko#2600: calling channel-opening methods on a
-# fresh, never-`.connect()`-ed `SSHClient` (or a `.close()`-d one) used to
-# raise `AttributeError: 'NoneType' object has no attribute 'open_session'`
-# from `paramiko/client.py`. The fix raises `SSHException` with a useful
-# message instead.
+# Regression for paramiko#2600.
 
 import pytest
 
@@ -32,7 +28,6 @@ def test_open_sftp_on_unconnected_client_raises_sshexception():
 
 
 def test_unconnected_client_does_not_raise_attribute_error():
-    """Pre-fix shape: AttributeError on NoneType. Ensure we never see that."""
     client = SSHClient()
     for op in (
         lambda: client.exec_command("echo hi"),
@@ -41,6 +36,3 @@ def test_unconnected_client_does_not_raise_attribute_error():
     ):
         with pytest.raises(SSHException):
             op()
-        # If the guard regressed, the above would raise AttributeError and the
-        # pytest.raises(SSHException) would fail the test with that as the
-        # actual exception.

--- a/tests/test_client_unconnected.py
+++ b/tests/test_client_unconnected.py
@@ -1,6 +1,6 @@
 # Regression test for paramiko#2600: calling channel-opening methods on a
 # fresh, never-`.connect()`-ed `SSHClient` (or a `.close()`-d one) used to
-# raise a bare `AttributeError: 'NoneType' object has no attribute 'open_session'`
+# raise `AttributeError: 'NoneType' object has no attribute 'open_session'`
 # from `paramiko/client.py`. The fix raises `SSHException` with a useful
 # message instead.
 

--- a/tests/test_client_unconnected.py
+++ b/tests/test_client_unconnected.py
@@ -1,0 +1,46 @@
+# Regression test for paramiko#2600: calling channel-opening methods on a
+# fresh, never-`.connect()`-ed `SSHClient` (or a `.close()`-d one) used to
+# raise a bare `AttributeError: 'NoneType' object has no attribute 'open_session'`
+# from `paramiko/client.py`. The fix raises `SSHException` with a useful
+# message instead.
+
+import pytest
+
+from paramiko import SSHClient
+from paramiko.ssh_exception import SSHException
+
+
+def test_exec_command_on_unconnected_client_raises_sshexception():
+    client = SSHClient()
+    with pytest.raises(SSHException) as ei:
+        client.exec_command("echo hi")
+    assert "not connected" in str(ei.value).lower()
+
+
+def test_invoke_shell_on_unconnected_client_raises_sshexception():
+    client = SSHClient()
+    with pytest.raises(SSHException) as ei:
+        client.invoke_shell()
+    assert "not connected" in str(ei.value).lower()
+
+
+def test_open_sftp_on_unconnected_client_raises_sshexception():
+    client = SSHClient()
+    with pytest.raises(SSHException) as ei:
+        client.open_sftp()
+    assert "not connected" in str(ei.value).lower()
+
+
+def test_unconnected_client_does_not_raise_attribute_error():
+    """Pre-fix shape: AttributeError on NoneType. Ensure we never see that."""
+    client = SSHClient()
+    for op in (
+        lambda: client.exec_command("echo hi"),
+        lambda: client.invoke_shell(),
+        lambda: client.open_sftp(),
+    ):
+        with pytest.raises(SSHException):
+            op()
+        # If the guard regressed, the above would raise AttributeError and the
+        # pytest.raises(SSHException) would fail the test with that as the
+        # actual exception.


### PR DESCRIPTION
Closes #2600.

`SSHClient.exec_command` / `.invoke_shell` / `.open_sftp` deref `self._transport` directly, so calling any of them on an `SSHClient()` that hasn't been `.connect()`-ed (or that has been `.close()`-d) raises `AttributeError: 'NoneType' object has no attribute 'open_session'`, uninformative and not one of the documented `SSHException` paths users catch.

Adds a small `_ensure_connected()` helper and calls it at the top of the three channel-opening methods. Raises `SSHException("SSHClient is not connected; call .connect() first")` instead.

Regression test in `tests/test_client_unconnected.py` exercises all three methods on a fresh `SSHClient()` and asserts each raises `SSHException` (not `AttributeError`). The fourth case explicitly guards against the AttributeError shape regressing.