### PR TITLE
Fix RSAKey.sign_ssh_data() KeyError when called without explicit algorithm

### DIFF
--- a/paramiko/rsakey.py
+++ b/paramiko/rsakey.py
@@ -133,7 +133,9 @@ class RSAKey(PKey):
 
     def sign_ssh_data(self, data, algorithm=None):
         if algorithm is None:
-            algorithm = self.name
+            # Default to rsa-sha2-256 (not self.name which is the legacy
+            # "ssh-rsa" identifier removed from HASHES in paramiko 5.0).
+            algorithm = "rsa-sha2-256"
         sig = self.key.sign(
             data,
             padding=padding.PKCS1v15(),

--- a/tests/test_pkey.py
+++ b/tests/test_pkey.py
@@ -204,6 +204,18 @@ class KeyTest(unittest.TestCase):
     def test_sign_and_verify_rsa_sha2_256(self):
         self._sign_and_verify_rsa("rsa-sha2-256", SIGNED_RSA_256)
 
+    def test_sign_ssh_data_default_algorithm_no_longer_raises(self):
+        # Regression test for GH-2628: RSAKey.sign_ssh_data() raised
+        # KeyError: 'ssh-rsa' when called without an explicit algorithm
+        # because the default fell back to self.name ("ssh-rsa") which was
+        # removed from HASHES in paramiko 5.0.  The default should now be
+        # "rsa-sha2-256".
+        key = RSAKey.generate(2048)
+        msg = key.sign_ssh_data(b"test data")
+        assert isinstance(msg, Message)
+        msg.rewind()
+        assert msg.get_text() == "rsa-sha2-256"
+
     def test_generate_rsa(self):
         # TODO: this probs needs to be larger number now
         key = RSAKey.generate(1024)


### PR DESCRIPTION
## Summary

Fixes #2628.

`RSAKey.sign_ssh_data()` raised `KeyError: 'ssh-rsa'` when called without an explicit `algorithm` argument.

## Root cause

```python
# rsakey.py — before
def sign_ssh_data(self, data, algorithm=None):
    if algorithm is None:
        algorithm = self.name  # self.name == "ssh-rsa"
    # KeyError here because "ssh-rsa" is not in HASHES:
    algorithm=self.HASHES[algorithm]()
```

`RSAKey.name` is `"ssh-rsa"` (the SSH protocol type identifier), but `"ssh-rsa"` was intentionally removed from `RSAKey.HASHES` in paramiko 5.0 as part of dropping legacy SHA-1 signature support.  So any call to `sign_ssh_data()` without an explicit algorithm crashed immediately.

```python
HASHES = {
    "rsa-sha2-256": hashes.SHA256,          # <-- these exist
    "rsa-sha2-256-cert-v01@openssh.com": hashes.SHA256,
    "rsa-sha2-512": hashes.SHA512,
    "rsa-sha2-512-cert-v01@openssh.com": hashes.SHA512,
    # "ssh-rsa" is NOT here — that's the bug
}
```

## Fix

Default to `"rsa-sha2-256"` instead of `self.name`:

```python
# rsakey.py — after
def sign_ssh_data(self, data, algorithm=None):
    if algorithm is None:
        # Default to rsa-sha2-256 (not self.name which is the legacy
        # "ssh-rsa" identifier removed from HASHES in paramiko 5.0).
        algorithm = "rsa-sha2-256"
```

`rsa-sha2-256` is the modern, widely-supported RSA signature algorithm (RFC 8332) and the natural successor for callers that don't specify an algorithm.

## Changes

| File | Change |
|---|---|
| `paramiko/rsakey.py` | Default `algorithm` to `"rsa-sha2-256"` instead of `self.name` |
| `tests/test_pkey.py` | Regression test: `test_sign_ssh_data_default_algorithm_no_longer_raises` |

## Reproducer (before fix)

```python
from paramiko import RSAKey
key = RSAKey.generate(2048)
key.sign_ssh_data(b"test")  # KeyError: 'ssh-rsa'
```

## After fix

```python
from paramiko import RSAKey, Message
key = RSAKey.generate(2048)
msg = key.sign_ssh_data(b"test")  # works
msg.rewind()
assert msg.get_text() == "rsa-sha2-256"  # correct modern algorithm
```