### PR TITLE
Raise SSHException when calling client methods before connect (#2600)

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -540,11 +540,15 @@ class SSHClient(ClosingContextManager):
             the stdin, stdout, and stderr of the executing command, as a
             3-tuple
 
-        :raises: `.SSHException` -- if the server fails to execute the command
+        :raises:
+            `.SSHException` -- if the client is not connected, or if the
+            server fails to execute the command
 
         .. versionchanged:: 1.10
             Added the ``get_pty`` kwarg.
         """
+        if self._transport is None:
+            raise SSHException("No existing session; call connect() first")
         chan = self._transport.open_session(timeout=timeout)
         if get_pty:
             chan.get_pty()
@@ -580,8 +584,12 @@ class SSHClient(ClosingContextManager):
         :param dict environment: the command's environment
         :return: a new `.Channel` connected to the remote shell
 
-        :raises: `.SSHException` -- if the server fails to invoke a shell
+        :raises:
+            `.SSHException` -- if the client is not connected, or if the
+            server fails to invoke a shell
         """
+        if self._transport is None:
+            raise SSHException("No existing session; call connect() first")
         chan = self._transport.open_session()
         chan.get_pty(term, width, height, width_pixels, height_pixels)
         chan.invoke_shell()
@@ -592,7 +600,12 @@ class SSHClient(ClosingContextManager):
         Open an SFTP session on the SSH server.
 
         :return: a new `.SFTPClient` session object
+
+        :raises:
+            `.SSHException` -- if the client is not connected
         """
+        if self._transport is None:
+            raise SSHException("No existing session; call connect() first")
         return self._transport.open_sftp_client()
 
     def get_transport(self):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -697,6 +697,30 @@ class SSHClientTest(ClientTest):
         )
         assert isinstance(self.tc._transport, MyTransport)
 
+    def test_exec_command_before_connect_raises_sshexception(self):
+        client = SSHClient()
+        try:
+            with pytest.raises(SSHException, match="connect"):
+                client.exec_command("echo hi")
+        finally:
+            client.close()
+
+    def test_invoke_shell_before_connect_raises_sshexception(self):
+        client = SSHClient()
+        try:
+            with pytest.raises(SSHException, match="connect"):
+                client.invoke_shell()
+        finally:
+            client.close()
+
+    def test_open_sftp_before_connect_raises_sshexception(self):
+        client = SSHClient()
+        try:
+            with pytest.raises(SSHException, match="connect"):
+                client.open_sftp()
+        finally:
+            client.close()
+
 
 class PasswordPassphraseTests(ClientTest):
     # TODO: most of these could reasonably be set up to use mocks/assertions


### PR DESCRIPTION
Closes #2600.

`SSHClient.exec_command()`, `invoke_shell()`, and `open_sftp()` previously raised an opaque `AttributeError: 'NoneType' object has no attribute 'open_session'` when called before `connect()`. They now raise `SSHException("No existing session; call connect() first")`, matching the docstring's `:raises: SSHException` contract and giving callers a usable error.

`get_transport()` is unchanged — returning `None` for an unconnected client is part of its documented behaviour.