### PR TITLE
SFTPFile.seek(SEEK_END) should propagate stat errors, not swallow them

### DIFF
--- a/paramiko/sftp_file.py
+++ b/paramiko/sftp_file.py
@@ -268,7 +268,14 @@ class SFTPFile(BufferedFile):
             self._pos += offset
             self._realpos = self._pos
         else:
-            self._realpos = self._pos = self._get_size() + offset
+            # Intentionally use stat() (which propagates errors) instead of
+            # _get_size() (which silently swallows them and returns 0) here.
+            # Silently treating an unknown/unreadable size as 0 would make
+            # SEEK_END seek to position 0 without any indication that
+            # anything went wrong, which can cause silent data loss/
+            # truncation for callers relying on tell() afterwards.
+            # See https://github.com/paramiko/paramiko/issues/2460.
+            self._realpos = self._pos = self.stat().st_size + offset
         self._rbuffer = bytes()
 
     def stat(self):

--- a/tests/test_sftp.py
+++ b/tests/test_sftp.py
@@ -30,6 +30,7 @@ import warnings
 from binascii import hexlify
 from io import StringIO
 from tempfile import mkstemp
+from unittest import mock
 
 import pytest
 
@@ -741,6 +742,37 @@ class TestSFTP:
                 assert f.readline() == "third line\n"
         finally:
             sftp.remove(sftp.FOLDER + "/append.txt")
+
+    def test_seek_end_propagates_stat_errors(self, sftp):
+        """
+        verify that SFTPFile.seek(0, SEEK_END) propagates errors from the
+        server instead of silently treating them as if the file were empty.
+
+        Some servers can fail to respond to CMD_FSTAT on a given file (see
+        https://github.com/paramiko/paramiko/issues/2460); previously,
+        SFTPFile.seek(..., SEEK_END) swallowed such errors and silently
+        reset the file's position to 0, causing tell() to lie about the
+        real size/position and potentially truncating data for callers
+        that trust it (e.g. code that streams the file elsewhere).
+        """
+        data = b"hello there\n"
+        try:
+            with sftp.open(sftp.FOLDER + "/seek_end.txt", "wb") as f:
+                f.write(data)
+
+            with sftp.open(sftp.FOLDER + "/seek_end.txt", "rb") as f:
+                # Sanity check: normal SEEK_END still works.
+                f.seek(0, f.SEEK_END)
+                assert f.tell() == len(data)
+
+                # Simulate a server that can't answer CMD_FSTAT.
+                with mock.patch.object(
+                    f, "stat", side_effect=IOError("stat failed")
+                ):
+                    with pytest.raises(IOError):
+                        f.seek(0, f.SEEK_END)
+        finally:
+            sftp.remove(sftp.FOLDER + "/seek_end.txt")
 
     def test_putfo_empty_file(self, sftp):
         """


### PR DESCRIPTION
### Problem

`SFTPFile.seek(offset, SFTPFile.SEEK_END)` computes the new position via `self._get_size()`:

```python
def _get_size(self):
    try:
        return self.stat().st_size
    except:
        return 0
```

`_get_size()` swallows *any* exception from `stat()` (i.e. `CMD_FSTAT`) and returns `0`. If the server's `CMD_FSTAT` implementation is broken or unsupported for a given file (as reported against a "Maverick" SFTP server), `seek(0, SEEK_END)` silently sets the position to `0` instead of raising - so `tell()` afterwards reports `0` instead of the real file size, with no indication anything went wrong.

This isn't just cosmetic: reporter noted that passing such an `SFTPFile` to `boto3`'s `upload_fileobj()` causes boto3 to determine (via `tell()`) that the file is empty, silently truncating the "transferred" file to 0 bytes.

Closes #2460

### Fix

`SFTPFile.seek()`'s `SEEK_END` branch now calls `self.stat().st_size` directly instead of `self._get_size()`, so a `stat()`/`CMD_FSTAT` failure propagates as an exception instead of being silently treated as "file is 0 bytes".

`_get_size()` itself is left unchanged, since it's also used by `BufferedFile._set_mode()` for append-mode opens (see #2050), which already depends on it defaulting to `0` on failure - changing that call site's behavior is a separate, more involved question I didn't want to bundle into this fix.

### Testing

- Added `test_seek_end_propagates_stat_errors`, which opens a real file against the test suite's stub SFTP server, confirms normal `seek(0, SEEK_END)` still works, then mocks `stat()` to raise and asserts `seek(0, SEEK_END)` now raises instead of silently resetting the position to 0.
- Confirmed the new test fails with `Failed: DID NOT RAISE <class 'OSError'>` when the fix is reverted (stashed `sftp_file.py` only, test unchanged).
- Full `tests/test_sftp.py` suite: 35 passed, 4 skipped (pre-existing skips, unrelated to this change).
- `black --line-length 79` (pinned project version 22.12.0) and `flake8` both clean on the changed files.
