### PR TITLE
Fix O(n²) memory copying in Channel.sendall()

### DIFF
--- a/paramiko/channel.py
+++ b/paramiko/channel.py
@@ -840,6 +840,7 @@ class Channel(ClosingContextManager):
             sent, there is no way to determine how much data (if any) was sent.
             This is irritating, but identically follows Python's API.
         """
+        s = memoryview(util.asbytes(s))
         while s:
             sent = self.send(s)
             s = s[sent:]
@@ -861,6 +862,7 @@ class Channel(ClosingContextManager):
 
         .. versionadded:: 1.1
         """
+        s = memoryview(util.asbytes(s))
         while s:
             sent = self.send_stderr(s)
             s = s[sent:]

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+- :bug:`-` Fix O(n²) memory copying in `Channel.sendall` and `Channel.sendall_stderr`
+  that caused high CPU usage and slow writes on small flow-control windows.
 - :release:`5.0.0 <2026-05-09>`
 - :bug:`- major` Fix `Ed25519Key <paramiko.ed25519key.Ed25519Key>`'s internals
   such that it no longer throws `AttributeError` during calls to ``__repr__``


### PR DESCRIPTION
## Issue:
Fixes https://github.com/paramiko/paramiko/issues/2659
- High CPU / slow writes on small flow-control windows.

## Root Cause:
- The `s = s[sent:]` on bytes copies the unsent suffix every loop, causing O(n²) total copies.

## Fix:
- Wrap data in `memoryview(bytearray(...))` so slicing is O(1) zero-copy.

## Test result:
<img width="820" height="683" alt="Screenshot 2026-07-26 031051" src="https://github.com/user-attachments/assets/7388bb02-8352-4105-b46f-e601af5e515d" />
