### PR TITLE
fix: warn and skip unknown Match criteria in SSHConfig

### DIFF
--- a/paramiko/config.py
+++ b/paramiko/config.py
@@ -23,10 +23,13 @@ Configuration file (aka ``ssh_config``) support.
 
 import fnmatch
 import getpass
+import logging
 import os
 import re
 import shlex
 import socket
+
+logger = logging.getLogger(__name__)
 from functools import partial
 from hashlib import sha1
 from io import StringIO
@@ -367,7 +370,8 @@ class SSHConfig:
             if type_ == "canonical":
                 if self._should_fail(canonical, candidate):
                     return False
-            if type_ == "final":
+                passed = canonical
+            elif type_ == "final":
                 passed = final
             # The parse step ensures we only see this by itself or after
             # canonical, so it's also an easy hard pass. (No negation here as
@@ -396,6 +400,15 @@ class SSHConfig:
                     raise invoke_import_error
                 # Like OpenSSH, we 'redirect' stdout but let stderr bubble up
                 passed = invoke.run(exec_cmd, hide="stdout", warn=True).ok
+            else:
+                # Unknown Match criterion — log warning and treat as non-matching
+                logger.warning(
+                    "Unknown Match criterion '%s' not supported by paramiko; "
+                    "treating Match block as not matching. "
+                    "If this is a valid OpenSSH keyword, please report a bug.",
+                    type_,
+                )
+                passed = False
             # Tackle any 'passed, but was negated' results from above
             if passed is not None and self._should_fail(passed, candidate):
                 return False

--- a/tests/configs/match-unknown-criteria
+++ b/tests/configs/match-unknown-criteria
@@ -1,0 +1,5 @@
+Match localnetwork 10.0.0.0/8
+    User should_not_apply
+
+Match host "target"
+    User should_apply

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1046,3 +1046,25 @@ class TestFinalMatching(object):
     def test_negated(self):
         result = load_config("match-final").lookup("jump")
         assert result["port"] == "1003"
+
+
+class TestMatchUnknownCriteria:
+    def test_unknown_criteria_skipped(self):
+        """
+        Unknown Match criteria (e.g. 'localnetwork') should be skipped with a
+        warning, and the Match block should be treated as not matching.
+        """
+        result = load_config("match-unknown-criteria").lookup("target")
+        # The block with unknown 'localnetwork' criterion should NOT match,
+        # so 'user' should come from the second block (Match host "target").
+        assert result["user"] == "should_apply"
+
+    def test_unknown_criteria_does_not_pollute_know_hosts(self):
+        """
+        A Match block with an unknown criterion should not affect hosts that
+        don't match other criteria in that block.
+        """
+        result = load_config("match-unknown-criteria").lookup("somehost")
+        # Only the skip block should not match 'somehost', and the host block
+        # only matches 'target'. So no config should apply.
+        assert "user" not in result


### PR DESCRIPTION
## Summary

Fixes #2632.

When paramiko encounters an unknown Match criterion in `ssh_config` (e.g. `localnetwork`, a valid OpenSSH keyword that paramiko doesn't support), it silently treats the criterion as matching. This causes Match blocks with unsupported criteria to be incorrectly applied.

## Root cause

The `_does_match` method in `config.py` has an `if/elif` chain for each known Match type (`canonical`, `final`, `all`, `host`, `originalhost`, `user`, `localuser`, `exec`). Unknown types like `localnetwork` fall through without setting `passed`, so `passed` stays `None` and the candidate is silently added to the matched list.

## Fix

1. Log a warning for unknown Match criteria
2. Set `passed = False` so the Match block is treated as not matching (matching OpenSSH behavior)
3. Restructured the `canonical` handling from a standalone `if` into the `elif` chain to ensure the new `else` clause only catches truly unknown types

## Test evidence

Added `match-unknown-criteria` test config and `TestMatchUnknownCriteria` class with two tests:

```
$ .venv/bin/pytest tests/test_config.py -k TestMatchUnknownCriteria -v
...
MatchUnknownCriteria
    unknown criteria skipped ... PASSED
    unknown criteria does not pollute know hosts ... PASSED

$ .venv/bin/pytest tests/test_config.py
...
115 passed, 7 skipped in 0.14s
```

The new warning is emitted at runtime when unknown criteria are encountered:

```
WARNING paramiko.config: Unknown Match criterion 'localnetwork' not supported by paramiko; treating Match block as not matching.
```