### PR TITLE
Fix RSAKey.sign_ssh_data() KeyError when algorithm is omitted

### DIFF
--- a/paramiko/rsakey.py
+++ b/paramiko/rsakey.py
@@ -133,7 +133,11 @@ class RSAKey(PKey):
 
     def sign_ssh_data(self, data, algorithm=None):
         if algorithm is None:
-            algorithm = self.name
+            # NOTE: self.name (`ssh-rsa`) is no longer a valid key in
+            # HASHES (SHA1-based signing was removed), so it can't be used
+            # as the default algorithm here; fall back to SHA2-256 instead,
+            # matching modern OpenSSH's own default preference.
+            algorithm = "rsa-sha2-256"
         sig = self.key.sign(
             data,
             padding=padding.PKCS1v15(),

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+- :bug:`2628 major` Fix `RSAKey.sign_ssh_data
+  <paramiko.rsakey.RSAKey.sign_ssh_data>` raising ``KeyError`` when called
+  without an explicit ``algorithm`` argument. It previously defaulted to
+  ``self.name`` (``ssh-rsa``), which is no longer a valid key in ``HASHES``
+  now that SHA1-based RSA signing has been removed; it now defaults to
+  ``rsa-sha2-256`` instead.
 - :release:`5.0.0 <2026-05-09>`
 - :bug:`- major` Fix `Ed25519Key <paramiko.ed25519key.Ed25519Key>`'s internals
   such that it no longer throws `AttributeError` during calls to ``__repr__``

--- a/tests/pkey.py
+++ b/tests/pkey.py
@@ -305,7 +305,7 @@ class Ed25519Key_:
         # been assigned).
         # When fixed, we get a normal looking repr (albeit whose fingerprint
         # will effectively be that of an 'empty' key bytes)
-        assert (
-            repr(info.traceback[1].locals["self"])
-            == "PKey(alg=ED25519, bits=256, fp=SHA256:UsIasxMWEd9VFEwjARWWtGJ08DgHp1eib3gSBLed54U)"
+        assert repr(info.traceback[1].locals["self"]) == (
+            "PKey(alg=ED25519, bits=256, "
+            "fp=SHA256:UsIasxMWEd9VFEwjARWWtGJ08DgHp1eib3gSBLed54U)"
         )

--- a/tests/test_pkey.py
+++ b/tests/test_pkey.py
@@ -204,6 +204,19 @@ class KeyTest(unittest.TestCase):
     def test_sign_and_verify_rsa_sha2_256(self):
         self._sign_and_verify_rsa("rsa-sha2-256", SIGNED_RSA_256)
 
+    def test_sign_ssh_data_default_algorithm(self):
+        # Regression test for #2628: calling sign_ssh_data() with no
+        # explicit algorithm used to raise KeyError, because it defaulted
+        # to self.name ("ssh-rsa"), which is not a key in HASHES anymore
+        # (SHA1-based signing was removed).
+        key = RSAKey.from_private_key_file(_support("rsa.key"))
+        msg = key.sign_ssh_data(b"ice weasels")
+        msg.rewind()
+        assert msg.get_text() == "rsa-sha2-256"
+        msg.rewind()
+        pub = RSAKey(data=key.asbytes())
+        assert pub.verify_ssh_sig(b"ice weasels", msg)
+
     def test_generate_rsa(self):
         # TODO: this probs needs to be larger number now
         key = RSAKey.generate(1024)


### PR DESCRIPTION
## Bug

Closes #2628

`RSAKey.sign_ssh_data(data, algorithm=None)` defaults `algorithm` to `self.name` (`"ssh-rsa"`) when the caller doesn't pass one explicitly:

```python
def sign_ssh_data(self, data, algorithm=None):
    if algorithm is None:
        algorithm = self.name
    sig = self.key.sign(
        data,
        padding=padding.PKCS1v15(),
        algorithm=self.HASHES[algorithm](),
    )
```

Since SHA1-based `ssh-rsa` signing was removed, `RSAKey.HASHES` no longer has an `"ssh-rsa"` entry (only `rsa-sha2-256`/`rsa-sha2-512` and their `*-cert-v01@openssh.com` variants). So any caller relying on the default, e.g.:

```python
key = RSAKey.generate(1024)
key.sign_ssh_data(b"hello")
```

hits:

```
KeyError: 'ssh-rsa'
```

## Fix

Default `algorithm` to `"rsa-sha2-256"` instead of `self.name`, matching modern OpenSSH's own default RSA signature preference (also mirrors the algorithm already used as the "generic" case throughout the existing test suite, e.g. `test_generate_rsa`).

## Testing

- Added `test_sign_ssh_data_default_algorithm` to `tests/test_pkey.py`, calling `sign_ssh_data()` with no `algorithm` argument and verifying the produced signature round-trips through `verify_ssh_sig`. Fails with the reported `KeyError` before the fix, passes after.
- Ran `pytest tests/test_pkey.py tests/test_transport.py`: 134 passed, 3 skipped (1 pre-existing, unrelated failure on this Windows sandbox — `test_new_keyfiles_avoid_descriptor_race_integration`, which checks POSIX file-mode bits and fails identically on a clean checkout with no changes, since Windows doesn't support `0600`-style permissions the same way).
- Added a changelog entry in `sites/www/changelog.rst` per repo convention.