### PR TITLE
Fix SFTPFile.seek() to return the new absolute position

### DIFF
--- a/paramiko/sftp_file.py
+++ b/paramiko/sftp_file.py
@@ -260,6 +260,10 @@ class SFTPFile(BufferedFile):
         Set the file's current position.
 
         See `file.seek` for details.
+
+        :returns:
+            the new absolute position, in bytes, matching the standard
+            Python file-object convention (as `io.IOBase.seek` does).
         """
         self.flush()
         if whence == self.SEEK_SET:
@@ -270,6 +274,7 @@ class SFTPFile(BufferedFile):
         else:
             self._realpos = self._pos = self._get_size() + offset
         self._rbuffer = bytes()
+        return self._pos
 
     def stat(self):
         """

--- a/tests/test_sftp.py
+++ b/tests/test_sftp.py
@@ -473,6 +473,41 @@ class TestSFTP:
             except:
                 pass
 
+    def test_seek_returns_new_position(self, sftp):
+        """
+        Regression test for
+        https://github.com/paramiko/paramiko/issues/2218
+
+        seek() should return the new absolute position, matching the
+        standard Python file-object convention (as io.IOBase.seek()
+        does), instead of None.
+        """
+        try:
+            with sftp.open(sftp.FOLDER + "/bunny.txt", "w") as f:
+                f.write("0123456789")
+
+            with sftp.open(sftp.FOLDER + "/bunny.txt", "r+") as f:
+                # SEEK_SET (absolute)
+                assert f.seek(3, f.SEEK_SET) == 3
+                assert f.tell() == 3
+
+                # SEEK_CUR (relative to current position)
+                assert f.seek(2, f.SEEK_CUR) == 5
+                assert f.tell() == 5
+
+                # SEEK_END (relative to end of file, file is 10 bytes)
+                assert f.seek(-4, f.SEEK_END) == 6
+                assert f.tell() == 6
+
+                # default whence (SEEK_SET)
+                assert f.seek(0) == 0
+                assert f.tell() == 0
+        finally:
+            try:
+                sftp.remove(sftp.FOLDER + "/bunny.txt")
+            except:
+                pass
+
     def test_realpath(self, sftp):
         """
         test that realpath is returning something non-empty and not an


### PR DESCRIPTION
Fixes #2218.

`seek()` updated `self._pos`/`self._realpos` but didn't return anything, implicitly returning `None`. Standard Python file objects (per `io.IOBase.seek()`'s documented contract) return the new absolute position from `seek()`, and `SFTPFile`'s own `tell()` already does exactly that (`return self._pos`), so this brings `seek()` in line with both the general Python file-object convention and this class's own sibling method.

This is a purely additive change: any existing caller not using the return value (the overwhelming majority, since it was always `None`) is completely unaffected; callers wanting the new position previously had to make a separate `tell()` call immediately after `seek()`.

**Testing**: verified against a real, live in-process SFTP server (this project's own test fixture, not a mock): confirmed `seek()` now returns the correct new position for `SEEK_SET`, `SEEK_CUR`, and `SEEK_END` modes (and the default whence), matching `tell()` called immediately afterward in each case.

Added a regression test exercising all three whence modes plus the default-whence call against a real remote file. I confirmed the test fails with the original code (returns `None`) and passes with the fix. Ran the full existing `test_sftp.py` suite (35 passed: 34 baseline + 1 new, 4 skipped for unrelated reasons), no regressions.
