### PR TITLE
Include port in BadHostKeyException.hostname for non-standard ports

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -457,7 +457,9 @@ class SSHClient(ClosingContextManager):
             if our_key != server_key:
                 if our_key is None:
                     our_key = list(our_server_keys.values())[0]
-                raise BadHostKeyException(hostname, server_key, our_key)
+                raise BadHostKeyException(
+                    server_hostkey_name, server_key, our_key
+                )
 
         if username is None:
             username = getpass.getuser()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -579,12 +579,20 @@ class SSHClientTest(ClientTest):
         known_hosts = self.tc.get_host_keys()
         known_hosts.add(hostname, host_key.get_name(), host_key)
 
-        self.assertRaises(
-            paramiko.BadHostKeyException,
-            self.tc.connect,
-            password="pygmalion",
-            **self.connect_kwargs,
-        )
+        with self.assertRaises(paramiko.BadHostKeyException) as ctx:
+            self.tc.connect(password="pygmalion", **self.connect_kwargs)
+
+        # Regression test for
+        # https://github.com/paramiko/paramiko/issues/2229
+        #
+        # BadHostKeyException.hostname must include the port (in the
+        # same "[hostname]:port" format HostKeys itself uses) whenever
+        # a non-standard port is in use, matching the format the
+        # exception's own known_hosts lookup key (`hostname` above)
+        # uses -- rather than the bare hostname/address, which
+        # wouldn't match any HostKeys entry and can't identify which
+        # of possibly many ports on that host had the bad key.
+        self.assertEqual(ctx.exception.hostname, hostname)
 
     def _client_host_key_good(self, ktype, kfile):
         threading.Thread(target=self._run).start()


### PR DESCRIPTION
Fixes #2229.

`SSHClient.connect()` already computes `server_hostkey_name` in the `[hostname]:port` format (matching `HostKeys`' own convention) whenever a non-standard port is used, and correctly passes it to `missing_host_key()`. However, the sibling `BadHostKeyException` raise a few lines later used the bare `hostname` parameter instead of this already-computed, correctly-formatted value -- an inconsistency between the two host-key-related error paths in the very same method, as reported in the issue.

**Fix**: use `server_hostkey_name` (already in scope) instead of `hostname` when raising `BadHostKeyException`. For the default port 22, `server_hostkey_name` equals `hostname` exactly, so this has no effect on the overwhelmingly common case; it only changes behavior for non-standard ports, where the exception's `hostname` now correctly identifies which port had the mismatched key, matching `HostKeys`' own `known_hosts` entry format.

**Testing**: verified against a real, live local SSH server (this project's own test fixture, which binds to a genuine OS-assigned non-standard port) with a deliberately mismatched host key: confirmed `BadHostKeyException.hostname` now correctly includes the port in `[hostname]:port` form, matching the `known_hosts` entry that was actually looked up, instead of the bare address.

Enhanced the existing `_client_host_key_bad` test helper (already exercising this non-standard-port scenario via a real connection attempt) to also assert the raised exception's `hostname` attribute matches the expected `[hostname]:port` format, rather than only checking that some `BadHostKeyException` was raised. I confirmed this assertion fails with the original code and passes with the fix. Ran the full existing `test_client.py` suite (33 passed, 2 skipped) and `test_ssh_exception.py` (9 passed), no regressions.
