### PR TITLE
SSHConfig: tolerate unresolvable local username

### DIFF
--- a/paramiko/config.py
+++ b/paramiko/config.py
@@ -353,7 +353,7 @@ class SSHConfig:
     ):
         matched = []
         candidates = match_list[:]
-        local_username = getpass.getuser()
+        local_username = _get_local_username()
         while candidates:
             candidate = candidates.pop(0)
             passed = None
@@ -433,7 +433,7 @@ class SSHConfig:
             port = config["port"]
         else:
             port = SSH_PORT
-        user = getpass.getuser()
+        user = _get_local_username()
         if "user" in config:
             remoteuser = config["user"]
         else:
@@ -554,6 +554,25 @@ class SSHConfig:
             if err is not None:
                 raise ConfigParseError(err)
         return matches
+
+
+def _get_local_username():
+    """
+    Best-effort lookup of the local username, used for ``Match
+    user/localuser`` and ``%u``/``%r`` token expansion.
+
+    ``getpass.getuser()`` can fail outright in minimal environments (e.g.
+    CI containers whose UID has no passwd entry and no username env vars),
+    which used to crash any ``SSHConfig.lookup()``; degrade to the numeric
+    UID (mirroring OpenSSH) or an empty string instead. See GH #2279.
+    """
+    try:
+        return getpass.getuser()
+    except (ImportError, KeyError, OSError):
+        try:
+            return str(os.getuid())
+        except AttributeError:
+            return ""
 
 
 def _addressfamily_host_lookup(hostname, options):

--- a/tests/pkey.py
+++ b/tests/pkey.py
@@ -305,7 +305,7 @@ class Ed25519Key_:
         # been assigned).
         # When fixed, we get a normal looking repr (albeit whose fingerprint
         # will effectively be that of an 'empty' key bytes)
-        assert (
-            repr(info.traceback[1].locals["self"])
-            == "PKey(alg=ED25519, bits=256, fp=SHA256:UsIasxMWEd9VFEwjARWWtGJ08DgHp1eib3gSBLed54U)"
+        assert repr(info.traceback[1].locals["self"]) == (
+            "PKey(alg=ED25519, bits=256, "
+            "fp=SHA256:UsIasxMWEd9VFEwjARWWtGJ08DgHp1eib3gSBLed54U)"
         )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1046,3 +1046,34 @@ class TestFinalMatching(object):
     def test_negated(self):
         result = load_config("match-final").lookup("jump")
         assert result["port"] == "1003"
+
+
+class TestUnresolvableLocalUsername:
+    # GH #2279: getpass.getuser() can blow up in minimal environments (no
+    # username env vars, unresolvable UID); config lookups must not crash.
+
+    @mark.parametrize(
+        "error",
+        [KeyError("getpwuid(): uid not found: 1005"), OSError],
+    )
+    def test_lookup_survives_getuser_failure(self, error):
+        with patch("paramiko.config.getpass.getuser", side_effect=error):
+            config = SSHConfig.from_text(
+                """
+Match localuser someone-else
+    Port 1234
+
+Host *
+    User everybody
+"""
+            )
+            result = config.lookup("whatever")
+            assert "port" not in result
+            assert result["user"] == "everybody"
+
+    @mark.parametrize("error", [KeyError("uid not found"), OSError])
+    def test_token_expansion_survives_getuser_failure(self, error):
+        with patch("paramiko.config.getpass.getuser", side_effect=error):
+            config = SSHConfig.from_text("IdentityFile /home/%u/.ssh/id_rsa")
+            result = config.lookup("whatever")
+            assert "identityfile" in result


### PR DESCRIPTION
Fixes #2279 
(GH #2279) getpass.getuser() raises (KeyError/OSError) in minimal environments such as CI containers whose UID has no passwd entry and no username env vars, crashing every SSHConfig.lookup() and token expansion. Route both call sites through a new _get_local_username() helper that degrades to the numeric UID (like OpenSSH) or an empty string.