### PR TITLE
ci: Add free-threaded Python 3.13t/3.14t to CircleCI testing matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ workflows:
           name: Test << matrix.version >> w/ << matrix.pip-overrides >>
           matrix:
             parameters:
-              version: ["3.9"]
+              version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.13t", "3.14t"]
               # TODO: I don't see a nicer way to do this that doesn't require
               # making the orb know too much about its client code...
               # TODO: the upper end of this needs to change and/or grow more


### PR DESCRIPTION
Hi @bitprophet and maintainers!

This PR updates the CircleCI testing matrix to inject broader Python version checks, specifically targeting the experimental `3.13t` and `3.14t` (free-threaded) builds introduced via PEP 703.

Without the GIL, the underlying C-extensions temporarily lose their implicit thread-safety. Adding this to the CI early provides high-value diagnostic logs to track compatibility. 

*Note: Paramiko heavily relies on `cryptography`, which does not currently publish free-threaded `abi3t` wheels. Therefore, the `3.13t` and `3.14t` tests will likely fail early during the build phase (or during test execution due to segfaults). This is expected. We highly recommend converting this PR to a **Draft** or setting the free-threaded tests as `continue-on-error`. This will serve as an excellent automated "radar" to track when upstream dependencies become fully compatible.*

Do you agree with this approach?