### PR TITLE
Fix SSHConfig parsing of 'Match host=pattern' syntax

### DIFF
--- a/paramiko/config.py
+++ b/paramiko/config.py
@@ -526,6 +526,16 @@ class SSHConfig:
             if type_.startswith("!"):
                 match["negate"] = True
                 type_ = type_[1:]
+            # OpenSSH allows "key=value" syntax for Match keywords (e.g.
+            # "Match host=foo") in addition to the space-separated form
+            # "Match host foo". Split on first '=' if the type token
+            # contains one, and handle it as if it were two tokens.
+            if "=" in type_ and type_ not in ("all", "canonical", "final"):
+                type_, param = type_.split("=", 1)
+                match["type"] = type_
+                match["param"] = param
+                matches.append(match)
+                continue
             match["type"] = type_
             # all/canonical have no params (everything else does)
             if type_ in ("all", "canonical", "final"):

--- a/tests/pkey.py
+++ b/tests/pkey.py
@@ -307,5 +307,6 @@ class Ed25519Key_:
         # will effectively be that of an 'empty' key bytes)
         assert (
             repr(info.traceback[1].locals["self"])
-            == "PKey(alg=ED25519, bits=256, fp=SHA256:UsIasxMWEd9VFEwjARWWtGJ08DgHp1eib3gSBLed54U)"
+            == "PKey(alg=ED25519, bits=256,"
+            " fp=SHA256:UsIasxMWEd9VFEwjARWWtGJ08DgHp1eib3gSBLed54U)"
         )


### PR DESCRIPTION
## Description

OpenSSH `ssh_config` supports `Match host=pattern` syntax (with `=` between the keyword and its argument) as an alternative to the space-separated form `Match host pattern`. The `shlex.split` call in `_get_matches()` does not split on `=`, so `host=pattern` ended up as a single token, causing a `ConfigParseError`: `Missing parameter to Match 'host=pattern' keyword`.

## Fix

Detect tokens containing `=` (for known Match keywords) and split them into type and param components inline, before the existing logic that handles space-separated arguments.

## Testing

- All 113 existing config tests pass
- Manually verified: `Match host=\"myhost*.domain.com\"`, `Match host=myhost`, `Match host=!badhost`, and mixed forms all parse correctly
- `Match host` (missing param) still correctly raises `ConfigParseError`

Fixes #2522