### PR TITLE
Use memoryview in Channel.sendall to avoid quadratic byte copying

### DIFF
--- a/paramiko/channel.py
+++ b/paramiko/channel.py
@@ -840,9 +840,10 @@ class Channel(ClosingContextManager):
             sent, there is no way to determine how much data (if any) was sent.
             This is irritating, but identically follows Python's API.
         """
-        while s:
-            sent = self.send(s)
-            s = s[sent:]
+        view = memoryview(s)
+        while view:
+            sent = self.send(view)
+            view = view[sent:]
         return None
 
     def sendall_stderr(self, s):
@@ -861,9 +862,10 @@ class Channel(ClosingContextManager):
 
         .. versionadded:: 1.1
         """
-        while s:
-            sent = self.send_stderr(s)
-            s = s[sent:]
+        view = memoryview(s)
+        while view:
+            sent = self.send_stderr(view)
+            view = view[sent:]
         return None
 
     def makefile(self, *params):

--- a/paramiko/channel.py
+++ b/paramiko/channel.py
@@ -840,6 +840,8 @@ class Channel(ClosingContextManager):
             sent, there is no way to determine how much data (if any) was sent.
             This is irritating, but identically follows Python's API.
         """
+        if isinstance(s, str):
+            s = s.encode("utf-8")
         view = memoryview(s)
         while view:
             sent = self.send(view)
@@ -862,6 +864,8 @@ class Channel(ClosingContextManager):
 
         .. versionadded:: 1.1
         """
+        if isinstance(s, str):
+            s = s.encode("utf-8")
         view = memoryview(s)
         while view:
             sent = self.send_stderr(view)

--- a/tests/test_sendall.py
+++ b/tests/test_sendall.py
@@ -1,0 +1,49 @@
+from unittest.mock import MagicMock, call, patch
+
+from paramiko import Channel
+
+
+class TestSendallMemoryview:
+    """sendall() should use memoryview to avoid O(n^2) copying on partial sends."""
+
+    def _make_channel(self):
+        chan = Channel(None)
+        chan.transport = MagicMock()
+        chan.transport._send_user_message = MagicMock()
+        return chan
+
+    def test_sendall_sends_all_data_with_partial_writes(self):
+        chan = MagicMock(spec=Channel)
+        chan.send = MagicMock(side_effect=[3, 3, 2])
+        Channel.sendall(chan, b"12345678")
+        assert chan.send.call_count == 3
+
+    def test_sendall_stderr_sends_all_data_with_partial_writes(self):
+        chan = MagicMock(spec=Channel)
+        chan.send_stderr = MagicMock(side_effect=[5, 3])
+        Channel.sendall_stderr(chan, b"12345678")
+        assert chan.send_stderr.call_count == 2
+
+    def test_sendall_passes_memoryview_to_send(self):
+        """send() receives memoryview slices, not copied bytes."""
+        received = []
+
+        def fake_send(data):
+            received.append(type(data))
+            return len(data)
+
+        chan = MagicMock(spec=Channel)
+        chan.send = MagicMock(side_effect=fake_send)
+        Channel.sendall(chan, b"hello")
+        assert received[0] is memoryview
+
+    def test_sendall_empty_data(self):
+        chan = MagicMock(spec=Channel)
+        Channel.sendall(chan, b"")
+        chan.send.assert_not_called()
+
+    def test_sendall_single_byte_sends(self):
+        chan = MagicMock(spec=Channel)
+        chan.send = MagicMock(side_effect=[1, 1, 1])
+        Channel.sendall(chan, b"abc")
+        assert chan.send.call_count == 3

--- a/tests/test_sendall.py
+++ b/tests/test_sendall.py
@@ -4,28 +4,21 @@ from paramiko import Channel
 
 
 class TestSendallMemoryview:
-    """sendall() should use memoryview to avoid quadratic copying."""
+    """sendall uses memoryview to avoid quadratic copying."""
 
-    def _make_channel(self):
-        chan = Channel(None)
-        chan.transport = MagicMock()
-        chan.transport._send_user_message = MagicMock()
-        return chan
-
-    def test_sendall_sends_all_data_with_partial_writes(self):
+    def test_partial_writes(self):
         chan = MagicMock(spec=Channel)
         chan.send = MagicMock(side_effect=[3, 3, 2])
         Channel.sendall(chan, b"12345678")
         assert chan.send.call_count == 3
 
-    def test_sendall_stderr_sends_all_data_with_partial_writes(self):
+    def test_stderr_partial_writes(self):
         chan = MagicMock(spec=Channel)
         chan.send_stderr = MagicMock(side_effect=[5, 3])
         Channel.sendall_stderr(chan, b"12345678")
         assert chan.send_stderr.call_count == 2
 
-    def test_sendall_passes_memoryview_to_send(self):
-        """send() receives memoryview slices, not copied bytes."""
+    def test_passes_memoryview_to_send(self):
         received = []
 
         def fake_send(data):
@@ -37,12 +30,12 @@ class TestSendallMemoryview:
         Channel.sendall(chan, b"hello")
         assert received[0] is memoryview
 
-    def test_sendall_empty_data(self):
+    def test_empty_data(self):
         chan = MagicMock(spec=Channel)
         Channel.sendall(chan, b"")
         chan.send.assert_not_called()
 
-    def test_sendall_single_byte_sends(self):
+    def test_single_byte_sends(self):
         chan = MagicMock(spec=Channel)
         chan.send = MagicMock(side_effect=[1, 1, 1])
         Channel.sendall(chan, b"abc")

--- a/tests/test_sendall.py
+++ b/tests/test_sendall.py
@@ -1,10 +1,10 @@
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock
 
 from paramiko import Channel
 
 
 class TestSendallMemoryview:
-    """sendall() should use memoryview to avoid O(n^2) copying on partial sends."""
+    """sendall() should use memoryview to avoid quadratic copying."""
 
     def _make_channel(self):
         chan = Channel(None)


### PR DESCRIPTION
Fixes #2659.

`sendall()` slices the input bytes on each partial send — `s = s[sent:]` — which copies the remaining buffer every time. when the remote side has a small flow-control window this makes it O(n^2) in total data length because each iteration allocates and copies a progressively shorter but still large buffer.

the fix wraps the input in a `memoryview` before the loop. slicing a memoryview just adjusts offsets, no copy. `send()` and the internal `_send` / `add_string` chain already accept buffer-protocol objects so nothing else needs to change.

also added tests for partial-write scenarios and made sure memoryview is actually what reaches `send()`.

both `sendall` and `sendall_stderr` are patched.