### PR TITLE
Add in certificate identifiers for Ed25519 and ECDSA key types (was u…

### DIFF
--- a/paramiko/ecdsakey.py
+++ b/paramiko/ecdsakey.py
@@ -174,8 +174,14 @@ class ECDSAKey(PKey):
     @classmethod
     def identifiers(cls):
         # include both the base idetifiers and the -cert-v01@openssh.com suffixed ones
-        cert_identifiers = [f"{name}-cert-v01@openssh.com" for name in  cls._ECDSA_CURVES.get_key_format_identifier_list()]
-        return cls._ECDSA_CURVES.get_key_format_identifier_list() + cert_identifiers
+        cert_identifiers = [
+            f"{name}-cert-v01@openssh.com"
+            for name in cls._ECDSA_CURVES.get_key_format_identifier_list()
+        ]
+        return (
+            cls._ECDSA_CURVES.get_key_format_identifier_list()
+            + cert_identifiers
+        )
 
     # TODO (backwards incompat): deprecate/remove
     @classmethod

--- a/paramiko/ecdsakey.py
+++ b/paramiko/ecdsakey.py
@@ -173,7 +173,8 @@ class ECDSAKey(PKey):
 
     @classmethod
     def identifiers(cls):
-        # include both the base idetifiers and the -cert-v01@openssh.com suffixed ones
+        # include both the base identifiers as well as
+        # the -cert-v01@openssh.com suffixed ones
         cert_identifiers = [
             f"{name}-cert-v01@openssh.com"
             for name in cls._ECDSA_CURVES.get_key_format_identifier_list()

--- a/paramiko/ecdsakey.py
+++ b/paramiko/ecdsakey.py
@@ -173,7 +173,9 @@ class ECDSAKey(PKey):
 
     @classmethod
     def identifiers(cls):
-        return cls._ECDSA_CURVES.get_key_format_identifier_list()
+        # include both the base idetifiers and the -cert-v01@openssh.com suffixed ones
+        cert_identifiers = [f"{name}-cert-v01@openssh.com" for name in  cls._ECDSA_CURVES.get_key_format_identifier_list()]
+        return cls._ECDSA_CURVES.get_key_format_identifier_list() + cert_identifiers
 
     # TODO (backwards incompat): deprecate/remove
     @classmethod

--- a/paramiko/ed25519key.py
+++ b/paramiko/ed25519key.py
@@ -67,6 +67,11 @@ class Ed25519Key(PKey):
         if self._signing_key is None and self._verifying_key is None:
             raise ValueError("need a key")
 
+    @classmethod
+    def identifiers(cls):
+        # Include both plain key name and cert name
+        return [cls.name, f"{cls.name}-cert-v01@openssh.com"]
+
     def _parse_signing_key_data(self, data, password):
         from paramiko.transport import Transport
 

--- a/tests/pkey.py
+++ b/tests/pkey.py
@@ -228,15 +228,15 @@ class PKey_:
                 "ssh-rsa-cert-v01@openssh.com",
             ]
 
-        def ed25519_is_protocol_name(self):
-            assert Ed25519Key.identifiers() == ["ssh-ed25519"]
+        def ed25519_is_protocol_name_plus_certname(self):
+            assert set(Ed25519Key.identifiers()) == set(["ssh-ed25519", "ssh-ed25519-cert-v01@openssh.com"])
 
-        def ecdsa_is_all_curve_names(self):
-            assert ECDSAKey.identifiers() == [
-                "ecdsa-sha2-nistp256",
-                "ecdsa-sha2-nistp384",
-                "ecdsa-sha2-nistp521",
-            ]
+        def ecdsa_is_all_curve_names_plus_certnames(self):
+            assert set(ECDSAKey.identifiers()) == set([
+                "ecdsa-sha2-nistp256", "ecdsa-sha2-nistp256-cert-v01@openssh.com",
+                "ecdsa-sha2-nistp384", "ecdsa-sha2-nistp384-cert-v01@openssh.com",
+                "ecdsa-sha2-nistp521", "ecdsa-sha2-nistp521-cert-v01@openssh.com"
+            ])
 
     class write_private_key_and_file:
         @mark.parametrize(

--- a/tests/pkey.py
+++ b/tests/pkey.py
@@ -229,14 +229,21 @@ class PKey_:
             ]
 
         def ed25519_is_protocol_name_plus_certname(self):
-            assert set(Ed25519Key.identifiers()) == set(["ssh-ed25519", "ssh-ed25519-cert-v01@openssh.com"])
+            assert set(Ed25519Key.identifiers()) == set(
+                ["ssh-ed25519", "ssh-ed25519-cert-v01@openssh.com"]
+            )
 
         def ecdsa_is_all_curve_names_plus_certnames(self):
-            assert set(ECDSAKey.identifiers()) == set([
-                "ecdsa-sha2-nistp256", "ecdsa-sha2-nistp256-cert-v01@openssh.com",
-                "ecdsa-sha2-nistp384", "ecdsa-sha2-nistp384-cert-v01@openssh.com",
-                "ecdsa-sha2-nistp521", "ecdsa-sha2-nistp521-cert-v01@openssh.com"
-            ])
+            assert set(ECDSAKey.identifiers()) == set(
+                [
+                    "ecdsa-sha2-nistp256",
+                    "ecdsa-sha2-nistp256-cert-v01@openssh.com",
+                    "ecdsa-sha2-nistp384",
+                    "ecdsa-sha2-nistp384-cert-v01@openssh.com",
+                    "ecdsa-sha2-nistp521",
+                    "ecdsa-sha2-nistp521-cert-v01@openssh.com",
+                ]
+            )
 
     class write_private_key_and_file:
         @mark.parametrize(

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1265,7 +1265,7 @@ class TestStrictKex:
 
     @mark.parametrize(
         "server_active,client_active",
-        itertools.product([True, False], repeat=2),
+        tuple(itertools.product([True, False], repeat=2)),
     )
     def test_mode_agreement(self, server_active, client_active):
         with server(


### PR DESCRIPTION
…nable to authenticate with ssh-agent certificates)

Updated test cases with new expected identifiers, and added using set() to make the list comparisons order independent

Bonus fix - fixed pytest deprecation warning in test_tarnsport.py
```
_pytest/python.py:124: PytestRemovedIn10Warning: Passing a non-Collection iterable to parametrize is deprecated.
  Test: tests/test_transport.py::TestStrictKex::test_mode_agreement, argvalues type: product
  Please convert to a list or tuple.
  See https://docs.pytest.org/en/stable/deprecations.html#parametrize-iterators
    metafunc.parametrize(*marker.args, **marker.kwargs, _param_mark=marker)
```