### PR TITLE
SFTP: Send server success when closing the connection

### DIFF
--- a/paramiko/sftp_server.py
+++ b/paramiko/sftp_server.py
@@ -161,6 +161,7 @@ class SFTPServer(BaseSFTP, SubsystemHandler):
 
     def finish_subsystem(self):
         self.server.session_ended()
+        self.sock.send_exit_status(0)
         super().finish_subsystem()
         # close any file handles that were left open
         # (so we can return them to the OS quickly)


### PR DESCRIPTION
As of openssh version 9, the scp tool will default to using sftp internally which means it can be used with a paramiko based sftp servers.

However, when using the scp tool to do an operetaion on the paramiko sftp server, the scp tool will successfully transfer the file, but return a non-zero exist status even though the transfer succeeded. When using scpwith other sftp servers, this does not happen.

This was tracked down to paramiko not sending an exit-status message when closing the connection and can be fixed by calling channel.send_exit_status(0) before closing the connection in SFTPServer.finish_subsystem().