### PR TITLE
BUG: Fix exec_command crashing with AttributeError when not connected (#2600)

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -545,6 +545,10 @@ class SSHClient(ClosingContextManager):
         .. versionchanged:: 1.10
             Added the ``get_pty`` kwarg.
         """
+        if self._transport is None:
+            raise SSHException(
+                "Not connected to an SSH server. Call connect() first."
+            )
         chan = self._transport.open_session(timeout=timeout)
         if get_pty:
             chan.get_pty()

--- a/tests/pkey.py
+++ b/tests/pkey.py
@@ -305,7 +305,6 @@ class Ed25519Key_:
         # been assigned).
         # When fixed, we get a normal looking repr (albeit whose fingerprint
         # will effectively be that of an 'empty' key bytes)
-        assert (
-            repr(info.traceback[1].locals["self"])
-            == "PKey(alg=ED25519, bits=256, fp=SHA256:UsIasxMWEd9VFEwjARWWtGJ08DgHp1eib3gSBLed54U)"
-        )
+        # noqa: E501
+        fp = "PKey(alg=ED25519, bits=256, fp=SHA256:UsIasxMWEd9VFEwjARWWtGJ08DgHp1eib3gSBLed54U)"  # noqa: E501
+        assert repr(info.traceback[1].locals["self"]) == fp

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -742,3 +742,10 @@ class PasswordPassphraseTests(ClientTest):
             password="television",
             passphrase="wat? lol no",
         )
+
+
+class TestExecCommandWithoutConnection:
+    def test_exec_command_raises_ssh_exception_when_not_connected(self):
+        client = paramiko.SSHClient()
+        with pytest.raises(paramiko.SSHException):
+            client.exec_command("ls")


### PR DESCRIPTION
Fixes #2600

When exec_command() is called on an SSHClient that hasn't been .connect()ed yet, self._transport is None and the code crashes with AttributeError instead of a meaningful error message.

Fix: Check if self._transport is None before calling open_session() and raise SSHException with a helpful message pointing the user to call connect() first.

## Testing
- New test `test_exec_command_raises_ssh_exception_when_not_connected` added
- All 542 existing tests pass