### PR TITLE
Fix bare except clauses in agent.py, channel.py, client.py, and transport.py

### DIFF
--- a/paramiko/agent.py
+++ b/paramiko/agent.py
@@ -145,7 +145,7 @@ class AgentProxyThread(threading.Thread):
             ):
                 raise AuthenticationException("Unable to connect to SSH agent")
             self._communicate()
-        except:
+        except Exception:
             # XXX Not sure what to do here ... raise or pass ?
             raise
 
@@ -200,7 +200,7 @@ class AgentLocalProxy(AgentProxyThread):
             conn.listen(1)
             (r, addr) = conn.accept()
             return r, addr
-        except:
+        except Exception:
             raise
 
 
@@ -228,7 +228,7 @@ def get_agent_connection():
         try:
             conn.connect(os.environ["SSH_AUTH_SOCK"])
             return conn
-        except:
+        except OSError:
             # probably a dangling env var: the ssh agent is gone
             return
     elif sys.platform == "win32":

--- a/paramiko/channel.py
+++ b/paramiko/channel.py
@@ -136,7 +136,7 @@ class Channel(ClosingContextManager):
     def __del__(self):
         try:
             self.close()
-        except:
+        except Exception:
             pass
 
     def __repr__(self):

--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -359,7 +359,7 @@ class SSHClient(ClosingContextManager):
                     if timeout is not None:
                         try:
                             sock.settimeout(timeout)
-                        except:
+                        except Exception:
                             pass
                     sock.connect(addr)
                     # Break out of the loop on success

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -2166,7 +2166,7 @@ class Transport(threading.Thread, ClosingContextManager):
                 finally:
                     self.lock.release()
             self.sock.close()
-        except:
+        except Exception:
             # Don't raise spurious 'NoneType has no attribute X' errors when we
             # wake up during interpreter shutdown. Or rather -- raise
             # everything *if* sys.modules (used as a convenient sentinel)


### PR DESCRIPTION
Fix 6 bare `except:` clauses that catch `BaseException` (including `SystemExit`, `KeyboardInterrupt`), replacing them with `except Exception:` or more specific types.

**`paramiko/agent.py`** (3 instances):
- Line 148: `except:` → `except Exception:` — `_communicate()` thread body; re-raises on failure.
- Line 203: `except:` → `except Exception:` — `_accept()` socket accept; re-raises on failure.
- Line 231: `except:` → `except OSError:` — `conn.connect(SSH_AUTH_SOCK)`; comment says "probably a dangling env var: the ssh agent is gone", so only `OSError` is expected.

**`paramiko/channel.py`** (1 instance):
- Line 139: `except: pass` → `except Exception: pass` — in `__del__` calling `self.close()`; standard cleanup.

**`paramiko/client.py`** (1 instance):
- Line 362: `except: pass` → `except Exception: pass` — around `sock.settimeout(timeout)`.

**`paramiko/transport.py`** (1 instance):
- Line 2169: `except:` → `except Exception:` — wraps transport run-loop teardown; conditionally re-raises if interpreter is still running.

Bare `except:` clauses are bad practice (PEP 8 / flake8 E722) because they swallow `KeyboardInterrupt` and `SystemExit`.