### PR TITLE
fix #2512: suppress CryptographyDeprecationWarning for TripleDES fallback import

### DIFF
--- a/paramiko/pkey.py
+++ b/paramiko/pkey.py
@@ -46,6 +46,7 @@ from paramiko.common import o600
 from paramiko.message import Message
 from paramiko.ssh_exception import PasswordRequiredException, SSHException
 from paramiko.util import b, u
+import warnings
 
 # TripleDES is moving from `cryptography.hazmat.primitives.ciphers.algorithms`
 # in cryptography>=43.0.0 to `cryptography.hazmat.decrepit.ciphers.algorithms`
@@ -55,10 +56,14 @@ from paramiko.util import b, u
 # Source References:
 # - https://github.com/pyca/cryptography/commit/722a6393e61b3ac
 # - https://github.com/pyca/cryptography/pull/11407/files
+import warnings
+
 try:
     from cryptography.hazmat.decrepit.ciphers.algorithms import TripleDES
 except ImportError:
-    from cryptography.hazmat.primitives.ciphers.algorithms import TripleDES
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
+        from cryptography.hazmat.primitives.ciphers.algorithms import TripleDES
 
 
 OPENSSH_AUTH_MAGIC = b"openssh-key-v1\x00"


### PR DESCRIPTION
Fix #2512

Suppress CryptographyDeprecationWarning when importing TripleDES from the legacy path (cryptography.hazmat.primitives.ciphers.algorithms.TripleDES) on cryptography < 43.0.0.

The deprecation warning fires because cryptography marks TripleDES as deprecated starting from cryptography 43.0.0, moving it to `cryptography.hazmat.decrepit.ciphers.algorithms`. The try/except already handles the import correctly, but the fallback path triggers a noisy warning. This fix wraps the fallback import in `warnings.catch_warnings()` to suppress it.