### PR TITLE
Use Cryptography instead of PyNaCl for Ed25519 keys

### DIFF
--- a/paramiko/ed25519key.py
+++ b/paramiko/ed25519key.py
@@ -17,14 +17,32 @@
 from typing import Union
 
 import bcrypt
-import nacl.signing
+from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
 from cryptography.hazmat.primitives.ciphers import Cipher
 
 from paramiko.message import Message
 from paramiko.pkey import OPENSSH_AUTH_MAGIC, PKey, _unpad_openssh
 from paramiko.ssh_exception import PasswordRequiredException, SSHException
 from paramiko.util import b
+
+
+def _public_bytes(key: Ed25519PublicKey) -> bytes:
+    """
+    Return the 32 raw bytes of ``key``, as used in the SSH ``ssh-ed25519``
+    key blob.
+
+    Cryptography's own ``public_bytes_raw`` is tidier, but only exists as of
+    version 40; this spelling works on every version we support.
+    """
+    return key.public_bytes(
+        serialization.Encoding.Raw, serialization.PublicFormat.Raw
+    )
 
 
 class Ed25519Key(PKey):
@@ -54,7 +72,9 @@ class Ed25519Key(PKey):
                 key_type=self.name,
                 cert_type="ssh-ed25519-cert-v01@openssh.com",
             )
-            self._verifying_key = nacl.signing.VerifyKey(msg.get_binary())
+            self._verifying_key = Ed25519PublicKey.from_public_bytes(
+                msg.get_binary()
+            )
         elif filename is not None:
             with open(filename, "r") as f:
                 pkformat, data = self._read_private_key("OPENSSH", f)
@@ -147,10 +167,10 @@ class Ed25519Key(PKey):
             key_data = message.get_binary()
             # The second half of the key data is yet another copy of the public
             # key...
-            signing_key = nacl.signing.SigningKey(key_data[:32])
+            signing_key = Ed25519PrivateKey.from_private_bytes(key_data[:32])
             # Verify that all the public keys are the same...
             assert (
-                signing_key.verify_key.encode()
+                _public_bytes(signing_key.public_key())
                 == public
                 == public_keys[i]
                 == key_data[32:]
@@ -166,7 +186,7 @@ class Ed25519Key(PKey):
     def asbytes(self):
         v = self.verifying_key
         # Handle not-fully-initialized situations gracefully
-        my_bytes = v.encode() if v is not None else b""
+        my_bytes = _public_bytes(v) if v is not None else b""
         m = Message()
         m.add_string(self.name)
         m.add_string(my_bytes)
@@ -174,7 +194,12 @@ class Ed25519Key(PKey):
 
     @property
     def _fields(self):
-        return (self.get_name(), self.verifying_key)
+        # NOTE: this deliberately uses the key's raw bytes and not the key
+        # object itself. Cryptography's key objects compare by identity on
+        # older versions and are unhashable on newer ones; neither is safe
+        # for the equality/hashing contract PKey relies on here.
+        v = self.verifying_key
+        return (self.get_name(), _public_bytes(v) if v is not None else b"")
 
     # TODO (backwards incompat): remove
     def get_name(self):
@@ -190,9 +215,9 @@ class Ed25519Key(PKey):
         return self._verifying_key is not None
 
     @property
-    def verifying_key(self) -> Union[nacl.signing.VerifyKey, None]:
+    def verifying_key(self) -> Union[Ed25519PublicKey, None]:
         if self.can_sign():
-            return self._signing_key.verify_key
+            return self._signing_key.public_key()
         elif self.can_verify():
             return self._verifying_key
         return None
@@ -200,7 +225,7 @@ class Ed25519Key(PKey):
     def sign_ssh_data(self, data, algorithm=None):
         m = Message()
         m.add_string(self.name)
-        m.add_string(self._signing_key.sign(data).signature)
+        m.add_string(self._signing_key.sign(data))
         return m
 
     def verify_ssh_sig(self, data, msg):
@@ -208,8 +233,8 @@ class Ed25519Key(PKey):
             return False
 
         try:
-            self._verifying_key.verify(data, msg.get_binary())
-        except nacl.exceptions.BadSignatureError:
+            self._verifying_key.verify(msg.get_binary(), data)
+        except InvalidSignature:
             return False
         else:
             return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ dependencies = [
   "bcrypt>=3.2",
   "cryptography>=3.3",
   "invoke>=2.0",
-  "pynacl>=1.5",
 ]
 
 classifiers = [

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -10,6 +10,19 @@ Changelog
   (which requires OpenSSL 3.5+, AWS-LC, or BoringSSL); it is preferred over
   the existing classical methods when available. See
   `paramiko.kex_mlkem.KexMLKEM768X25519`.
+- :support:`2527` Ed25519 key support no longer requires `PyNaCl
+  <https://pypi.org/project/PyNaCl/>`_; it now uses Cryptography, which has
+  supported Ed25519 since its 2.6 release and which Paramiko already depends
+  on for every other public key type. ``pynacl`` has been dropped from our
+  install requirements as a result.
+
+  .. warning::
+    `Ed25519Key.verifying_key <paramiko.ed25519key.Ed25519Key>` now returns a
+    ``cryptography.hazmat.primitives.asymmetric.ed25519.Ed25519PublicKey``
+    instead of a ``nacl.signing.VerifyKey``. Code touching that attribute
+    directly will need updating; the SSH-facing API and the on-the-wire
+    signatures are unchanged.
+
 - :release:`5.0.0 <2026-05-09>`
 - :bug:`- major` Fix `Ed25519Key <paramiko.ed25519key.Ed25519Key>`'s internals
   such that it no longer throws `AttributeError` during calls to ``__repr__``

--- a/sites/www/installing.rst
+++ b/sites/www/installing.rst
@@ -23,8 +23,8 @@ Paramiko has only a few **direct dependencies**:
 
 - The big one, with its own sub-dependencies, is Cryptography; see :ref:`its
   specific note below <cryptography>` for more details;
-- `bcrypt <https://pypi.org/project/bcrypt/>`_ and `pynacl
-  <https://pypi.org/project/PyNaCl/>`_ for Ed25519 key support.
+- `bcrypt <https://pypi.org/project/bcrypt/>`_, for decrypting
+  password-protected OpenSSH-format private keys.
 
 There are also a handful of **optional dependencies** you may install using
 `setuptools 'extras'

--- a/tests/test_pkey.py
+++ b/tests/test_pkey.py
@@ -63,6 +63,7 @@ FINGER_ECDSA_521 = "521 44:58:22:52:12:33:16:0e:ce:0e:be:2c:7c:7e:cc:1e"
 SIGNED_RSA = "20:d7:8a:31:21:cb:f7:92:12:f2:a4:89:37:f5:78:af:e6:16:b6:25:b9:97:3d:a2:cd:5f:ca:20:21:73:4c:ad:34:73:8f:20:77:28:e2:94:15:08:d8:91:40:7a:85:83:bf:18:37:95:dc:54:1a:9b:88:29:6c:73:ca:38:b4:04:f1:56:b9:f2:42:9d:52:1b:29:29:b4:4f:fd:c9:2d:af:47:d2:40:76:30:f3:63:45:0c:d9:1d:43:86:0f:1c:70:e2:93:12:34:f3:ac:c5:0a:2f:14:50:66:59:f1:88:ee:c1:4a:e9:d1:9c:4e:46:f0:0e:47:6f:38:74:f1:44:a8"  # noqa
 SIGNED_RSA_256 = "cc:6:60:e0:0:2c:ac:9e:26:bc:d5:68:64:3f:9f:a7:e5:aa:41:eb:88:4a:25:5:9c:93:84:66:ef:ef:60:f4:34:fb:f4:c8:3d:55:33:6a:77:bd:b2:ee:83:f:71:27:41:7e:f5:7:5:0:a9:4c:7:80:6f:be:76:67:cb:58:35:b9:2b:f3:c2:d3:3c:ee:e1:3f:59:e0:fa:e4:5c:92:ed:ae:74:de:d:d6:27:16:8f:84:a3:86:68:c:94:90:7d:6e:cc:81:12:d8:b6:ad:aa:31:a8:13:3d:63:81:3e:bb:5:b6:38:4d:2:d:1b:5b:70:de:83:cc:3a:cb:31"  # noqa
 SIGNED_RSA_512 = "87:46:8b:75:92:33:78:a0:22:35:32:39:23:c6:ab:e1:6:92:ad:bc:7f:6e:ab:19:32:e4:78:b2:2c:8f:1d:c:65:da:fc:a5:7:ca:b6:55:55:31:83:b1:a0:af:d1:95:c5:2e:af:56:ba:f5:41:64:f:39:9d:af:82:43:22:8f:90:52:9d:89:e7:45:97:df:f3:f2:bc:7b:3a:db:89:e:34:fd:18:62:25:1b:ef:77:aa:c6:6c:99:36:3a:84:d6:9c:2a:34:8c:7f:f4:bb:c9:a5:9a:6c:11:f2:cf:da:51:5e:1e:7f:90:27:34:de:b2:f3:15:4f:db:47:32:6b:a7"  # noqa
+SIGNED_ED25519 = "92:e7:e3:93:c2:67:84:16:62:f9:44:79:f7:e5:ce:06:8d:54:86:ef:6d:d5:c8:a2:cc:22:86:fa:2b:ae:ba:86:9c:24:e2:e5:40:ef:e3:18:52:75:d1:58:44:8c:7c:e5:69:b5:61:18:0a:11:62:6a:e9:9b:97:97:16:b7:f2:0d"  # noqa
 FINGER_RSA_2K_OPENSSH = "2048 68:d1:72:01:bf:c0:0c:66:97:78:df:ce:75:74:46:d6"
 FINGER_EC_384_OPENSSH = "384 72:14:df:c1:9a:c3:e6:0e:11:29:d6:32:18:7b:ea:9b"
 
@@ -498,6 +499,33 @@ class KeyTest(unittest.TestCase):
         self.assertTrue(key.can_sign())
         self.assertTrue(not pub.can_sign())
         self.assertEqual(key, pub)
+        # __hash__ is built on the same _fields as __eq__
+        self.assertEqual(hash(key), hash(pub))
+
+    def test_sign_and_verify_ed25519(self):
+        # Ed25519 signatures are deterministic, so unlike ECDSA we can compare
+        # against a known-correct signature.
+        key = Ed25519Key.from_private_key_file(_support("ed25519.key"))
+        msg = key.sign_ssh_data(b"ice weasels")
+        assert isinstance(msg, Message)
+        msg.rewind()
+        assert msg.get_text() == "ssh-ed25519"
+        expected = b"".join(
+            [byte_chr(int(x, 16)) for x in SIGNED_ED25519.split(":")]
+        )
+        assert msg.get_binary() == expected
+        msg.rewind()
+        pub = Ed25519Key(data=key.asbytes())
+        self.assertTrue(pub.verify_ssh_sig(b"ice weasels", msg))
+
+    def test_ed25519_verify_rejects_bad_signature(self):
+        key = Ed25519Key.from_private_key_file(_support("ed25519.key"))
+        pub = Ed25519Key(data=key.asbytes())
+        msg = Message()
+        msg.add_string("ssh-ed25519")
+        msg.add_string(b"\x00" * 64)
+        msg.rewind()
+        self.assertFalse(pub.verify_ssh_sig(b"ice weasels", msg))
 
     # No point testing on systems that never exhibited the bug originally
     @pytest.mark.skipif(


### PR DESCRIPTION
`Ed25519Key` is the only thing left in Paramiko that uses PyNaCl, so this moves
it over to Cryptography and drops `pynacl` from the requirements.

Ed25519 support landed in 2.2 (#325 via #972) on PyNaCl because Cryptography
had no Ed25519 primitive at the time. It got one in 2.6, and our floor is
already 3.3, so it has been available to us the whole time. Same approach as
@adiroiban's #1806 and @boyxuper's #2103, both of which have gone stale against
main — credit for it is theirs. Refs #1419 and #2527.

Besides shedding a dependency that generates a steady trickle of install and
import reports (#1265, #1435, most recently #2550), the reason I care about
this: Paramiko already lets OpenSSL decide what is usable, e.g.
`KexCurve25519.is_available()` drops curve25519 when OpenSSL refuses it.
Ed25519 is the one algorithm that cannot take part, because libsodium does not
know the OpenSSL configuration exists. On a host with a restricted algorithm
policy, OpenSSL will happily do Ed25519 — its FIPS provider has registered it
`fips=yes` since 3.4.0 — while libsodium simply is not in the picture. This
does not make Paramiko work under such a policy by itself, mind: `hashlib.md5()`
in `pkey.py` is still there, which is #396 and what #1928 / #2189 are about.
Nothing here overlaps those in `paramiko/`.

Three things that are not obvious from the diff:

- I used `public_bytes(Encoding.Raw, PublicFormat.Raw)` rather than the nicer
  `public_bytes_raw()`, which only exists in Cryptography 40+; the floor cell is
  still 3.3.2.
- `_fields` now holds raw bytes rather than the key object. Cryptography's key
  objects compare by identity on 3.3.2 and 39.0.0, and are unhashable on recent
  versions — and `PKey.__eq__`/`__hash__` are both built on `_fields`. Swap the
  bytes back for the object and `test_ed25519_compare` fails either way, once I
  added a `hash()` assertion to it; without that assertion only the equality
  half was caught.
- Cryptography's `verify()` takes `(signature, data)`, the other way round from
  PyNaCl's.

The one API change is `Ed25519Key.verifying_key`, which now returns an
`Ed25519PublicKey` instead of a `nacl.signing.VerifyKey`; there is a warning on
the changelog entry. I filed that as `:support:` — happy to move it if you would
rather it waited for a major.

Wire format is unchanged, and as Ed25519 is deterministic the new test pins the
exact signature the PyNaCl code produced for the existing fixture.

I diffed behaviour against main across certificates, `PKey.from_path`,
`from_type_string`, deepcopy, equality/hashing/set membership, fingerprints,
`get_bits`, `identifiers`, malformed key blobs and partly-initialised objects.
All identical, including error types. Three things do differ:

- `pickle.dumps()` on an `Ed25519Key` now raises `TypeError`, as Cryptography's
  key objects are not picklable. Worth knowing, though `RSAKey` and `ECDSAKey`
  are already unpicklable on main for exactly this reason — Ed25519Key was the
  only one that worked, by accident of PyNaCl. `copy.deepcopy()` still works.
- `verify_ssh_sig()` with a signature that is not 64 bytes used to raise
  `ValueError` out of a remote-supplied value; it now returns `False`. That
  looks like an improvement, but it is a change.
- On a host whose OpenSSL refuses Ed25519 — a FIPS provider older than 3.4.0,
  or OpenSSL below 1.1.1b — loading a key or parsing a peer's host key now
  raises `UnsupportedAlgorithm` where PyNaCl was simply unaffected by the
  policy. Obeying the policy is the point, but the failure is not graceful:
  `import paramiko` is fine, however `ssh-ed25519` stays in `_preferred_keys`,
  since there is no availability gate for host key algorithms like the one
  `KexCurve25519` has. Happy to add one if you want it here rather than
  separately.

Tested with `pynacl` uninstalled: the full suite on 3.13, which leaves exactly
the same 17 failures as unpatched 142f593e (the `AgentKey.public_blob` ones,
#2462), and `test_pkey.py`, `pkey.py`, `test_hostkeys.py` on 3.9 against all
three of your cryptography cells — 3.3.2, 39.0.0 and the newly added 48.0.0.
Worth noting 48.0.0 makes the `_fields` change load-bearing rather than
theoretical: `Ed25519PublicKey` is unhashable there, so the object form would
raise.
`test_ed25519_32bit_collision` is skipped off 32-bit, so I checked by hand that
the two badhash fixtures still differ in `_fields`.

Rebased onto 142f593e. This previously carried a second commit fixing the E501
in `tests/pkey.py`; you fixed that line yourself with a `# noqa` in the
meantime, so I dropped mine — this is now a single commit touching five files,
none of which you've changed upstream.
