### PR TITLE
docs: clarify PKey.sign_ssh_data return types

### DIFF
--- a/paramiko/pkey.py
+++ b/paramiko/pkey.py
@@ -416,15 +416,18 @@ class PKey:
 
     def sign_ssh_data(self, data, algorithm=None):
         """
-        Sign a blob of data with this private key, and return a `.Message`
-        representing an SSH signature message.
+        Sign a blob of data with this private key, and return an SSH signature
+        message.
 
         :param bytes data:
             the data to sign.
         :param str algorithm:
             the signature algorithm to use, if different from the key's
             internal name. Default: ``None``.
-        :return: an SSH signature `message <.Message>`.
+        :rtype: `.Message` or bytes
+        :return:
+            an SSH signature `message <.Message>`, or the encoded message as
+            ``bytes`` for agent-backed keys.
 
         .. versionchanged:: 2.9
             Added the ``algorithm`` kwarg.


### PR DESCRIPTION
Fixes #2539

`AgentKey.sign_ssh_data()` returns an encoded byte string, while locally held key implementations return a `Message`. Clarify the generic `PKey` API documentation and its return type so the inherited AgentKey documentation no longer promises only `Message`.

Tests:
- `uv run flake8 paramiko/pkey.py`
- `uv run codespell paramiko/pkey.py`
- `uv run pytest tests/test_pkey.py -q` (39 passed, 1 skipped)
- `uv run sphinx-build -E -W -b html sites/docs sites/docs/_build`