### PR TITLE
Use constant-time comparison for host key bytes

### DIFF
--- a/paramiko/hostkeys.py
+++ b/paramiko/hostkeys.py
@@ -219,7 +219,7 @@ class HostKeys(MutableMapping):
         host_key = k.get(key.get_name(), None)
         if host_key is None:
             return False
-        return host_key.asbytes() == key.asbytes()
+        return constant_time_bytes_eq(host_key.asbytes(), key.asbytes())
 
     def clear(self):
         """

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -120,6 +120,7 @@ from paramiko.util import (
     ClosingContextManager,
     b,
     clamp_value,
+    constant_time_bytes_eq,
 )
 
 # TripleDES is moving from `cryptography.hazmat.primitives.ciphers.algorithms`
@@ -1327,7 +1328,7 @@ class Transport(threading.Thread, ClosingContextManager):
             key = self.get_remote_server_key()
             if (
                 key.get_name() != hostkey.get_name()
-                or key.asbytes() != hostkey.asbytes()
+                or not constant_time_bytes_eq(key.asbytes(), hostkey.asbytes())
             ):
                 self._log(DEBUG, "Bad host key from server")
                 self._log(

--- a/tests/test_hostkeys.py
+++ b/tests/test_hostkeys.py
@@ -94,6 +94,14 @@ class HostKeysTest(unittest.TestCase):
         self.assertEqual(b"7EC91BB336CB6D810B124B1353C32396", fp)
         self.assertTrue(hostdict.check("foo.example.com", key))
 
+    def test_check_rejects_mismatched_key(self):
+        # check() now compares key bytes via constant_time_bytes_eq rather
+        # than ==; confirm a same-type, different-bytes key is still
+        # correctly rejected, not just "doesn't crash".
+        hostdict = paramiko.HostKeys("hostfile.temp")
+        other_key = paramiko.RSAKey(data=decodebytes(keyblob))
+        self.assertFalse(hostdict.check("secure.example.com", other_key))
+
     def test_dict(self):
         hostdict = paramiko.HostKeys("hostfile.temp")
         self.assertTrue("secure.example.com" in hostdict)


### PR DESCRIPTION
Fixes #2585.

Host key comparisons in hostkeys.py and transport.py use == and != on the raw key bytes, which short-circuit on the first differing byte and leak timing information. `constant_time_bytes_eq` already exists in paramiko.util and is already used for hashed hostname matching in hostkeys.py, just not for the key bytes themselves.

Switched both comparisons to use it. Added a test that a same-type key with different bytes is still correctly rejected by `HostKeys.check`, not just that it stops crashing. The existing host key mismatch tests in test_client.py cover the transport.py path.

Ran test_hostkeys.py, test_util.py, and the host_key tests in test_client.py, flake8, and black, all clean.
