### PR TITLE
Fix duplicate Transport auth docs (#2556)

### DIFF
--- a/paramiko/transport.py
+++ b/paramiko/transport.py
@@ -3173,6 +3173,11 @@ class ServiceRequestingTransport(Transport):
     """
     Transport, but also handling service requests, like it oughtta!
 
+    Opt-in via `SSHClient.connect <paramiko.client.SSHClient.connect>`'s
+    ``transport_factory``. Authentication methods match `.Transport` but
+    always block: ``auth_password`` and ``auth_publickey`` have no ``event``
+    parameter.
+
     .. versionadded:: 3.2
     """
 
@@ -3209,6 +3214,12 @@ class ServiceRequestingTransport(Transport):
         self._log(DEBUG, "MSG_SERVICE_ACCEPT received; auth may begin")
 
     def ensure_session(self):
+        """
+        Block until this transport may send userauth requests.
+
+        Sends ``MSG_SERVICE_REQUEST`` for ``ssh-userauth`` if the server has
+        not yet accepted that service, then assigns `.get_auth_handler`.
+        """
         # Make sure we're not trying to auth on a not-yet-open or
         # already-closed transport session; that's our responsibility, not that
         # of AuthHandler.
@@ -3245,16 +3256,27 @@ class ServiceRequestingTransport(Transport):
         self.auth_handler = self.get_auth_handler()
 
     def get_auth_handler(self):
+        """
+        Return a new `~paramiko.auth_handler.AuthOnlyHandler` bound to this
+        transport.
+        """
         # NOTE: using new sibling subclass instead of classic AuthHandler
         return AuthOnlyHandler(self)
 
     def auth_none(self, username):
+        """See `.Transport.auth_none`."""
         # TODO (backwards incompat): merge to parent, preserving (most of)
         # docstring
         self.ensure_session()
         return self.auth_handler.auth_none(username)
 
     def auth_password(self, username, password, fallback=True):
+        """
+        Authenticate using a password. See `.Transport.auth_password`.
+
+        Always blocks until authentication succeeds or fails. Unlike
+        `.Transport.auth_password`, this method has no ``event`` parameter.
+        """
         # TODO (backwards incompat): merge to parent, preserving (most of)
         # docstring
         self.ensure_session()
@@ -3284,12 +3306,19 @@ class ServiceRequestingTransport(Transport):
                 raise e
 
     def auth_publickey(self, username, key):
+        """
+        Authenticate using a private key. See `.Transport.auth_publickey`.
+
+        Always blocks until authentication succeeds or fails. Unlike
+        `.Transport.auth_publickey`, this method has no ``event`` parameter.
+        """
         # TODO (backwards incompat): merge to parent, preserving (most of)
         # docstring
         self.ensure_session()
         return self.auth_handler.auth_publickey(username, key)
 
     def auth_interactive(self, username, handler, submethods=""):
+        """See `.Transport.auth_interactive`."""
         # TODO (backwards incompat): merge to parent, preserving (most of)
         # docstring
         self.ensure_session()
@@ -3298,6 +3327,7 @@ class ServiceRequestingTransport(Transport):
         )
 
     def auth_interactive_dumb(self, username, handler=None, submethods=""):
+        """See `.Transport.auth_interactive_dumb`."""
         # TODO (backwards incompat): merge to parent, preserving (most of)
         # docstring
         # NOTE: legacy impl omitted equiv of ensure_session since it just wraps

--- a/sites/docs/api/transport.rst
+++ b/sites/docs/api/transport.rst
@@ -3,3 +3,9 @@ Transport
 
 .. automodule:: paramiko.transport
     :member-order: bysource
+    :exclude-members: ServiceRequestingTransport
+
+.. autoclass:: paramiko.transport.ServiceRequestingTransport
+    :show-inheritance:
+    :members: ensure_session, get_auth_handler
+    :member-order: bysource

--- a/sites/docs/api/transport.rst
+++ b/sites/docs/api/transport.rst
@@ -7,5 +7,7 @@ Transport
 
 .. autoclass:: paramiko.transport.ServiceRequestingTransport
     :show-inheritance:
+    :no-special-members:
     :members: ensure_session, get_auth_handler
+    :exclude-members: auth_none, auth_password, auth_publickey, auth_interactive, auth_interactive_dumb
     :member-order: bysource

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+- :bug:`2556` Stop listing `.ServiceRequestingTransport` authentication
+  methods as full copies of `.Transport`'s on the Transport API page (so
+  ``auth_interactive`` / ``auth_interactive_dumb`` no longer appear twice)
+  and give the subclass ``auth_password`` / ``auth_publickey`` docstrings
+  that match their signatures (no ``event`` parameter).
 - :feature:`-` Added support for the ``mlkem768x25519-sha256`` post-quantum
   hybrid key exchange method described in
   ``draft-ietf-sshm-mlkem-hybrid-kex``. It pairs ML-KEM-768 (FIPS 203) with

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -20,6 +20,7 @@
 Some unit tests for the ssh2 protocol in Transport.
 """
 
+import inspect
 import itertools
 import random
 import select
@@ -1086,6 +1087,18 @@ class ServiceRequestingTransportTest(TransportTest):
         # New class who dis
         self.tc = ServiceRequestingTransport(self.sockc)
         self.ts = ServiceRequestingTransport(self.socks)
+
+    def test_auth_password_and_publickey_omit_event(self):
+        # Subclass signatures drop Transport's event= kwarg; their docs must
+        # not inherit the parent text that describes that argument.
+        inherited_event_text = "If an ``event`` is passed in"
+        for name in ("auth_password", "auth_publickey"):
+            method = getattr(ServiceRequestingTransport, name)
+            assert "event" not in inspect.signature(method).parameters
+            assert inherited_event_text not in (method.__doc__ or "")
+            assert ":param .threading.Event event" not in (
+                method.__doc__ or ""
+            )
 
 
 class AlgorithmDisablingTests(unittest.TestCase):


### PR DESCRIPTION
#2658 already has an open draft PR (#2665) implementing BufferedIOBase on BufferedFile, so this change addresses the smallest unassigned non-security bug that did not already have an open PR.

`sites/docs/api/transport.rst` used `automodule`, which listed both `Transport` and `ServiceRequestingTransport`. The subclass overrode `auth_interactive`, `auth_interactive_dumb`, `auth_password`, and `auth_publickey` without its own docstrings, so:

- `auth_interactive` / `auth_interactive_dumb` appeared twice on the Transport API page
- `ServiceRequestingTransport.auth_password(username, password, fallback=True)` inherited the parent docstring that describes an `event` argument the method does not accept

This PR documents `ServiceRequestingTransport` separately (only its unique session/auth-handler methods) and gives the overridden auth methods short docstrings that match their signatures.

Fixes #2556