### PR TITLE
AgentKey.sign_ssh_data: return a Message like other PKey subclasses

### DIFF
--- a/paramiko/agent.py
+++ b/paramiko/agent.py
@@ -495,4 +495,8 @@ class AgentKey(PKey):
         ptype, result = self.agent._send_message(msg)
         if ptype != SSH2_AGENT_SIGN_RESPONSE:
             raise SSHException("key cannot be used for signing")
-        return result.get_binary()
+        # The agent's response blob is already an SSH-format signature
+        # (algorithm string + signature). Wrap it in a Message to match the
+        # base-class contract and the other PKey subclasses, which return
+        # Messages rather than raw bytes (GH #2539).
+        return Message(result.get_binary())

--- a/tests/agent.py
+++ b/tests/agent.py
@@ -150,7 +150,9 @@ class AgentKey_:
             blobby = inner_key.public_blob.key_blob
         key = AgentKey(agent=agent, blob=blobby)
         result = key.sign_ssh_data(b"data-to-sign", **sign_kwargs)
-        assert result == b"lol"
+        # GH #2539: signatures are Messages, like the other PKey subclasses
+        assert isinstance(result, Message)
+        assert result.asbytes() == b"lol"
         msg = agent._sent_message
         msg.rewind()
         assert msg.get_byte() == cSSH2_AGENTC_SIGN_REQUEST

--- a/tests/pkey.py
+++ b/tests/pkey.py
@@ -305,7 +305,7 @@ class Ed25519Key_:
         # been assigned).
         # When fixed, we get a normal looking repr (albeit whose fingerprint
         # will effectively be that of an 'empty' key bytes)
-        assert (
-            repr(info.traceback[1].locals["self"])
-            == "PKey(alg=ED25519, bits=256, fp=SHA256:UsIasxMWEd9VFEwjARWWtGJ08DgHp1eib3gSBLed54U)"
+        assert repr(info.traceback[1].locals["self"]) == (
+            "PKey(alg=ED25519, bits=256, "
+            "fp=SHA256:UsIasxMWEd9VFEwjARWWtGJ08DgHp1eib3gSBLed54U)"
         )


### PR DESCRIPTION
Fixes #2539 
(GH #2539) PKey.sign_ssh_data documents a Message return value and all concrete subclasses return one, except AgentKey, which returned raw bytes. Wrap the agent's SSH-format signature blob in a Message so callers no longer need to special-case the return type. Wire bytes are unchanged (Message.add_string coerces via asbytes).