### PR TITLE
Fix _transfer_with_callback() undercounting size for text-mode readers

### DIFF
--- a/paramiko/sftp_client.py
+++ b/paramiko/sftp_client.py
@@ -677,7 +677,17 @@ class SFTPClient(BaseSFTP, ClosingContextManager):
         while True:
             data = reader.read(32768)
             writer.write(data)
-            size += len(data)
+            # writer.write() (see BufferedFile.write) auto-encodes str
+            # data to UTF-8 bytes before actually writing it. Measure
+            # the same encoded bytes here, rather than len(data),
+            # since len() of a str counts characters, not bytes --
+            # for a text-mode reader (e.g. io.StringIO) containing
+            # non-ASCII content, that undercounts the real number of
+            # bytes transferred, throwing off both the progress
+            # reported to `callback` and this method's own return
+            # value. See GH #2170.
+            data_len = len(data) if isinstance(data, bytes) else len(data.encode("utf-8"))
+            size += data_len
             if len(data) == 0:
                 break
             if callback is not None:

--- a/tests/test_sftp.py
+++ b/tests/test_sftp.py
@@ -755,6 +755,39 @@ class TestSFTP:
         finally:
             sftp.remove(target)
 
+    def test_putfo_non_ascii_size(self, sftp):
+        """
+        Regression test for
+        https://github.com/paramiko/paramiko/issues/2170
+
+        When reading from a text-mode (str-producing) file-like object
+        containing non-ASCII, multi-byte characters, the reported
+        size (both the callback's running total and putfo()'s return
+        value, via the remote file's attrs.st_size) must reflect the
+        actual number of UTF-8 encoded bytes written to the remote
+        file, not the character count of the source text.
+        """
+        text = u("日本語テスト")  # 6 characters, 18 bytes in UTF-8
+        expected_bytes = len(text.encode("utf-8"))
+        target = sftp.FOLDER + "/nonascii.txt"
+        stream = StringIO(text)
+
+        callback_calls = []
+
+        def callback(transferred, total):
+            callback_calls.append(transferred)
+
+        try:
+            attrs = sftp.putfo(stream, target, callback=callback)
+            assert attrs.st_size == expected_bytes
+            assert callback_calls[-1] == expected_bytes
+
+            # Confirm what's actually on the remote server matches too.
+            remote_attrs = sftp.stat(target)
+            assert remote_attrs.st_size == expected_bytes
+        finally:
+            sftp.remove(target)
+
     # TODO: this test doesn't actually fail if the regression (removing '%'
     # expansion to '%%' within sftp.py's def _log()) is removed - stacktraces
     # appear but they're clearly emitted from subthreads that have no error


### PR DESCRIPTION
Fixes #2170.

`_transfer_with_callback()` (used by both `put()` and `putfo()`) computed the number of bytes transferred as `len(data)`, where `data` comes directly from `reader.read()`. When `reader` is a text-mode (`str`-producing) file-like object -- e.g. `io.StringIO`, which `putfo()`'s own docstring documents as an acceptable "file-like object" -- and the content contains non-ASCII, multi-byte characters, `len(data)` counts characters, not bytes.

`writer.write(data)` (see `BufferedFile.write`) auto-encodes `str` data to UTF-8 bytes before actually writing it to the remote file, so the real number of bytes transferred can be larger than `len(data)` reports whenever multi-byte characters are present. This produces an incorrect running total passed to the progress `callback`, an incorrect final return value from `_transfer_with_callback()` (and therefore from `put()`/`putfo()`, which use it to build/verify the resulting `SFTPAttributes`), and -- more severely -- can make `putfo()`'s own default `confirm=True` size-verification step raise:

```
OSError: size mismatch in put!  <written> != <reported>
```

for any legitimate non-ASCII text content, even though the transfer itself succeeded correctly.

**Fix**: compute the transferred byte count from the same UTF-8 encoded bytes that `writer.write()` actually writes, rather than from `len(data)`, so callback progress and the return value are always correct regardless of whether `reader` produces `str` or `bytes`.

**Testing**: verified directly (bytes actually written vs. reported size) and end-to-end against a real, live in-process SFTP server (this project's own test fixture) using genuinely non-ASCII, multi-byte content: confirmed the original code both undercounted the size (6 vs. 18 for a 6-character, 18-byte Japanese string) and raised the exact `"size mismatch in put!"` `OSError` described above when using `putfo()`'s default `confirm=True`, and confirmed the fix resolves both issues, with the remote file's actual size, the callback's final value, and `putfo()`'s returned `attrs.st_size` all agreeing.

Added a regression test performing a real `putfo()` call with non-ASCII content against a live SFTP server, checking the callback's final value, `putfo()`'s returned size, and the remote file's actual `stat()` size all match the expected UTF-8 byte count. I confirmed the test fails with the original code and passes with the fix. Ran the full existing `test_sftp.py` suite (36 passed: 35 baseline + 1 new, 4 skipped for unrelated reasons), no regressions.
