### PR TITLE
docs: document byte credentials for SSHClient.connect

### DIFF
--- a/paramiko/client.py
+++ b/paramiko/client.py
@@ -271,10 +271,10 @@ class SSHClient(ClosingContextManager):
         :param str username:
             the username to authenticate as (defaults to the current local
             username)
-        :param str password:
+        :param str or bytes password:
             Used for password authentication; is also used for private key
             decryption if ``passphrase`` is not given.
-        :param str passphrase:
+        :param str or bytes passphrase:
             Used for decrypting private keys.
         :param .PKey pkey: an optional private key to use for authentication
         :param str key_filename:

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+- :bug:`2602` Documented that the ``password`` and ``passphrase`` parameters
+  of `SSHClient.connect <paramiko.client.SSHClient.connect>` accept both
+  ``str`` and ``bytes`` values.
+
 - :release:`5.0.0 <2026-05-09>`
 - :bug:`- major` Fix `Ed25519Key <paramiko.ed25519key.Ed25519Key>`'s internals
   such that it no longer throws `AttributeError` during calls to ``__repr__``


### PR DESCRIPTION
## Purpose
Document that the `password` and `passphrase` parameters of `SSHClient.connect` accept both `str` and `bytes` values, matching the supported behavior.

## References
Closes #2602

## Verification
- `python -m compileall -q paramiko`
- `python -m pytest -q tests/test_client.py` (33 passed, 2 skipped)
- `git diff --check`