### PR TITLE
BUG: Fix known_hosts parsing failing on multiple whitespace delimiters (#2204)

### DIFF
--- a/paramiko/hostkeys.py
+++ b/paramiko/hostkeys.py
@@ -334,7 +334,7 @@ class HostKeyEntry:
         :param str line: a line from an OpenSSH known_hosts file
         """
         log = get_logger("paramiko.hostkeys")
-        fields = re.split(" |\t", line)
+        fields = re.split(r"\s+", line)
         if len(fields) < 3:
             # Bad number of fields
             msg = "Not enough fields found in known_hosts in line {} ({!r})"

--- a/tests/pkey.py
+++ b/tests/pkey.py
@@ -305,7 +305,6 @@ class Ed25519Key_:
         # been assigned).
         # When fixed, we get a normal looking repr (albeit whose fingerprint
         # will effectively be that of an 'empty' key bytes)
-        assert (
-            repr(info.traceback[1].locals["self"])
-            == "PKey(alg=ED25519, bits=256, fp=SHA256:UsIasxMWEd9VFEwjARWWtGJ08DgHp1eib3gSBLed54U)"
-        )
+        # noqa: E501
+        fp = "PKey(alg=ED25519, bits=256, fp=SHA256:UsIasxMWEd9VFEwjARWWtGJ08DgHp1eib3gSBLed54U)"  # noqa: E501
+        assert repr(info.traceback[1].locals["self"]) == fp

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -750,8 +750,10 @@ class TestKnownHostsWhitespaceParsing:
 
         key_b64 = (
             "AAAAB3NzaC1yc2EAAAABIwAAAIEA1PD6U2/TVxET6lkpKhOk5r"
-            "9q/kAYG6sP9f5zuUYP8i7FOFp/6ncCEbbtg/lB+A3iidyxoSWl+9jtoyyDOOVX4UIDV9G11Ml8om3"
-            "D+jrpI9cycZHqilK0HmxDeCuxbwyMuaCygU9gS2qoRvNLWZk70OpIKSSpBo0Wl3/XUmz9uhc="
+            "9q/kAYG6sP9f5zuUYP8i7FOFp/6ncCEbbtg/lB+A3iidyxoSWl"
+            "+9jtoyyDOOVX4UIDV9G11Ml8om3"
+            "D+jrpI9cycZHqilK0HmxDeCuxbwyMuaCygU9gS2qoRvNLWZk70"
+            "OpIKSSpBo0Wl3/XUmz9uhc="
         )
         line = "host.example.com    ssh-rsa    {}".format(key_b64)
         entry = HostKeyEntry.from_line(line)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -742,3 +742,18 @@ class PasswordPassphraseTests(ClientTest):
             password="television",
             passphrase="wat? lol no",
         )
+
+
+class TestKnownHostsWhitespaceParsing:
+    def test_known_hosts_multiple_whitespace(self):
+        from paramiko.hostkeys import HostKeyEntry
+
+        key_b64 = (
+            "AAAAB3NzaC1yc2EAAAABIwAAAIEA1PD6U2/TVxET6lkpKhOk5r"
+            "9q/kAYG6sP9f5zuUYP8i7FOFp/6ncCEbbtg/lB+A3iidyxoSWl+9jtoyyDOOVX4UIDV9G11Ml8om3"
+            "D+jrpI9cycZHqilK0HmxDeCuxbwyMuaCygU9gS2qoRvNLWZk70OpIKSSpBo0Wl3/XUmz9uhc="
+        )
+        line = "host.example.com    ssh-rsa    {}".format(key_b64)
+        entry = HostKeyEntry.from_line(line)
+        assert entry is not None
+        assert "host.example.com" in entry.hostnames


### PR DESCRIPTION
Fixes #2204

## Summary
OpenSSH ``known_hosts`` lines may use one or more spaces *or* tabs (or mixtures) to separate the host, key type, and key fields. Paramiko was splitting on a single space-or-tab character, so any extra whitespace produced empty fields and either rejected the line or mis-attributed the key type. This change switches to ``re.split(r"\s+", line)`` to match OpenSSH's behavior.

## Test plan
- [x] New test in ``tests/test_client.py`` (``TestKnownHostsWhitespaceParsing``) parses a line with multiple spaces between fields and confirms an entry is produced.
- [x] Full existing test suite still passes (``pytest tests/ -x -q``).