### PR TITLE
Add Include directive support for SSH config parsing

### DIFF
--- a/paramiko/config.py
+++ b/paramiko/config.py
@@ -23,6 +23,7 @@ Configuration file (aka ``ssh_config``) support.
 
 import fnmatch
 import getpass
+import glob
 import os
 import re
 import shlex
@@ -103,10 +104,19 @@ class SSHConfig:
         """
         Create a new, parsed `SSHConfig` from the file found at ``path``.
 
+        ``Include`` directives within the file will be resolved. Relative
+        include paths are resolved against the directory containing the
+        config file.
+
         .. versionadded:: 2.7
+        .. versionchanged:: 5.1
+            Added ``Include`` directive support.
         """
         with open(path) as flo:
-            return cls.from_file(flo)
+            obj = cls()
+            base_dir = os.path.dirname(os.path.realpath(path))
+            obj.parse(flo, base_dir=base_dir)
+            return obj
 
     @classmethod
     def from_file(cls, flo):
@@ -119,12 +129,54 @@ class SSHConfig:
         obj.parse(flo)
         return obj
 
-    def parse(self, file_obj):
+    def parse(self, file_obj, base_dir=None):
         """
         Read an OpenSSH config from the given file object.
 
         :param file_obj: a file-like object to read the config file from
+        :param str base_dir:
+            Optional base directory for resolving ``Include`` directives.
+            Relative include paths are resolved against this directory.
+            If ``None``, any ``Include`` directive will raise
+            `ConfigParseError`. Typically set to ``~/.ssh/``.
+
+        .. versionchanged:: 5.1
+            Added ``base_dir`` parameter and ``Include`` directive support.
         """
+        # Track included files to detect circular includes
+        included_files = set()
+        # Add the root file to prevent self-includes
+        if hasattr(file_obj, "name"):
+            root_path = os.path.normcase(os.path.realpath(file_obj.name))
+            included_files.add(root_path)
+        context = self._parse_file(
+            file_obj,
+            base_dir=base_dir,
+            included_files=included_files
+        )
+        # Store last 'open' block and we're done
+        self._config.append(context)
+
+    def _parse_file(
+        self, file_obj, base_dir=None, included_files=None):
+        """
+        Internal recursive parser that handles ``Include`` directives.
+
+        :param file_obj: a file-like object to read the config file from
+        :param str base_dir:
+            Base directory for resolving relative ``Include`` paths.
+        :param set included_files:
+            Set of already-included absolute file paths (for circular
+            include detection).
+        :returns:
+            The current context dict (the last open Host/Match block).
+
+        .. versionchanged:: 5.1
+            Added ``base_dir`` and ``included_files`` parameters for
+            ``Include`` directive support.
+        """
+        if included_files is None:
+            included_files = set()
         # Start out w/ implicit/anonymous global host-like block to hold
         # anything not contained by an explicit one.
         context = {"host": ["*"], "config": {}}
@@ -143,8 +195,23 @@ class SSHConfig:
             key = match.group(1).lower()
             value = match.group(2)
 
+            # Handle Include directive
+            if key == "include":
+                if base_dir is None:
+                    raise ConfigParseError(
+                        "Include directive found but no base directory "
+                        "is available for resolving paths. Use "
+                        "SSHConfig.from_path() to enable Include support."
+                    )
+                # Save current context before processing includes
+                self._config.append(context)
+                context = self._process_include(
+                    value,
+                    base_dir=base_dir,
+                    included_files=included_files,
+                )
             # Host keyword triggers switch to new block/context
-            if key in ("host", "match"):
+            elif key in ("host", "match"):
                 self._config.append(context)
                 context = {"config": {}}
                 if key == "host":
@@ -176,8 +243,59 @@ class SSHConfig:
                         context["config"][key] = [value]
                 elif key not in context["config"]:
                     context["config"][key] = value
-        # Store last 'open' block and we're done
-        self._config.append(context)
+        return context
+
+    def _process_include(
+        self, value, base_dir, included_files):
+        """
+        Process an ``Include`` directive value.
+
+        Expands tilde and glob patterns, resolves paths relative to
+        ``base_dir``, and recursively parses each matched file.
+
+        :param str value: The raw value from the ``Include`` directive.
+        :param str base_dir:
+            Base directory for resolving relative paths.
+        :param set included_files:
+            Set of already-included absolute paths for circular detection.
+        :returns:
+            The last context dict from the included file(s).
+
+        .. versionadded:: 5.1
+        """
+        # Expand ~ to user's home directory
+        value = os.path.expanduser(value)
+        # Resolve relative paths against base_dir (OpenSSH resolves
+        # relative to ~/.ssh/ for user configs, /etc/ssh/ for system)
+        if not os.path.isabs(value):
+            value = os.path.join(base_dir, value)
+        # Expand glob patterns and sort alphabetically (matching OpenSSH)
+        matched_files = sorted(glob.glob(value))
+        # Last context from included files; start with a fresh global
+        # block in case no files match
+        context = {"host": ["*"], "config": {}}
+        for filepath in matched_files:
+            filepath = os.path.normcase(os.path.realpath(filepath))
+            # Skip non-files (e.g. directories)
+            if not os.path.isfile(filepath):
+                continue
+            # Circular include detection
+            if filepath in included_files:
+                raise ConfigParseError(
+                    "Circular Include detected: '{}' has already "
+                    "been included".format(filepath)
+                )
+            included_files.add(filepath)
+            # Append the previous context (from the prior included file
+            # or the initial empty block) before parsing the next file.
+            self._config.append(context)
+            with open(filepath) as flo:
+                context = self._parse_file(
+                    flo,
+                    base_dir=base_dir,
+                    included_files=included_files,
+                )
+        return context
 
     def lookup(self, hostname):
         """

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -2,6 +2,13 @@
 Changelog
 =========
 
+- :feature:`-` Added support for the ``Include`` directive in `SSHConfig
+  <paramiko.config.SSHConfig>` parsing, matching OpenSSH behavior. Supports
+  relative and absolute paths, tilde (``~``) expansion, glob patterns (sorted
+  alphabetically), recursive includes, and circular include detection. The
+  `~paramiko.config.SSHConfig.from_path` constructor automatically enables
+  ``Include`` support; `~paramiko.config.SSHConfig.parse` now accepts an
+  optional ``base_dir`` parameter.
 - :release:`5.0.0 <2026-05-09>`
 - :bug:`- major` Fix `Ed25519Key <paramiko.ed25519key.Ed25519Key>`'s internals
   such that it no longer throws `AttributeError` during calls to ``__repr__``

--- a/tests/configs/include-basic
+++ b/tests/configs/include-basic
@@ -1,0 +1,4 @@
+Host main-host
+    User main-user
+
+Include include-basic-sub

--- a/tests/configs/include-basic-sub
+++ b/tests/configs/include-basic-sub
@@ -1,0 +1,3 @@
+Host included-host
+    User included-user
+    Port 2222

--- a/tests/configs/include-circular-a
+++ b/tests/configs/include-circular-a
@@ -1,0 +1,4 @@
+Host circular-a
+    User user-a
+
+Include include-circular-b

--- a/tests/configs/include-circular-b
+++ b/tests/configs/include-circular-b
@@ -1,0 +1,4 @@
+Host circular-b
+    User user-b
+
+Include include-circular-a

--- a/tests/configs/include-glob
+++ b/tests/configs/include-glob
@@ -1,0 +1,4 @@
+Host glob-main
+    User glob-user
+
+Include include-subdir/*.conf

--- a/tests/configs/include-nonexistent
+++ b/tests/configs/include-nonexistent
@@ -1,0 +1,4 @@
+Host main-host
+    User main-user
+
+Include nonexistent-dir/*.conf

--- a/tests/configs/include-recursive-a
+++ b/tests/configs/include-recursive-a
@@ -1,0 +1,4 @@
+Host level-a
+    User user-a
+
+Include include-recursive-b

--- a/tests/configs/include-recursive-b
+++ b/tests/configs/include-recursive-b
@@ -1,0 +1,4 @@
+Host level-b
+    User user-b
+
+Include include-recursive-c

--- a/tests/configs/include-recursive-c
+++ b/tests/configs/include-recursive-c
@@ -1,0 +1,2 @@
+Host level-c
+    User user-c

--- a/tests/configs/include-subdir/alpha.conf
+++ b/tests/configs/include-subdir/alpha.conf
@@ -1,0 +1,2 @@
+Host alpha-host
+    User alpha-user

--- a/tests/configs/include-subdir/beta.conf
+++ b/tests/configs/include-subdir/beta.conf
@@ -1,0 +1,2 @@
+Host beta-host
+    User beta-user

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1046,3 +1046,70 @@ class TestFinalMatching(object):
     def test_negated(self):
         result = load_config("match-final").lookup("jump")
         assert result["port"] == "1003"
+
+
+class TestSSHConfigInclude:
+    """Tests for the ``Include`` directive support."""
+
+    def _load_with_include(self, name):
+        """
+        Load a config file using parse() with base_dir set to the test
+        configs directory, so that relative Include paths resolve correctly.
+        """
+        from os.path import dirname
+
+        path = _config(name)
+        base_dir = dirname(path)
+        config = SSHConfig()
+        with open(path) as flo:
+            config.parse(flo, base_dir=base_dir)
+        return config
+
+    def test_include_basic(self):
+        """Single Include pulls in another file's Host blocks."""
+        config = self._load_with_include("include-basic")
+        # Host from the main file
+        result = config.lookup("main-host")
+        assert result["user"] == "main-user"
+        # Host from the included file
+        result = config.lookup("included-host")
+        assert result["user"] == "included-user"
+        assert result["port"] == "2222"
+
+    def test_include_glob(self):
+        """Include with glob pattern loads multiple files."""
+        config = self._load_with_include("include-glob")
+        # Host from main file
+        result = config.lookup("glob-main")
+        assert result["user"] == "glob-user"
+        # Hosts from glob-matched files (sorted alphabetically)
+        result = config.lookup("alpha-host")
+        assert result["user"] == "alpha-user"
+        result = config.lookup("beta-host")
+        assert result["user"] == "beta-user"
+
+    def test_include_recursive(self):
+        """File A includes B which includes C — all hosts available."""
+        config = self._load_with_include("include-recursive-a")
+        result = config.lookup("level-a")
+        assert result["user"] == "user-a"
+        result = config.lookup("level-b")
+        assert result["user"] == "user-b"
+        result = config.lookup("level-c")
+        assert result["user"] == "user-c"
+
+    def test_include_circular_raises(self):
+        """Circular includes raise ConfigParseError."""
+        with raises(ConfigParseError, match="Circular Include detected"):
+            self._load_with_include("include-circular-a")
+
+    def test_include_nonexistent_glob_ignored(self):
+        """Glob that matches no files is silently skipped."""
+        config = self._load_with_include("include-nonexistent")
+        result = config.lookup("main-host")
+        assert result["user"] == "main-user"
+
+    def test_include_without_base_dir_raises(self):
+        """Include in from_text() raises ConfigParseError."""
+        with raises(ConfigParseError, match="Include directive found"):
+            SSHConfig.from_text("Include some-file.conf")


### PR DESCRIPTION
## Requirement:
Fixes https://github.com/paramiko/paramiko/issues/1609
- Implement OpenSSH-style `Include` directive in `SSHConfig` parser, enabling config files to reference and include other configuration files.

## Support added:
- Relative and absolute path resolution for Include values
- Tilde (~) expansion for home directory paths
- Glob pattern matching (e.g., `Include conf.d/*.conf`), sorted alphabetically
- Recursive Include support (file A includes B includes C)
- Circular Include detection with `ConfigParseError`
- Silent skip for glob patterns matching no files
- Guard against Include when no base directory is available (e.g., `from_text()`)
- Test configs for basic, glob, recursive, circular, and nonexistent includes
- Comprehensive test suite in `TestSSHConfigInclude`