### PR TITLE
Avoid O(n^2) copying in Channel.sendall/sendall_stderr

### DIFF
--- a/paramiko/channel.py
+++ b/paramiko/channel.py
@@ -840,9 +840,13 @@ class Channel(ClosingContextManager):
             sent, there is no way to determine how much data (if any) was sent.
             This is irritating, but identically follows Python's API.
         """
-        while s:
-            sent = self.send(s)
-            s = s[sent:]
+        # Slice a memoryview instead of the bytes object itself: the latter
+        # copies the entire remaining buffer on each pass, which is O(n^2)
+        # when the remote flow-control window is small. See GH #2659.
+        view = memoryview(util.asbytes(s))
+        while len(view):
+            sent = self.send(view)
+            view = view[sent:]
         return None
 
     def sendall_stderr(self, s):
@@ -861,9 +865,11 @@ class Channel(ClosingContextManager):
 
         .. versionadded:: 1.1
         """
-        while s:
-            sent = self.send_stderr(s)
-            s = s[sent:]
+        # Mirror sendall()'s O(1)-slice behavior (see GH #2659).
+        view = memoryview(util.asbytes(s))
+        while len(view):
+            sent = self.send_stderr(view)
+            view = view[sent:]
         return None
 
     def makefile(self, *params):

--- a/tests/pkey.py
+++ b/tests/pkey.py
@@ -305,7 +305,7 @@ class Ed25519Key_:
         # been assigned).
         # When fixed, we get a normal looking repr (albeit whose fingerprint
         # will effectively be that of an 'empty' key bytes)
-        assert (
-            repr(info.traceback[1].locals["self"])
-            == "PKey(alg=ED25519, bits=256, fp=SHA256:UsIasxMWEd9VFEwjARWWtGJ08DgHp1eib3gSBLed54U)"
+        assert repr(info.traceback[1].locals["self"]) == (
+            "PKey(alg=ED25519, bits=256, "
+            "fp=SHA256:UsIasxMWEd9VFEwjARWWtGJ08DgHp1eib3gSBLed54U)"
         )


### PR DESCRIPTION
Fixes #2659 
(GH #2659) sendall repeatedly did s = s[sent:], copying the entire remaining buffer each time send() could only push a small chunk (e.g. tiny remote flow-control windows). Advance a memoryview instead, which slices in O(1).