### PR TITLE
Validate default_window_size and default_max_packet_size in Transport

### DIFF
--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -513,6 +513,14 @@ class Transport(threading.Thread, ClosingContextManager):
         self.channel_events = {}  # (id -> Event)
         self.channels_seen = {}  # (id -> True)
         self._channel_counter = 0
+        for arg_name, value in (
+            ("default_window_size", default_window_size),
+            ("default_max_packet_size", default_max_packet_size),
+        ):
+            if not isinstance(value, int):
+                raise TypeError(
+                    "{} must be an int, got {!r}".format(arg_name, value)
+                )
         self.default_max_packet_size = default_max_packet_size
         self.default_window_size = default_window_size
         self._forward_agent_handler = None

--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -519,7 +519,7 @@ class Transport(threading.Thread, ClosingContextManager):
         ):
             if not isinstance(value, int):
                 raise TypeError(
-                    "{} must be an int, got {!r}".format(arg_name, value)
+                    f"{arg_name} must be an int, got {value!r}"
                 )
         self.default_max_packet_size = default_max_packet_size
         self.default_window_size = default_window_size

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -834,6 +834,19 @@ class TransportTest(unittest.TestCase):
         ]:
             self.assertEqual(self.tc._sanitize_window_size(val), correct)
 
+    def test_rejects_non_int_default_window_size(self):
+        """
+        A non-int default_window_size should fail fast in the constructor
+        rather than surface a confusing TypeError from deep inside channel
+        or SFTP setup later on.
+        """
+        with self.assertRaises(TypeError):
+            Transport(LoopSocket(), default_window_size="not-a-size")
+
+    def test_rejects_non_int_default_max_packet_size(self):
+        with self.assertRaises(TypeError):
+            Transport(LoopSocket(), default_max_packet_size="not-a-size")
+
     @slow
     def test_handshake_timeout(self):
         """


### PR DESCRIPTION
Closes #2545.

Transport's constructor takes default_window_size and default_max_packet_size, but never checked that either was actually an int. Pass a string (which is easy to do by accident, since Transport's signature is sock plus these kwargs, not a two-argument host/port constructor the way it reads at first glance) and it gets stored just fine. The failure only shows up later, inside clamp_value, when it tries min(your_value, MAX_WINDOW_SIZE) and hits a TypeError comparing str against int, deep inside channel or SFTP setup rather than at the call that actually caused it.

That's the exact scenario in the linked issue: someone called Transport('host', '21') expecting host/port semantics, and instead got a confusing crash from SFTPClient.from_transport much later.

Both values now get a type check right where they're assigned, so a bad type raises TypeError immediately with a message naming which argument was wrong, instead of surfacing wherever the value first gets compared against something.

Added two tests alongside the existing test_sanitze_window_size/test_sanitze_packet_size, confirmed they fail without the fix (constructor happily accepts the string, and I reproduced the original clamp_value TypeError manually to make sure the new check catches the same case) and pass with it. Ran the full transport test suite, 99 passed / 2 skipped, same skips as before this change. flake8 clean on both files.