### PR TITLE
BUG: Fix server advertising group-exchange KEX without moduli file (#2126)

### DIFF
--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -2266,7 +2266,7 @@ class Transport(threading.Thread, ClosingContextManager):
                     for k in self.get_security_options().kex
                     if not k.startswith(mp_required_prefix)
                 ]
-                self.get_security_options().kex = pkex
+                kex_algos = pkex
             available_server_keys = list(
                 filter(
                     list(self.server_key_dict.keys()).__contains__,

--- a/tests/pkey.py
+++ b/tests/pkey.py
@@ -305,7 +305,6 @@ class Ed25519Key_:
         # been assigned).
         # When fixed, we get a normal looking repr (albeit whose fingerprint
         # will effectively be that of an 'empty' key bytes)
-        assert (
-            repr(info.traceback[1].locals["self"])
-            == "PKey(alg=ED25519, bits=256, fp=SHA256:UsIasxMWEd9VFEwjARWWtGJ08DgHp1eib3gSBLed54U)"
-        )
+        # noqa: E501
+        fp = "PKey(alg=ED25519, bits=256, fp=SHA256:UsIasxMWEd9VFEwjARWWtGJ08DgHp1eib3gSBLed54U)"  # noqa: E501
+        assert repr(info.traceback[1].locals["self"]) == fp


### PR DESCRIPTION
Fixes #2126

## Summary
When running paramiko as a server with no moduli pack loaded, the transport filtered ``diffie-hellman-group-exchange-*`` algorithms out of a list and then assigned the result back to ``self.get_security_options().kex``. That mutated the persistent security-options list rather than the local ``kex_algos`` copy that gets serialized into the outgoing KEXINIT — so the server kept advertising group-exchange KEX even though it had no primes available, causing handshake failures with clients that chose it.

This fix assigns the filtered list to ``kex_algos`` instead, so only the outgoing KEXINIT is trimmed and the configured security options are left intact.

## Test plan
- [x] Full existing test suite still passes (``pytest tests/ -x -q``).
- [ ] Manual verification with a server that has no moduli file: KEXINIT no longer advertises group-exchange algorithms. (Hard to exercise in unit tests without a full server harness.)