### PR TITLE
Map `SFTP_OP_UNSUPPORTED` to an appropriate `errno.ENOTSUP`

### DIFF
--- a/paramiko/sftp_client.py
+++ b/paramiko/sftp_client.py
@@ -59,6 +59,7 @@ from paramiko.sftp import (
     SFTP_OK,
     SFTP_EOF,
     SFTP_NO_SUCH_FILE,
+    SFTP_OP_UNSUPPORTED,
     SFTP_PERMISSION_DENIED,
     int64,
 )
@@ -938,6 +939,8 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
             raise IOError(errno.ENOENT, text)
         elif code == SFTP_PERMISSION_DENIED:
             raise IOError(errno.EACCES, text)
+        elif code == SFTP_OP_UNSUPPORTED:
+            raise IOError(errno.ENOTSUP, text)
         else:
             raise IOError(text)
 


### PR DESCRIPTION
When an SFTP client receives an error message, an `IOError` is raised. Error codes `SFTP_EOF`, `SFTP_NO_SUCH_FILE`, `SFTP_PERMISSION_DENIED` are mapped to appropriate exceptions so that the caller can act accordlingly.

However `SFTP_OP_NOTSUPPORTED` is not. As a result, calling `posix_rename` on a server which does not support it just raises a generic `IOError`, meaning the only way to determine you should fall back to plain `rename` is to read the text returned - which is brittle.

Map such an error to an IOError with errno set to `errno.ENOTSUP` whose description is: "Operation not supported (POSIX.1-2001)"