### PR TITLE
fix: raise SSHException when SSHClient ops are called before .connect() (#2600)

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -545,6 +545,10 @@ class SSHClient(ClosingContextManager):
         .. versionchanged:: 1.10
             Added the ``get_pty`` kwarg.
         """
+        if self._transport is None:
+            raise SSHException(
+                "SSHClient is not connected; call .connect() first."
+            )
         chan = self._transport.open_session(timeout=timeout)
         if get_pty:
             chan.get_pty()
@@ -582,6 +586,10 @@ class SSHClient(ClosingContextManager):
 
         :raises: `.SSHException` -- if the server fails to invoke a shell
         """
+        if self._transport is None:
+            raise SSHException(
+                "SSHClient is not connected; call .connect() first."
+            )
         chan = self._transport.open_session()
         chan.get_pty(term, width, height, width_pixels, height_pixels)
         chan.invoke_shell()
@@ -593,6 +601,10 @@ class SSHClient(ClosingContextManager):
 
         :return: a new `.SFTPClient` session object
         """
+        if self._transport is None:
+            raise SSHException(
+                "SSHClient is not connected; call .connect() first."
+            )
         return self._transport.open_sftp_client()
 
     def get_transport(self):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -697,6 +697,21 @@ class SSHClientTest(ClientTest):
         )
         assert isinstance(self.tc._transport, MyTransport)
 
+    def test_exec_command_raises_when_not_connected(self):
+        client = SSHClient()
+        with pytest.raises(SSHException, match="not connected"):
+            client.exec_command("ls")
+
+    def test_invoke_shell_raises_when_not_connected(self):
+        client = SSHClient()
+        with pytest.raises(SSHException, match="not connected"):
+            client.invoke_shell()
+
+    def test_open_sftp_raises_when_not_connected(self):
+        client = SSHClient()
+        with pytest.raises(SSHException, match="not connected"):
+            client.open_sftp()
+
 
 class PasswordPassphraseTests(ClientTest):
     # TODO: most of these could reasonably be set up to use mocks/assertions


### PR DESCRIPTION
Fixes #2600.

`exec_command`, `invoke_shell`, and `open_sftp` dereference `self._transport` directly; before `.connect()` is called this is `None`, so callers see `AttributeError: 'NoneType' object has no attribute 'open_session'` instead of a paramiko exception.

Guard each entry point with an explicit `self._transport is None` check that raises `SSHException` with a message pointing at the missing `.connect()` call, matching the docstrings' documented `:raises: SSHException` contract. Tests added covering all three methods.