### PR TITLE
BUG: Fix exec_command crashing with AttributeError when not connected (#2600)

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -545,6 +545,10 @@ class SSHClient(ClosingContextManager):
         .. versionchanged:: 1.10
             Added the ``get_pty`` kwarg.
         """
+        if self._transport is None:
+            raise SSHException(
+                "Not connected to an SSH server. Call connect() first."
+            )
         chan = self._transport.open_session(timeout=timeout)
         if get_pty:
             chan.get_pty()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -742,3 +742,10 @@ class PasswordPassphraseTests(ClientTest):
             password="television",
             passphrase="wat? lol no",
         )
+
+
+class TestExecCommandWithoutConnection:
+    def test_exec_command_raises_ssh_exception_when_not_connected(self):
+        client = paramiko.SSHClient()
+        with pytest.raises(paramiko.SSHException):
+            client.exec_command("ls")


### PR DESCRIPTION
Fixes #2600

## Summary
Calling `SSHClient.exec_command()` before `connect()` previously raised an `AttributeError` because `self._transport` was `None`. This change adds an explicit check that raises an `SSHException` with a clear message instructing the user to call `connect()` first.

## Test plan
- [x] New test added in `tests/test_client.py` (`TestExecCommandWithoutConnection`) that verifies calling `exec_command` on an unconnected client raises `SSHException`.
- [x] Full existing test suite still passes (`pytest tests/ -x -q`).