### PR TITLE
BUG: Fix connection failure when server has no password set (#2530)

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -774,6 +774,13 @@ class SSHClient(ClosingContextManager):
             except SSHException as e:
                 saved_exception = e
 
+        if password is None and not two_factor:
+            try:
+                self._transport.auth_password(username, "")
+                return
+            except SSHException:
+                pass
+
         # if we got an auth-failed exception earlier, re-raise it
         if saved_exception is not None:
             raise saved_exception

--- a/tests/pkey.py
+++ b/tests/pkey.py
@@ -305,7 +305,6 @@ class Ed25519Key_:
         # been assigned).
         # When fixed, we get a normal looking repr (albeit whose fingerprint
         # will effectively be that of an 'empty' key bytes)
-        assert (
-            repr(info.traceback[1].locals["self"])
-            == "PKey(alg=ED25519, bits=256, fp=SHA256:UsIasxMWEd9VFEwjARWWtGJ08DgHp1eib3gSBLed54U)"
-        )
+        # noqa: E501
+        fp = "PKey(alg=ED25519, bits=256, fp=SHA256:UsIasxMWEd9VFEwjARWWtGJ08DgHp1eib3gSBLed54U)"  # noqa: E501
+        assert repr(info.traceback[1].locals["self"]) == fp


### PR DESCRIPTION
Fixes #2530

## Summary
Some SSH servers accept an empty password for accounts that have no password configured. ``SSHClient.connect()`` previously never attempted an empty password when the caller passed ``password=None``, so connections to such servers would fail even though authentication would have succeeded.

This adds a final fallback that tries ``auth_password(username, "")`` after all key-based attempts have been exhausted, when no password was supplied and the server did not request two-factor auth. If the empty password is rejected, the existing "no authentication methods available" path runs unchanged.

## Test plan
- [x] Full existing test suite still passes (``pytest tests/ -x -q``).
- [x] Manual verification: a server that accepts an empty password now connects without callers having to pass ``password=""`` explicitly.