### PR TITLE
Fix RSAKey.sign_ssh_data KeyError on default ssh-rsa algorithm

### DIFF
--- a/paramiko/rsakey.py
+++ b/paramiko/rsakey.py
@@ -134,6 +134,17 @@ class RSAKey(PKey):
     def sign_ssh_data(self, data, algorithm=None):
         if algorithm is None:
             algorithm = self.name
+        # The bare "ssh-rsa" (SHA-1) signing algorithm was dropped in 5.0 and
+        # is no longer present in HASHES, so it cannot be used as a hash key.
+        # When asked to sign with the legacy default (e.g. a direct
+        # sign_ssh_data() call that does not specify an algorithm, or a server
+        # kex path that still passes the "ssh-rsa" key type), upgrade to the
+        # strongest SHA-2 variant we offer so the call succeeds and produces a
+        # verifiable signature. Explicit rsa-sha2-* requests are untouched.
+        if algorithm == "ssh-rsa":
+            algorithm = "rsa-sha2-512"
+        elif algorithm == "ssh-rsa-cert-v01@openssh.com":
+            algorithm = "rsa-sha2-512-cert-v01@openssh.com"
         sig = self.key.sign(
             data,
             padding=padding.PKCS1v15(),

--- a/tests/test_pkey.py
+++ b/tests/test_pkey.py
@@ -211,6 +211,30 @@ class KeyTest(unittest.TestCase):
         msg.rewind()
         self.assertTrue(key.verify_ssh_sig(b"jerri blank", msg))
 
+    def test_sign_rsa_with_default_algorithm(self):
+        # Regression for #2628: ssh-rsa (SHA-1) was removed from HASHES in
+        # 5.0, but it is still the default signing algorithm, so signing with
+        # no explicit algorithm raised KeyError: 'ssh-rsa'. The default should
+        # transparently upgrade to a SHA-2 variant and produce a verifiable
+        # signature.
+        key = RSAKey.from_private_key_file(_support("rsa.key"))
+        msg = key.sign_ssh_data(b"jerri blank")
+        assert isinstance(msg, Message)
+        msg.rewind()
+        assert msg.get_text() == "rsa-sha2-512"
+        msg.rewind()
+        self.assertTrue(key.verify_ssh_sig(b"jerri blank", msg))
+
+    def test_sign_rsa_with_explicit_ssh_rsa_algorithm(self):
+        # Passing the legacy "ssh-rsa" name explicitly should also succeed
+        # rather than raising KeyError, upgrading to a SHA-2 signature.
+        key = RSAKey.from_private_key_file(_support("rsa.key"))
+        msg = key.sign_ssh_data(b"jerri blank", algorithm="ssh-rsa")
+        msg.rewind()
+        assert msg.get_text() == "rsa-sha2-512"
+        msg.rewind()
+        self.assertTrue(key.verify_ssh_sig(b"jerri blank", msg))
+
     def test_generate_ecdsa(self):
         key = ECDSAKey.generate()
         msg = key.sign_ssh_data(b"jerri blank")


### PR DESCRIPTION
Fixes #2628

## Problem

`RSAKey.sign_ssh_data()` raises `KeyError: 'ssh-rsa'` when called with the default algorithm. Reproduction from the issue:

```python
from paramiko import RSAKey
key = RSAKey.generate(1024)
msg = key.sign_ssh_data(b"jerri blank")
```

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../paramiko/rsakey.py", line 142, in sign_ssh_data
    algorithm=self.HASHES[algorithm](),
KeyError: 'ssh-rsa'
```

## Root cause

The legacy `ssh-rsa` (SHA-1) signing algorithm was removed from `RSAKey.HASHES` in 5.0, on purpose (see the note in `RSAKey.identifiers()`). But `sign_ssh_data()` still defaults `algorithm` to `self.name`, which for an RSA key is `"ssh-rsa"`:

```python
def sign_ssh_data(self, data, algorithm=None):
    if algorithm is None:
        algorithm = self.name          # -> "ssh-rsa"
    sig = self.key.sign(
        ...
        algorithm=self.HASHES[algorithm](),   # KeyError: 'ssh-rsa'
    )
```

So the default code path looks up a key that no longer exists in `HASHES` and crashes. The same crash happens if a caller passes `algorithm="ssh-rsa"` explicitly.

In normal `Transport`/auth flows this is not hit, because the auth handler resolves a concrete SHA-2 algorithm via `_finalize_pubkey_algorithm()` and passes it in, and the RSA host-key algorithms advertised in `_preferred_keys` are only `rsa-sha2-512` / `rsa-sha2-256`. The regression is reachable through the public `sign_ssh_data()` API (no explicit algorithm), which worked in 4.x where `ssh-rsa` defaulted to SHA-1.

## Fix

Before the `HASHES` lookup, map the bare `ssh-rsa` name (and its cert variant) to the strongest SHA-2 variant we still support, then sign and label with that. Explicit `rsa-sha2-256` / `rsa-sha2-512` requests are untouched.

Choosing `rsa-sha2-512` keeps the emitted algorithm label inside `HASHES`, so the resulting signature also round-trips through `verify_ssh_sig()` (which rejects any algorithm not in `HASHES`). It also matches the top RSA entry in the transport's preferred-algorithm list.

## Before / after

Before (current `main`): the repro above and `algorithm="ssh-rsa"` both raise `KeyError: 'ssh-rsa'`.

After this change:

```python
key = RSAKey.generate(2048)
msg = key.sign_ssh_data(b"jerri blank")   # no error
msg.rewind()
msg.get_text()                            # 'rsa-sha2-512'
msg.rewind()
key.verify_ssh_sig(b"jerri blank", msg)   # True
```

## Tests

Adds two regression tests in `tests/test_pkey.py`:

- `test_sign_rsa_with_default_algorithm` - signing with no explicit algorithm succeeds, is labeled `rsa-sha2-512`, and verifies.
- `test_sign_rsa_with_explicit_ssh_rsa_algorithm` - passing the legacy `ssh-rsa` name explicitly also succeeds and verifies.

Both fail on current `main` with `KeyError: 'ssh-rsa'` and pass with the fix. The existing `rsa-sha2-256` / `rsa-sha2-512` sign/verify tests still pass. Full `tests/test_pkey.py` is green (41 passed, 1 pre-existing skip).

## Note for maintainers

This restores a working default for the public `sign_ssh_data()` API while keeping SHA-1 out of `HASHES`. If the intended contract is that callers must always pass an explicit SHA-2 algorithm, an alternative would be to raise a clear `SSHException` instead of silently upgrading. Happy to switch to that shape if preferred.
